### PR TITLE
Support `initial_state` mapping in system spec

### DIFF
--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -76,6 +76,8 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
             "axis_order": axes_meta.axis_order,
             "axis_sizes": axes_meta.axis_sizes,
             "axis_coords": axes_meta.axis_coords,
+            "state_names": compiled.state_names,
+            "initial_state": compiled.meta.get("initial_state"),
             "state_shape": shape_dims,
             "flatten": flatten_fn,
             "unflatten": unflatten_fn,

--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -367,3 +367,50 @@ def test_option_flatten_unflatten_roundtrip() -> None:
     assert flat.size == np.prod(shape)
     recovered = unflatten(flat)
     np.testing.assert_array_equal(recovered, tensor)
+
+
+# -- initial_state and state_names options --------------------------------------
+
+
+def test_option_state_names(sir_spec: dict[str, object]) -> None:
+    """state_names option exposes compiled state names."""
+    sys = OpSystemSystem(spec=sir_spec)
+    assert sys.option("state_names") == ("S", "I", "R")
+
+
+def test_option_initial_state_absent(sir_spec: dict[str, object]) -> None:
+    """initial_state option is None when spec has no initial_state block."""
+    sys = OpSystemSystem(spec=sir_spec)
+    assert sys.option("initial_state") is None
+
+
+def test_option_initial_state_scalar() -> None:
+    """Scalar initial_state mapping is exposed via option."""
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "state": ["S", "I"],
+        "equations": {"S": "-S", "I": "S"},
+        "initial_state": {"S": "S0", "I": "I0"},
+    }
+    sys = OpSystemSystem(spec=spec)
+    assert sys.option("initial_state") == {"S": "S0", "I": "I0"}
+
+
+def test_option_initial_state_templated() -> None:
+    """Templated initial_state expands and is exposed via option."""
+    spec: dict[str, object] = {
+        "kind": "transitions",
+        "axes": [{"name": "vax", "coords": ["u", "v"]}],
+        "state": ["S[vax]", "D"],
+        "transitions": [
+            {"from": "S[vax]", "to": "D", "rate": "mu"},
+        ],
+        "initial_state": {"S[vax]": "S0[vax]", "D": "D0"},
+    }
+    sys = OpSystemSystem(spec=spec)
+    ic = sys.option("initial_state")
+    assert ic == {
+        "S__vax_u": "S0__vax_u",
+        "S__vax_v": "S0__vax_v",
+        "D": "D0",
+    }

