### PR TITLE
feat(provider): wire system options with mixing_kernels

### DIFF
--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -91,9 +91,7 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
 
     @staticmethod
     def _extract_axes_meta(compiled: CompiledRhs) -> _AxesMeta:
-        meta = compiled.meta if hasattr(compiled, "meta") else None
-        meta_dict = meta if isinstance(meta, dict) else {}
-        axes_meta = meta_dict.get("axes", [])
+        axes_meta = compiled.meta.get("axes", [])
         axis_sizes: dict[str, int] = {"subgroup": 1}
         axis_coords: dict[str, np.ndarray] = {
             "subgroup": np.asarray([0], dtype=np.float64)
@@ -102,7 +100,15 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
         for ax in axes_meta:
             name = str(ax.get("name"))
             size = int(ax.get("size", 0) or len(ax.get("coords", []) or []))
-            coords = np.asarray(ax.get("coords", np.arange(size)), dtype=np.float64)
+            raw_coords = ax.get("coords", None)
+            try:
+                coords = (
+                    np.asarray(raw_coords, dtype=np.float64)
+                    if raw_coords is not None
+                    else np.arange(size, dtype=np.float64)
+                )
+            except (ValueError, TypeError):
+                coords = np.arange(size, dtype=np.float64)
             axis_sizes[name] = size
             axis_coords[name] = coords
             axis_order.append(name)
@@ -113,9 +119,7 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
     def _build_mixing_kernels(
         self, compiled: CompiledRhs, axis_coords: dict[str, np.ndarray]
     ) -> dict[str, np.ndarray]:
-        meta = compiled.meta if hasattr(compiled, "meta") else None
-        meta_dict = meta if isinstance(meta, dict) else {}
-        mixing_meta = meta_dict.get("mixing", [])
+        mixing_meta = compiled.meta.get("kernels", []) or []
         kernels: dict[str, np.ndarray] = {}
         for mk in mixing_meta:
             name = str(mk.get("name"))

--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -65,6 +65,7 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
         self.flatten = flatten_fn
         self.unflatten = unflatten_fn
         self.mixing_kernels = mixing_kernels
+        self.options = {"mixing_kernels": mixing_kernels}
 
         def _stepper(
             time: np.float64,

--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -52,3 +52,33 @@ def test_invalid_spec_raises() -> None:
     bad_spec: dict[str, object] = {"kind": "expr", "state": ["x"], "equations": {}}
     with pytest.raises(ValueError, match=r"Missing equation"):
         OpSystemSystem(spec=bad_spec)
+
+
+def test_option_mixing_kernels_bare_spec(sir_spec: dict[str, object]) -> None:
+    """A spec without kernels exposes an empty mixing_kernels option."""
+    sys = OpSystemSystem(spec=sir_spec)
+    mk = sys.option("mixing_kernels", None)
+    assert isinstance(mk, dict)
+    assert mk == {}
+
+
+def test_option_mixing_kernels_with_kernel() -> None:
+    """A spec with a kernel exposes it via the mixing_kernels option."""
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": ["0", "1"]}],
+        "kernels": [
+            {
+                "name": "contact",
+                "form": "gaussian",
+                "params": {"scale": 1.0, "sigma": 0.5},
+            },
+        ],
+        "state": ["S[loc]"],
+        "equations": {"S[loc]": "-S[loc]"},
+    }
+    sys = OpSystemSystem(spec=spec)
+    mk = sys.option("mixing_kernels", None)
+    assert isinstance(mk, dict)
+    assert "contact" in mk
+    assert isinstance(mk["contact"], np.ndarray)

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -20,7 +20,8 @@ whitelist, and evaluation runs with empty builtins.
 from __future__ import annotations
 
 import ast
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, NoReturn, Protocol, cast
 
 import numpy as np
@@ -138,6 +139,7 @@ class CompiledRhs:
     state_names: tuple[str, ...]
     param_names: tuple[str, ...]
     eval_fn: EvalFn
+    meta: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
 
     def bind(
         self, params: Mapping[str, object]

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -495,4 +495,5 @@ def compile_rhs(rhs: NormalizedRhs) -> CompiledRhs:
         state_names=rhs.state_names,
         param_names=rhs.param_names,
         eval_fn=eval_fn,
+        meta=rhs.meta,
     )

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -11,6 +11,7 @@ These tests cover:
 - AST whitelist rejects disallowed calls/attribute access
 - alias dependency resolution and cycles
 - transitions RHS compiles and evaluates with expected flow semantics
+- compile_rhs threads NormalizedRhs.meta through to CompiledRhs.meta
 
 Note:
 - errors.py was removed, so we only assert built-in exception types and messages.
@@ -23,6 +24,7 @@ import re
 import numpy as np
 import pytest
 
+from op_system import compile_spec
 from op_system.compile import CompiledRhs, compile_rhs
 from op_system.specs import NormalizedRhs, normalize_rhs
 
@@ -317,3 +319,54 @@ def test_transitions_rhs_compiles_and_evaluates() -> None:
     rec = 0.1 * float(y[1])
     expected = np.array([-inf, inf - rec, rec], dtype=np.float64)
     assert np.allclose(out, expected)
+
+
+# ---------------------------------------------------------------------------
+# Meta threading (#11)
+# ---------------------------------------------------------------------------
+
+
+def test_compiled_rhs_meta_from_spec_with_axes_and_kernels() -> None:
+    """compile_rhs preserves axes and kernels metadata from NormalizedRhs."""
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "axes": [{"name": "age", "coords": ["a0", "a1", "a2"]}],
+        "state": ["S", "I"],
+        "kernels": [
+            {
+                "name": "contact",
+                "form": "gaussian",
+                "params": {"scale": 1.0, "sigma": 0.5},
+            },
+        ],
+        "equations": {"S": "-beta * S", "I": "beta * S"},
+    }
+    rhs = normalize_rhs(spec)
+    compiled = compile_rhs(rhs)
+
+    assert "axes" in compiled.meta
+    assert len(compiled.meta["axes"]) == 1
+    assert compiled.meta["axes"][0]["name"] == "age"
+    assert "kernels" in compiled.meta
+    assert len(compiled.meta["kernels"]) == 1
+    assert compiled.meta["kernels"][0]["name"] == "contact"
+
+
+def test_compiled_rhs_meta_empty_for_bare_spec(compiled_xy: CompiledRhs) -> None:
+    """A spec with no axes/kernels/operators produces meta with empty values."""
+    assert compiled_xy.meta.get("axes") == []
+    assert compiled_xy.meta.get("kernels") == []
+
+
+def test_compile_spec_preserves_meta() -> None:
+    """compile_spec (public facade) round-trips meta through normalize+compile."""
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "axes": [{"name": "space", "coords": ["s0", "s1"]}],
+        "state": ["x"],
+        "equations": {"x": "a * x"},
+    }
+    compiled = compile_spec(spec)
+
+    assert "axes" in compiled.meta
+    assert compiled.meta["axes"][0]["name"] == "space"


