### PR TITLE
Add `state_change` attribute to `OpSystemSystem`

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -4,6 +4,7 @@ A brief tutorial on how to get started with `OP System`.
 
 ```python
 import math
+
 foo = 2 * math.pi
 ```
 

--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Self
 import numpy as np
 from flepimop2.configuration import ModuleModel
 from flepimop2.system.abc import SystemABC
+from flepimop2.typing import StateChangeEnum
 from pydantic import ConfigDict, Field, model_validator
 
 from op_system import CompiledRhs, compile_spec  # type: ignore[attr-defined]
@@ -35,6 +36,8 @@ class _AxesMeta(NamedTuple):
 
 class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
     module: Literal["flepimop2.system.op_system"] = "flepimop2.system.op_system"
+    state_change: StateChangeEnum = StateChangeEnum.FLOW
+
     spec: dict[str, object] | None = Field(
         default=None, description="Inline op_system RHS specification (already loaded)"
     )


### PR DESCRIPTION
Added the `state_change` attribute to the `OpSystemSystem` class in the `flepimop2-op_system` provider package as required by `flepimop2.system.abc.SystemABC`. Also minor formatting of getting started documentation guide code by ruff.