### PR TITLE
Add `IdentifierString` type, `StateString` model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ authors = [
 ]
 dependencies = [
     "numpy>=1.26",
+    "pydantic>=2.12.5,<3.0.0",
 ]
 
 classifiers = [

--- a/src/op_system/__init__.py
+++ b/src/op_system/__init__.py
@@ -21,6 +21,9 @@ Design guarantees:
 
 from __future__ import annotations
 
+from op_system._identifer_string import IdentifierString
+from op_system._state_string import StateString
+
 from .compile import CompiledRhs, EvalFn, compile_rhs
 from .specs import (
     NormalizedRhs,
@@ -70,7 +73,9 @@ __all__ = [
     "SUPPORTED_RHS_KINDS",
     "CompiledRhs",
     "EvalFn",
+    "IdentifierString",
     "NormalizedRhs",
+    "StateString",
     "__version__",
     "compile_rhs",
     "compile_spec",

--- a/src/op_system/_identifer_string.py
+++ b/src/op_system/_identifer_string.py
@@ -1,0 +1,103 @@
+"""Validated identifier string type for op_system."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import AfterValidator
+
+
+def _validate_identifier_string(value: str) -> str:
+    """
+    Validate an identifier-like string.
+
+    Identifier strings must be non-empty, contain only alphanumeric characters, and
+    start with a letter. Leading and trailing whitespace is stripped before validation.
+
+    Args:
+        value: Candidate identifier string.
+
+    Returns:
+        The validated identifier string.
+
+    Raises:
+        TypeError: If `value` is not a string.
+        ValueError: If `value` is empty.
+        ValueError: If `value` contains non-alphanumeric characters or does not start
+            with a letter.
+
+    Examples:
+        >>> _validate_identifier_string("S")
+        'S'
+        >>> _validate_identifier_string("Foobar")
+        'Foobar'
+        >>> _validate_identifier_string(123)
+        Traceback (most recent call last):
+            ...
+        TypeError: IdentifierString must be a string.
+        >>> _validate_identifier_string("")
+        Traceback (most recent call last):
+            ...
+        ValueError: IdentifierString must not be empty.
+        >>> _validate_identifier_string("   ")
+        Traceback (most recent call last):
+            ...
+        ValueError: IdentifierString must not be empty.
+        >>> _validate_identifier_string("123abc")
+        Traceback (most recent call last):
+            ...
+        ValueError: IdentifierString must contain only alphanumerical characters and start with a letter.
+        >>> _validate_identifier_string("abc-123")
+        Traceback (most recent call last):
+            ...
+        ValueError: IdentifierString must contain only alphanumerical characters and start with a letter.
+    """  # noqa: E501
+    if not isinstance(value, str):
+        msg = "IdentifierString must be a string."
+        raise TypeError(msg)
+    value = value.strip()
+    if not value:
+        msg = "IdentifierString must not be empty."
+        raise ValueError(msg)
+    if not value[0].isalpha() or not value.isalnum():
+        msg = (
+            "IdentifierString must contain only alphanumerical "
+            "characters and start with a letter."
+        )
+        raise ValueError(msg)
+    return value
+
+
+IdentifierString = Annotated[str, AfterValidator(_validate_identifier_string)]
+"""
+Custom `pydantic` type for validated identifier strings used in `op_system`.
+
+Identifier strings are used for state names, dimension names, and other keys in the
+system. They must be non-empty, contain only alphanumeric characters, and start with a
+letter. Leading and trailing whitespace is stripped before validation.
+
+Examples:
+    >>> from pydantic import BaseModel
+    >>> from op_system import IdentifierString
+    >>> class ExampleModel(BaseModel):
+    ...     identifier: IdentifierString
+    ...
+    >>> ExampleModel(identifier="S")
+    ExampleModel(identifier='S')
+    >>> ExampleModel(identifier="  Foobar  ")
+    ExampleModel(identifier='Foobar')
+    >>> ExampleModel(identifier="123abc")
+    Traceback (most recent call last):
+        ...
+    pydantic_core._pydantic_core.ValidationError: 1 validation error for ExampleModel
+    identifier
+    Value error, IdentifierString must contain only alphanumerical characters and start with a letter. [...]
+        For further information visit ...
+    >>> ExampleModel(identifier="")
+    Traceback (most recent call last):
+        ...
+    pydantic_core._pydantic_core.ValidationError: 1 validation error for ExampleModel
+    identifier
+    Value error, IdentifierString must not be empty. [...]
+        For further information visit ...
+"""  # noqa: E501

--- a/src/op_system/_state_string.py
+++ b/src/op_system/_state_string.py
@@ -1,0 +1,161 @@
+"""State-string parsing and serialization for op_system."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Final, TypedDict
+
+from pydantic import BaseModel, model_serializer, model_validator
+
+from op_system._identifer_string import IdentifierString  # noqa: TC001
+
+_STATE_STRING_RE: Final[re.Pattern[str]] = re.compile(
+    r"^(?P<name>[A-Za-z][A-Za-z0-9]*)(?:\[(?P<dims>.*)\])?$"
+)
+
+
+class StateStringDict(TypedDict):
+    """
+    Structured mapping for `StateString` model fields.
+
+    Light typing aid for the `_parse_string` method. Attributes mirror the fields of
+    `StateString`, but are not validated or stripped.
+
+    Attributes:
+        name: State name.
+        dims: State dimensions.
+    """
+
+    name: str
+    dims: tuple[str, ...]
+
+
+class StateString(BaseModel, frozen=True, str_strip_whitespace=False):
+    """
+    Structured representation of a state string.
+
+    A state string is either a bare state name like `"S"` or a state name
+    followed immediately by bracketed dimensions like `"R[age,vax]"`.
+
+    Examples:
+        >>> StateString.model_validate("S")
+        StateString(name='S', dims=())
+        >>> recovery = StateString.model_validate("R[age,vax]")
+        >>> recovery
+        StateString(name='R', dims=('age', 'vax'))
+        >>> print(recovery)
+        R[age,vax]
+        >>> recovery.model_dump()
+        'R[age,vax]'
+        >>> StateString.model_validate("Foobar[ age , vax ]")
+        StateString(name='Foobar', dims=('age', 'vax'))
+    """
+
+    name: IdentifierString
+    dims: tuple[IdentifierString, ...]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _parse_state_string(cls, value: Any) -> Any:  # noqa: ANN401
+        """
+        Parse compact state-string input before model validation.
+
+        Args:
+            value: Raw value passed to the model.
+
+        Returns:
+            Mapping-like data suitable for normal field validation.
+
+        Raises:
+            TypeError: If `value` is of an unsupported type.
+        """
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, str):
+            return cls._parse_string(value)
+        if isinstance(value, dict):
+            return value
+        msg = "StateString must be validated from a string or mapping."
+        raise TypeError(msg)
+
+    @classmethod
+    def _parse_string(cls, value: str) -> StateStringDict:
+        """
+        Parse a compact state string into model fields.
+
+        Args:
+            value: Compact state string.
+
+        Returns:
+            Parsed model field mapping.
+
+        Raises:
+            ValueError: If the compact form is invalid.
+
+        Examples:
+            >>> StateString._parse_string("S")
+            {'name': 'S', 'dims': ()}
+            >>> StateString._parse_string("R[age,vax]")
+            {'name': 'R', 'dims': ('age', 'vax')}
+            >>> StateString._parse_string("Foobar[ age , vax ]")
+            {'name': 'Foobar', 'dims': (' age ', ' vax ')}
+            >>> StateString._parse_string("Fizz[dim]")
+            {'name': 'Fizz', 'dims': ('dim',)}
+            >>> StateString._parse_string("lambda[dim1, dim2, dim3]")
+            {'name': 'lambda', 'dims': ('dim1', ' dim2', ' dim3')}
+            >>> StateString._parse_string("Invalid[dim")
+            Traceback (most recent call last):
+                ...
+            ValueError: Invalid state string. Expected 'Name' or 'Name[dim1,dim2]' with no whitespace before '['.
+            >>> StateString._parse_string("123Invalid[dim]")
+            Traceback (most recent call last):
+                ...
+            ValueError: Invalid state string. Expected 'Name' or 'Name[dim1,dim2]' with no whitespace before '['.
+        """  # noqa: E501
+        stripped_value = value.strip()
+        match = _STATE_STRING_RE.fullmatch(stripped_value)
+        if match is None:
+            msg = (
+                "Invalid state string. Expected 'Name' or 'Name[dim1,dim2]' "
+                "with no whitespace before '['."
+            )
+            raise ValueError(msg)
+        dims_group = match.group("dims")
+        return {
+            "name": match.group("name"),
+            "dims": tuple(dim for dim in (dims_group).split(","))
+            if (dims_group := match.group("dims"))
+            else (),
+        }
+
+    def __str__(self) -> str:
+        """
+        Return the compact string form.
+
+        Returns:
+            Compact state string.
+
+        Examples:
+            >>> str(StateString(name="S", dims=()))
+            'S'
+            >>> str(StateString(name="R", dims=("age",)))
+            'R[age]'
+            >>> str(StateString(name="R", dims=("age", "vax")))
+            'R[age,vax]'
+            >>> str(StateString(name="lambda", dims=("age", "vax", "state")))
+            'lambda[age,vax,state]'
+        """
+        if not self.dims:
+            return self.name
+        dims = ",".join(self.dims)
+        return f"{self.name}[{dims}]"
+
+    @model_serializer(mode="plain")
+    def _serialize(self) -> str:
+        """
+        Serialize the model to its compact string form.
+
+        Returns:
+            Compact state string.
+        """
+        return str(self)


### PR DESCRIPTION
Added the `IdentifierString` pydantic type to enforce validation of object naming, like compartments and dimensions. Also added `StateString` pydantic model to represent a state which has 0 or more dimensions.

- Added `pydantic` as a dependency of `op_system`.
- Added `op_system.IdentifierString` and `op_system.StateString`

Closes #25.