--- a/src/op_system/specs.py
+++ b/src/op_system/specs.py
@@ -1076,6 +1076,71 @@ def _expand_alias_templates(
     return aliases_out, alias_template_map
 
 
+def _expand_initial_state_templates(
+    initial_state_raw: Mapping[str, str] | None,
+    *,
+    axes: list[dict[str, Any]],
+    template_map: Mapping[str, list[tuple[str, dict[str, str]]]],
+) -> dict[str, str] | None:
+    """Expand a templated initial_state mapping into concrete state→param pairs.
+
+    Args:
+        initial_state_raw: Mapping of (possibly templated) state name to
+            (possibly templated) parameter name, or ``None``.
+        axes: Normalized axis definitions.
+        template_map: Combined template map from states and aliases.
+
+    Returns:
+        Expanded ``dict[str, str]`` mapping each concrete state name to its
+        concrete parameter name, or ``None`` if *initial_state_raw* is ``None``.
+    """
+    if initial_state_raw is None:
+        return None
+
+    ic_keys = list(initial_state_raw.keys())
+    ic_expanded_keys, ic_template_map = _expand_state_templates(ic_keys, axes=axes)
+    if len(ic_expanded_keys) != len(set(ic_expanded_keys)):
+        _raise_invalid_rhs_spec(detail="expanded initial_state keys contain duplicates")
+
+    combined = {**template_map, **ic_template_map}
+    result: dict[str, str] = {}
+
+    for raw_key, raw_val in initial_state_raw.items():
+        val_s = str(raw_val).strip()
+        if not val_s:
+            _raise_invalid_rhs_spec(
+                detail=f"initial_state[{raw_key!r}] must be a non-empty string",
+            )
+        if raw_key in ic_template_map:
+            for expanded_key, assignment in ic_template_map[raw_key]:
+                result[expanded_key] = _apply_template_substitutions(
+                    val_s,
+                    assignment=assignment,
+                    template_map=combined,
+                )
+        else:
+            result[raw_key] = val_s
+
+    return result
+
+
+def _maybe_attach_initial_state(
+    meta: dict[str, Any],
+    initial_state_raw: Mapping[str, str] | None,
+    *,
+    axes: list[dict[str, Any]],
+    template_map: Mapping[str, list[tuple[str, dict[str, str]]]],
+) -> None:
+    """Expand *initial_state_raw* and attach it to *meta* when present."""
+    expanded = _expand_initial_state_templates(
+        initial_state_raw,
+        axes=axes,
+        template_map=template_map,
+    )
+    if expanded is not None:
+        meta["initial_state"] = expanded
+
+
 def _extract_placeholders_from_expr(expr: str) -> set[str]:
     """Extract placeholder symbols found inside [...] tokens in an expression.
 
@@ -1807,6 +1872,13 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:
         template_map=template_map_all,
     )
 
+    _maybe_attach_initial_state(
+        meta,
+        spec.get("initial_state"),
+        axes=axes_meta,
+        template_map=template_map_all,
+    )
+
     return NormalizedRhs(
         kind="expr",
         state_names=tuple(state_expanded),
@@ -1995,6 +2067,13 @@ def normalize_transitions_rhs(
             all_syms=all_syms,
             d_terms=d_terms,
         )
+
+    _maybe_attach_initial_state(
+        meta,
+        spec.get("initial_state"),
+        axes=axes_meta,
+        template_map=template_map_all,
+    )
 
     return NormalizedRhs(
         kind="transitions",

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -827,3 +827,113 @@ def test_expr_equation_keys_extra_spaces_normalised() -> None:
     }
     out = normalize_expr_rhs(spec)
     assert len(out.state_names) == 2
+
+
+# -- initial_state template expansion ------------------------------------------
+
+
+def test_transitions_no_initial_state_omits_meta_key() -> None:
+    """When initial_state is absent, meta has no initial_state key."""
+    spec = {
+        "kind": "transitions",
+        "state": ["S", "I", "R"],
+        "transitions": [
+            {"from": "S", "to": "I", "rate": "beta"},
+            {"from": "I", "to": "R", "rate": "gamma"},
+        ],
+    }
+    out = normalize_transitions_rhs(spec)
+    assert "initial_state" not in out.meta
+
+
+def test_transitions_scalar_initial_state() -> None:
+    """Scalar (non-templated) initial_state passes through unchanged."""
+    spec = {
+        "kind": "transitions",
+        "state": ["S", "I", "R"],
+        "transitions": [
+            {"from": "S", "to": "I", "rate": "beta"},
+            {"from": "I", "to": "R", "rate": "gamma"},
+        ],
+        "initial_state": {"S": "S0", "I": "I0", "R": "R0"},
+    }
+    out = normalize_transitions_rhs(spec)
+    assert out.meta["initial_state"] == {"S": "S0", "I": "I0", "R": "R0"}
+
+
+def test_transitions_templated_initial_state_expands() -> None:
+    """Templated keys and values expand across axis coordinates."""
+    spec = {
+        "kind": "transitions",
+        "axes": [{"name": "vax", "coords": ["u", "v"]}],
+        "state": ["S[vax]", "D"],
+        "transitions": [
+            {"from": "S[vax]", "to": "D", "rate": "mu"},
+        ],
+        "initial_state": {"S[vax]": "S0[vax]", "D": "D0"},
+    }
+    out = normalize_transitions_rhs(spec)
+    expected = {
+        "S__vax_u": "S0__vax_u",
+        "S__vax_v": "S0__vax_v",
+        "D": "D0",
+    }
+    assert out.meta["initial_state"] == expected
+
+
+def test_transitions_multi_axis_initial_state() -> None:
+    """Initial state expands over multiple axes."""
+    spec = {
+        "kind": "transitions",
+        "axes": [
+            {"name": "age", "coords": ["y", "o"]},
+            {"name": "vax", "coords": ["u", "v"]},
+        ],
+        "state": ["S[age,vax]"],
+        "transitions": [
+            {"from": "S[age,vax]", "to": "S[age,vax]", "rate": "alpha"},
+        ],
+        "initial_state": {"S[age,vax]": "S0[age,vax]"},
+    }
+    out = normalize_transitions_rhs(spec)
+    ic = out.meta["initial_state"]
+    assert len(ic) == 4
+    assert ic["S__age_y__vax_u"] == "S0__age_y__vax_u"
+    assert ic["S__age_o__vax_v"] == "S0__age_o__vax_v"
+
+
+def test_expr_no_initial_state_omits_meta_key() -> None:
+    """When initial_state is absent, meta has no initial_state key (expr)."""
+    spec = {
+        "kind": "expr",
+        "state": ["S", "I", "R"],
+        "equations": {"S": "-beta*S", "I": "beta*S - gamma*I", "R": "gamma*I"},
+    }
+    out = normalize_expr_rhs(spec)
+    assert "initial_state" not in out.meta
+
+
+def test_expr_scalar_initial_state() -> None:
+    """Scalar initial_state passes through in expr specs."""
+    spec = {
+        "kind": "expr",
+        "state": ["S", "I"],
+        "equations": {"S": "-S", "I": "S"},
+        "initial_state": {"S": "S0", "I": "I0"},
+    }
+    out = normalize_expr_rhs(spec)
+    assert out.meta["initial_state"] == {"S": "S0", "I": "I0"}
+
+
+def test_expr_templated_initial_state_expands() -> None:
+    """Templated initial_state expands in expr specs."""
+    spec = {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": ["a", "b"]}],
+        "state": ["u[loc]"],
+        "equations": {"u[loc]": "-u[loc]"},
+        "initial_state": {"u[loc]": "u0[loc]"},
+    }
+    out = normalize_expr_rhs(spec)
+    expected = {"u__loc_a": "u0__loc_a", "u__loc_b": "u0__loc_b"}
+    assert out.meta["initial_state"] == expected


### PR DESCRIPTION
Closes #64

## Summary

Adds support for an optional `initial_state` block in the system spec that maps state names to parameter names. Template expansion (axes, cartesian products) is fully supported, following the same pattern as state and alias expansion.

## Changes

**`src/op_system/specs.py`**
- New `_expand_initial_state_templates()` — expands templated `initial_state` keys/values into concrete `state→param` pairs using the existing `_expand_state_templates` and `_apply_template_substitutions` machinery.
- New `_maybe_attach_initial_state()` — thin wrapper that conditionally attaches the expanded map to `meta["initial_state"]`, keeping `normalize_*_rhs` functions within complexity limits.
- Both `normalize_expr_rhs` and `normalize_transitions_rhs` now call `_maybe_attach_initial_state` after template maps are built.

**`flepimop2-op_system/.../op_system/__init__.py`**
- Adapter exposes `state_names` and `initial_state` via `self.options`.

**Tests** (+238 lines)
- 7 root tests: scalar, templated, multi-axis, and absent-key cases for both `expr` and `transitions` kinds.
- 4 provider tests: verify `option("state_names")`, `option("initial_state")` for absent, scalar, and templated specs.

## Design notes

- `initial_state` values are **symbolic** (parameter names, not literals) — the simulate/engine layer resolves them.
- When `initial_state` is omitted, `meta` has no `initial_state` key (no sentinel value).
- The helper-extraction pattern (`_maybe_attach_initial_state`) avoids pushing `normalize_transitions_rhs` over the C901/PLR0914 thresholds.