### PR TITLE
fix: consolidate adapter metadata into self.options (#12)

### DIFF
--- a/flepimop2-op_system/pyproject.toml
+++ b/flepimop2-op_system/pyproject.toml
@@ -84,3 +84,7 @@ dev = [
   "ruff>=0.13.3",
   "mypy>=1.18.2",
 ]
+
+[[tool.mypy.overrides]]
+module = "flepimop2.*"
+follow_imports = "normal"

--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -70,16 +70,15 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
             n_state, axes_meta
         )
 
-        self.axis_order = axes_meta.axis_order
-        self.axis_sizes = axes_meta.axis_sizes
-        self.axis_coords = axes_meta.axis_coords
-        self.state_shape = shape_dims
-        self.flatten = flatten_fn
-        self.unflatten = unflatten_fn
-        self.mixing_kernels = mixing_kernels
         operators = self._extract_operators(compiled)
         operator_axis = self._extract_operator_axis(compiled)
         self.options = {
+            "axis_order": axes_meta.axis_order,
+            "axis_sizes": axes_meta.axis_sizes,
+            "axis_coords": axes_meta.axis_coords,
+            "state_shape": shape_dims,
+            "flatten": flatten_fn,
+            "unflatten": unflatten_fn,
             "mixing_kernels": mixing_kernels,
             "operators": operators,
             "operator_axis": operator_axis,
@@ -97,7 +96,7 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
                     f"expected ({n_state},), got {state_arr.shape}."
                 )
                 raise ValueError(msg)
-            params = dict(self.mixing_kernels)
+            params = dict(mixing_kernels)
             params.update(kwargs)
             return np.asarray(
                 compiled.eval_fn(np.float64(time), state_arr, **params),

--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -266,3 +266,104 @@ def test_option_operators_independent_of_mixing_kernels(
     assert isinstance(mk, dict)
     assert ops is not None
     assert len(ops) == 1
+
+
+# -- Axis / shape / flatten options (#12) ---------------------------------------
+
+
+def test_option_axis_order_bare_spec(sir_spec: dict[str, object]) -> None:
+    """A bare SIR spec has axis_order ('state', 'subgroup')."""
+    sys = OpSystemSystem(spec=sir_spec)
+    assert sys.option("axis_order", None) == ("state", "subgroup")
+
+
+def test_option_axis_order_with_axes() -> None:
+    """A spec with an explicit axis appends it to axis_order."""
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": ["a", "b"]}],
+        "state": ["S[loc]"],
+        "equations": {"S[loc]": "-S[loc]"},
+    }
+    sys = OpSystemSystem(spec=spec)
+    order = sys.option("axis_order", None)
+    assert order == ("state", "subgroup", "loc")
+
+
+def test_option_axis_sizes_bare_spec(sir_spec: dict[str, object]) -> None:
+    """A bare SIR spec has axis_sizes {'subgroup': 1}."""
+    sys = OpSystemSystem(spec=sir_spec)
+    assert sys.option("axis_sizes", None) == {"subgroup": 1}
+
+
+def test_option_axis_sizes_with_axes() -> None:
+    """A spec with an explicit axis includes its size."""
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": ["a", "b"]}],
+        "state": ["S[loc]"],
+        "equations": {"S[loc]": "-S[loc]"},
+    }
+    sys = OpSystemSystem(spec=spec)
+    sizes = sys.option("axis_sizes", None)
+    assert sizes == {"subgroup": 1, "loc": 2}
+
+
+def test_option_axis_coords_bare_spec(sir_spec: dict[str, object]) -> None:
+    """A bare SIR spec has subgroup coords as [0]."""
+    sys = OpSystemSystem(spec=sir_spec)
+    coords = sys.option("axis_coords", None)
+    assert "subgroup" in coords
+    np.testing.assert_array_equal(coords["subgroup"], np.array([0], dtype=np.float64))
+
+
+def test_option_axis_coords_with_axes() -> None:
+    """A spec with an explicit axis includes its coords as a float array."""
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": ["0", "1"]}],
+        "state": ["S[loc]"],
+        "equations": {"S[loc]": "-S[loc]"},
+    }
+    sys = OpSystemSystem(spec=spec)
+    coords = sys.option("axis_coords", None)
+    assert "loc" in coords
+    np.testing.assert_array_equal(coords["loc"], np.array([0, 1], dtype=np.float64))
+
+
+def test_option_state_shape_bare_spec(sir_spec: dict[str, object]) -> None:
+    """A bare SIR spec has state_shape (3, 1)."""
+    sys = OpSystemSystem(spec=sir_spec)
+    assert sys.option("state_shape", None) == (3, 1)
+
+
+def test_option_state_shape_with_axes() -> None:
+    """A spec with an axis includes the axis dimension in state_shape."""
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": ["a", "b"]}],
+        "state": ["S[loc]"],
+        "equations": {"S[loc]": "-S[loc]"},
+    }
+    sys = OpSystemSystem(spec=spec)
+    assert sys.option("state_shape", None) == (2, 1, 2)
+
+
+def test_option_flatten_unflatten_roundtrip() -> None:
+    """Flatten then unflatten recovers the original shaped array."""
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": ["a", "b", "c"]}],
+        "state": ["S[loc]", "I[loc]"],
+        "equations": {"S[loc]": "-S[loc]", "I[loc]": "S[loc]"},
+    }
+    sys = OpSystemSystem(spec=spec)
+    shape = sys.option("state_shape", None)
+    flatten = sys.option("flatten", None)
+    unflatten = sys.option("unflatten", None)
+    tensor = np.arange(np.prod(shape), dtype=np.float64).reshape(shape)
+    flat = flatten(tensor)
+    assert flat.ndim == 1
+    assert flat.size == np.prod(shape)
+    recovered = unflatten(flat)
+    np.testing.assert_array_equal(recovered, tensor)


### PR DESCRIPTION
Upgrades the flepimop2 provider adapter to expose all metadata through `self.options` instead of bare instance attributes, per flepimop2 discussion #129 and the `ModuleABC.option()` API (ACCIDDA/flepimop2#118).

## Changes

### Adapter (`flepimop2-op_system/src/.../op_system/__init__.py`)
- **Consolidated** 9 bare instance attributes (`self.axis_order`, `self.axis_sizes`, `self.axis_coords`, `self.state_shape`, `self.flatten`, `self.unflatten`, `self.mixing_kernels`, plus `operators` and `operator_axis`) into a single `self.options = {...}` dict
- **Fixed stepper closure** to capture `mixing_kernels` as a local variable instead of referencing the (now removed) `self.mixing_kernels`

### Tests (`flepimop2-op_system/tests/test_system.py`)
- Added 9 new tests validating option access via `system.option()`:
  - `test_option_axis_order_bare_spec` / `test_option_axis_order_with_axes`
  - `test_option_axis_sizes_bare_spec` / `test_option_axis_sizes_with_axes`
  - `test_option_axis_coords_bare_spec` / `test_option_axis_coords_with_axes`
  - `test_option_state_shape_bare_spec` / `test_option_state_shape_with_axes`
  - `test_option_flatten_unflatten_roundtrip`

### mypy (`flepimop2-op_system/pyproject.toml`)
- Added `[[tool.mypy.overrides]]` for `flepimop2.*` with `follow_imports = "normal"` to handle flepimop2's implicit namespace package (see ACCIDDA/flepimop2#205)

Closes #12