### PR TITLE
Wire operators and operator_axis options in provider (#8, #54)

### DIFF
--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import functools
 import sys
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 import numpy as np
@@ -76,7 +77,13 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
         self.flatten = flatten_fn
         self.unflatten = unflatten_fn
         self.mixing_kernels = mixing_kernels
-        self.options = {"mixing_kernels": mixing_kernels}
+        operators = self._extract_operators(compiled)
+        operator_axis = self._extract_operator_axis(compiled)
+        self.options = {
+            "mixing_kernels": mixing_kernels,
+            "operators": operators,
+            "operator_axis": operator_axis,
+        }
 
         def _stepper(
             time: np.float64,
@@ -133,6 +140,35 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
         return _AxesMeta(
             axis_order=tuple(axis_order), axis_sizes=axis_sizes, axis_coords=axis_coords
         )
+
+    @staticmethod
+    def _extract_operators(
+        compiled: CompiledRhs,
+    ) -> tuple[MappingProxyType[str, Any], ...] | None:
+        """Extract operator metadata from compiled spec as immutable mappings.
+
+        Returns:
+            Tuple of read-only operator dicts, or ``None`` if no operators.
+        """
+        ops = compiled.meta.get("operators")
+        if not ops:
+            return None
+        return tuple(MappingProxyType(op) for op in ops)
+
+    @staticmethod
+    def _extract_operator_axis(compiled: CompiledRhs) -> str | None:
+        """Return the single shared axis name if all operators act on the same axis.
+
+        Returns:
+            Shared axis name, or ``None`` if there are zero or multiple axes.
+        """
+        ops = compiled.meta.get("operators")
+        if not ops:
+            return None
+        axes = {op.get("axis") for op in ops}
+        if len(axes) == 1:
+            return str(next(iter(axes)))
+        return None
 
     def _build_mixing_kernels(
         self, compiled: CompiledRhs, axis_coords: dict[str, np.ndarray]

--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -1,5 +1,7 @@
 """Tests for the flepimop2 op_system adapter System."""
 
+from types import MappingProxyType
+
 import numpy as np
 import pytest
 from flepimop2.typing import SystemProtocol
@@ -137,3 +139,130 @@ def test_bind_roundtrip_multi_step(sir_spec: dict[str, object]) -> None:
 
     # Population is conserved: S + I + R == 1.0
     np.testing.assert_allclose(state.sum(), 1.0, atol=1e-14)
+
+
+# -- Operator wiring (#8, #54) -------------------------------------------------
+
+
+@pytest.fixture
+def sir_with_operators_spec() -> dict[str, object]:
+    """SIR spec with a single diffusion operator on the loc axis.
+
+    Returns:
+        dict[str, object]: Spec with one operator.
+    """
+    return {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": ["a", "b"]}],
+        "state": ["S[loc]", "I[loc]", "R[loc]"],
+        "equations": {
+            "S[loc]": "-beta * S[loc] * I[loc]",
+            "I[loc]": "beta * S[loc] * I[loc] - gamma * I[loc]",
+            "R[loc]": "gamma * I[loc]",
+        },
+        "operators": [
+            {"kind": "diffusion", "axis": "loc", "bc": "neumann"},
+        ],
+    }
+
+
+@pytest.fixture
+def multi_operator_spec() -> dict[str, object]:
+    """Spec with two operators on different axes.
+
+    Returns:
+        dict[str, object]: Spec with operators on loc and age axes.
+    """
+    return {
+        "kind": "expr",
+        "axes": [
+            {"name": "loc", "coords": ["a", "b"]},
+            {"name": "age", "coords": ["young", "old"]},
+        ],
+        "state": ["u[loc,age]"],
+        "equations": {"u[loc,age]": "-u[loc,age]"},
+        "operators": [
+            {"kind": "diffusion", "axis": "loc"},
+            {"kind": "advection", "axis": "age"},
+        ],
+    }
+
+
+def test_option_operators_none_when_absent(sir_spec: dict[str, object]) -> None:
+    """A spec without operators returns None for the operators option."""
+    sys = OpSystemSystem(spec=sir_spec)
+    assert sys.option("operators", "missing") is None
+
+
+def test_option_operators_present(
+    sir_with_operators_spec: dict[str, object],
+) -> None:
+    """A spec with operators exposes them via the operators option."""
+    sys = OpSystemSystem(spec=sir_with_operators_spec)
+    ops = sys.option("operators", None)
+    assert ops is not None
+    assert len(ops) == 1
+    assert ops[0]["kind"] == "diffusion"
+    assert ops[0]["axis"] == "loc"
+    assert ops[0]["bc"] == "neumann"
+
+
+def test_option_operators_returns_immutable(
+    sir_with_operators_spec: dict[str, object],
+) -> None:
+    """Operator dicts returned by option() are immutable MappingProxy objects."""
+    sys = OpSystemSystem(spec=sir_with_operators_spec)
+    ops = sys.option("operators", None)
+    assert ops is not None
+    assert isinstance(ops, tuple)
+    assert isinstance(ops[0], MappingProxyType)
+    with pytest.raises(TypeError):
+        ops[0]["kind"] = "advection"  # type: ignore[index]
+
+
+def test_option_operator_axis_single(
+    sir_with_operators_spec: dict[str, object],
+) -> None:
+    """When all operators share one axis, operator_axis returns that name."""
+    sys = OpSystemSystem(spec=sir_with_operators_spec)
+    assert sys.option("operator_axis", None) == "loc"
+
+
+def test_option_operator_axis_none_when_absent(
+    sir_spec: dict[str, object],
+) -> None:
+    """No operators means operator_axis is None."""
+    sys = OpSystemSystem(spec=sir_spec)
+    assert sys.option("operator_axis", None) is None
+
+
+def test_option_operator_axis_none_when_mixed(
+    multi_operator_spec: dict[str, object],
+) -> None:
+    """Multiple axes across operators means operator_axis is None."""
+    sys = OpSystemSystem(spec=multi_operator_spec)
+    assert sys.option("operator_axis", None) is None
+
+
+def test_option_operators_multi_axis(
+    multi_operator_spec: dict[str, object],
+) -> None:
+    """Multi-operator spec surfaces both operators."""
+    sys = OpSystemSystem(spec=multi_operator_spec)
+    ops = sys.option("operators", None)
+    assert ops is not None
+    assert len(ops) == 2
+    kinds = {op["kind"] for op in ops}
+    assert kinds == {"diffusion", "advection"}
+
+
+def test_option_operators_independent_of_mixing_kernels(
+    sir_with_operators_spec: dict[str, object],
+) -> None:
+    """Operators and mixing_kernels are independent options."""
+    sys = OpSystemSystem(spec=sir_with_operators_spec)
+    mk = sys.option("mixing_kernels", None)
+    ops = sys.option("operators", None)
+    assert isinstance(mk, dict)
+    assert ops is not None
+    assert len(ops) == 1

--- a/src/op_system/specs.py
+++ b/src/op_system/specs.py
@@ -254,6 +254,25 @@ def _ensure_mapping(x: object, *, name: str) -> Mapping[str, Any]:
     return x
 
 
+def _normalize_bracket_key(key: str) -> str:
+    """Normalize whitespace inside bracket notation.
+
+    Strips spaces around commas and bracket edges so that user-provided keys
+    like ``"u[x, y]"`` match the canonical template form ``"u[x,y]"``.
+
+    Returns:
+        Canonical bracket key string.
+    """
+    if "[" not in key:
+        return key.strip()
+    m = _STATE_TEMPLATE_RE.fullmatch(key)
+    if not m:
+        return key.strip()
+    base = m.group(1)
+    parts = [p.strip() for p in m.group(2).split(",")]
+    return f"{base}[{','.join(parts)}]"
+
+
 def _normalize_axis_name(ax_map: Mapping[str, Any], *, idx: int, seen: set[str]) -> str:
     name_val = ax_map.get("name")
     if not isinstance(name_val, str) or not name_val.strip():
@@ -1726,6 +1745,9 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:
     equations_map = spec.get("equations")
     if not isinstance(equations_map, dict):
         _raise_invalid_rhs_spec(detail="equations must be a mapping of state->expr")
+
+    # Normalize equation keys so that e.g. "u[x, y]" matches template "u[x,y]"
+    equations_map = {_normalize_bracket_key(k): v for k, v in equations_map.items()}
 
     axes_meta = _normalize_axes(spec.get("axes"))
     meta_parts = _normalize_common_meta(

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -779,3 +779,51 @@ def test_normalize_constraints_rejects_rule_axis_not_in_constraint_axes() -> Non
     raw = [{"axes": ["age", "vax"], "allow": [{"region": "east"}]}]
     with pytest.raises(ValueError, match=r"references axis 'region' not in"):
         _normalize_constraints(raw, axes=axes)
+
+
+# -- Equation key whitespace normalisation --
+
+
+def test_expr_equation_keys_with_spaces_accepted() -> None:
+    """Equation keys with spaces inside brackets match their template."""
+    spec = {
+        "kind": "expr",
+        "axes": [
+            {"name": "x", "coords": ["a", "b"]},
+            {"name": "y", "coords": ["c", "d"]},
+        ],
+        "state": ["u[x,y]"],
+        "equations": {"u[x, y]": "-u[x, y]"},
+    }
+    out = normalize_expr_rhs(spec)
+    assert len(out.state_names) == 4
+    assert len(out.equations) == 4
+
+
+def test_expr_equation_keys_spaces_three_axes() -> None:
+    """Equation keys with spaces work for 3+ axes."""
+    spec = {
+        "kind": "expr",
+        "axes": [
+            {"name": "a", "coords": ["a1", "a2"]},
+            {"name": "b", "coords": ["b1"]},
+            {"name": "c", "coords": ["c1"]},
+        ],
+        "state": ["u[a,b,c]"],
+        "equations": {"u[a, b, c]": "-u[a, b, c]"},
+    }
+    out = normalize_expr_rhs(spec)
+    assert len(out.state_names) == 2
+    assert len(out.equations) == 2
+
+
+def test_expr_equation_keys_extra_spaces_normalised() -> None:
+    """Extra whitespace around axis names in equation keys is tolerated."""
+    spec = {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": ["a", "b"]}],
+        "state": ["S[loc]"],
+        "equations": {"S[ loc ]": "-S[ loc ]"},
+    }
+    out = normalize_expr_rhs(spec)
+    assert len(out.state_names) == 2


### PR DESCRIPTION
### Summary

Expose operator metadata through `SystemABC.option()` so downstream engines (e.g., `op_engine`) can discover IMEX operator configuration without re-parsing the spec. Also fixes a bug where whitespace in template equation keys caused false validation errors.

### Changes

**Bug fix — `specs.py` whitespace normalisation** (`01cbe8e`)

Equation keys written with spaces inside brackets (e.g., `"u[x, y]"`) failed validation because `_expand_state_templates` builds canonical keys without spaces (`"u[x,y]"`). Added `_normalize_bracket_key` to strip whitespace inside brackets at equation-map entry, using the existing `_STATE_TEMPLATE_RE` regex. Tested with 2-axis and 3-axis cases.

> This helper is intentionally minimal — broader parsing consolidation is tracked in #30 and the Pydantic-ify milestone (#22, #28).

**Feature — operator wiring** (`4a3bef5`)

Two new static methods on `OpSystemSystem`:
- `_extract_operators` → returns `tuple[MappingProxyType, ...] | None` from `compiled.meta["operators"]`
- `_extract_operator_axis` → returns the shared axis name (`str`) when all operators act on one axis, otherwise `None`

Wired into `model_post_init` alongside the existing `mixing_kernels`:
```python
self.options = {
    "mixing_kernels": mixing_kernels,
    "operators": operators,
    "operator_axis": operator_axis,
}
```

Operator dicts are stored as `MappingProxyType` to prevent callers from accidentally mutating spec metadata.

### Tests added

- Equation key spaces accepted (2-axis and 3-axis)
- Extra whitespace around axis names normalised
- Operators present/absent via `option()`
- Immutability enforcement (`MappingProxyType` rejects mutation)
- Single vs. mixed operator axis detection
- Multi-operator specs surface both operators
- Operators independent of `mixing_kernels`

### Closes

- Closes #8
- Closes #54

### Related

- #30 (revisit helper logic) — `_normalize_bracket_key` will be absorbed when parsing is consolidated
- #22, #28 (Pydantic-ify milestone) — structured models will replace ad-hoc dict parsing
- #12 (adapter upgrade) — separate PR