### PR DESCRIPTION
## Summary

Wires `self.options` in the op_system provider so that `system.option("mixing_kernels")` works as expected by op_engine.

## Changes

### Commit 1: `feat(provider): wire self.options with mixing_kernels`
- Add `self.options = {"mixing_kernels": mixing_kernels}` in `model_post_init()` after kernel construction

### Commit 2: `refactor(provider): remove hasattr guards for compiled.meta`
- Remove `hasattr(compiled, "meta")` introspection guards — `CompiledRhs.meta` is now guaranteed (PR #53)
- Fix meta key: `"mixing"` → `"kernels"` (bug found and fixed)
- Fix string coord crash: `np.asarray(["a","b"], dtype=float64)` raises ValueError — added try/except fallback to `np.arange(size)` (bug found and fixed)

### Commit 3: `test(provider): verify options expose mixing_kernels`
- `test_option_mixing_kernels_bare_spec` — bare spec produces empty kernel list
- `test_option_mixing_kernels_with_kernel` — spec with gaussian kernel populates correctly

## Testing

All 5 provider tests pass. Lint clean.

## Related

- Stacked on PR #53 (`feat/11-compile-meta-threading`)
- Unblocks op_engine #42 (replace getattr with system.option)
- Follow-up: op_system #54 (wire `operators`/`operator_axis`)
