### PR TITLE
Implement `_bind_impl` for SystemABC compliance

### DIFF
--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -10,12 +10,23 @@ pydantic BaseModel subclass is defined here, flepimop2 auto-generates a
 
 from __future__ import annotations
 
+import functools
+import sys
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 import numpy as np
 from flepimop2.configuration import ModuleModel
 from flepimop2.system.abc import SystemABC
-from flepimop2.typing import StateChangeEnum
+from flepimop2.typing import (
+    IdentifierString,
+    StateChangeEnum,
+    SystemProtocol,
+)
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 from pydantic import ConfigDict, Field
 
 from op_system import CompiledRhs, compile_spec
@@ -88,6 +99,13 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
 
         self._stepper = _stepper
         self._compiled_rhs = compiled  # handy for debugging/adapters
+
+    @override
+    def _bind_impl(
+        self, params: dict[IdentifierString, Any] | None = None
+    ) -> SystemProtocol:
+        """Return a stepper with any static parameters partially applied."""
+        return functools.partial(self._stepper, **(params or {}))
 
     @staticmethod
     def _extract_axes_meta(compiled: CompiledRhs) -> _AxesMeta:

--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -113,3 +113,27 @@ def test_bind_delegates_to_step(sir_spec: dict[str, object]) -> None:
     via_bind = sys.bind()(time=np.float64(0.0), state=y0, beta=0.3, gamma=0.1)
 
     np.testing.assert_allclose(via_bind, via_step, rtol=0.0, atol=0.0)
+
+
+# -- Integration: full SystemABC.bind() contract -----------------------------------
+
+
+def test_bind_rejects_forbidden_param(sir_spec: dict[str, object]) -> None:
+    """SystemABC.bind() rejects 'time' and 'state' in params."""
+    sys = OpSystemSystem(spec=sir_spec)
+    with pytest.raises(TypeError, match="time"):
+        sys.bind(params={"time": 0.0})
+
+
+def test_bind_roundtrip_multi_step(sir_spec: dict[str, object]) -> None:
+    """Bound stepper can be called repeatedly (simulating an engine loop)."""
+    sys = OpSystemSystem(spec=sir_spec)
+    stepper = sys.bind(params={"beta": 0.3, "gamma": 0.1})
+    state = np.array([0.999, 0.001, 0.0], dtype=np.float64)
+
+    for _ in range(5):
+        deriv = stepper(time=np.float64(0.0), state=state)
+        state += 0.1 * deriv  # simple Euler step
+
+    # Population is conserved: S + I + R == 1.0
+    np.testing.assert_allclose(state.sum(), 1.0, atol=1e-14)

--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+from flepimop2.typing import SystemProtocol
 
 from flepimop2.system.op_system import OpSystemSystem
 
@@ -82,3 +83,33 @@ def test_option_mixing_kernels_with_kernel() -> None:
     assert isinstance(mk, dict)
     assert "contact" in mk
     assert isinstance(mk["contact"], np.ndarray)
+
+
+def test_bind_returns_system_protocol(sir_spec: dict[str, object]) -> None:
+    """bind() returns a callable satisfying SystemProtocol."""
+    sys = OpSystemSystem(spec=sir_spec)
+    stepper = sys.bind()
+    assert isinstance(stepper, SystemProtocol)
+
+
+def test_bind_with_static_params(sir_spec: dict[str, object]) -> None:
+    """bind(params=...) partially applies parameters to the stepper."""
+    sys = OpSystemSystem(spec=sir_spec)
+    y0 = np.array([0.999, 0.001, 0.0], dtype=np.float64)
+
+    stepper = sys.bind(params={"beta": 0.3, "gamma": 0.1})
+    out = stepper(time=np.float64(0.0), state=y0)
+
+    expected = np.array([-0.0002997, 0.0001997, 0.0001], dtype=np.float64)
+    np.testing.assert_allclose(out, expected, rtol=1e-12, atol=0.0)
+
+
+def test_bind_delegates_to_step(sir_spec: dict[str, object]) -> None:
+    """bind() without params produces the same result as step()."""
+    sys = OpSystemSystem(spec=sir_spec)
+    y0 = np.array([0.999, 0.001, 0.0], dtype=np.float64)
+
+    via_step = sys.step(np.float64(0.0), y0, beta=0.3, gamma=0.1)
+    via_bind = sys.bind()(time=np.float64(0.0), state=y0, beta=0.3, gamma=0.1)
+
+    np.testing.assert_allclose(via_bind, via_step, rtol=0.0, atol=0.0)


### PR DESCRIPTION
Implements `_bind_impl()` on the op_system provider, aligning with the `SystemABC` refactor landed in flepimop2 PR [#182](https://github.com/ACCIDDA/flepimop2/pull/182).

## Changes

- **`_bind_impl` implementation** — Uses `functools.partial(self._stepper, **(params or {}))` following the simple connector pattern from flepimop2's reference SIR system.
- **Imports updated** — `SystemProtocol`, `IdentifierString` imported from `flepimop2.typing`; `@override` decorator with `sys.version_info` gate for 3.11 compat.
- **flepimop2 lockfile upgraded** — `2f38ad09` → `50296246` (post-PR #182).

## Tests (5 new, 10 total)

| Test | What it exercises |
|---|---|
| `test_bind_returns_system_protocol` | `bind()` returns a `SystemProtocol`-conformant callable |
| `test_bind_with_static_params` | `bind(params=...)` partially applies parameters |
| `test_bind_delegates_to_step` | `bind()` and `step()` produce identical results |
| `test_bind_rejects_forbidden_param` | `SystemABC.bind()` rejects `"time"`/`"state"` keys |
| `test_bind_roundtrip_multi_step` | Bound stepper works across repeated calls with population conservation |

## Related

- Closes #55
- Unblocks ACCIDDA/op_engine#49 (engine-side `system._stepper` → `system.bind()`)