### PR TITLE
feat: add `coord_shift` transition type

### DIFF
--- a/src/op_system/specs.py
+++ b/src/op_system/specs.py
@@ -1756,6 +1756,173 @@ def _apply_transition_chains(
             })
 
 
+def _validate_coord_shift_entry(
+    tr: dict[str, Any],
+    axis_lookup: Mapping[str, list[str]],
+) -> tuple[str, str, str, list[Any], str]:
+    """Parse and validate a single ``coord_shift`` transition entry.
+
+    Returns:
+        ``(axis_name, from_coord, to_coord, apply_to, rate)``
+    """
+    shift_spec = tr["coord_shift"]
+    if not isinstance(shift_spec, dict) or len(shift_spec) != 1:
+        _raise_invalid_rhs_spec(
+            detail="coord_shift must be a mapping with exactly one axis entry",
+        )
+
+    axis_name, arrow = next(iter(shift_spec.items()))
+    if axis_name not in axis_lookup:
+        _raise_invalid_rhs_spec(
+            detail=f"coord_shift axis {axis_name!r} is not defined",
+        )
+
+    if not isinstance(arrow, str) or "->" not in arrow:
+        _raise_invalid_rhs_spec(
+            detail=f"coord_shift[{axis_name}] must be 'from_coord -> to_coord'",
+        )
+    parts = [p.strip() for p in arrow.split("->")]
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        _raise_invalid_rhs_spec(
+            detail=f"coord_shift[{axis_name}] must be 'from_coord -> to_coord'",
+        )
+    from_coord, to_coord = parts
+    valid_coords = axis_lookup[axis_name]
+    for coord in (from_coord, to_coord):
+        if coord not in valid_coords:
+            _raise_invalid_rhs_spec(
+                detail=(
+                    f"coord_shift coordinate {coord!r} not in "
+                    f"axis {axis_name!r} coords {valid_coords}"
+                ),
+            )
+
+    apply_to = tr.get("apply_to")
+    if not isinstance(apply_to, list) or not apply_to:
+        _raise_invalid_rhs_spec(
+            detail="coord_shift requires a non-empty 'apply_to' list",
+        )
+
+    rate_s = tr.get("rate")
+    if not isinstance(rate_s, str) or not rate_s.strip():
+        _raise_invalid_rhs_spec(detail="coord_shift requires a 'rate' string")
+
+    return axis_name, from_coord, to_coord, apply_to, rate_s.strip()
+
+
+def _apply_coord_shifts(
+    *,
+    transitions_raw: list[dict[str, Any]],
+    state_expanded: list[str],
+    axes: list[dict[str, Any]],
+) -> None:
+    """Expand ``coord_shift`` entries into concrete transitions.
+
+    Each ``coord_shift`` entry describes movement along one axis coordinate for
+    a set of states.  The entry is replaced *in-place* by one concrete
+    transition per state listed in ``apply_to``, per combination of the
+    remaining (non-shifted) axes those states carry.
+
+    Args:
+        transitions_raw: Mutable transition list — ``coord_shift`` entries are
+            replaced by concrete transition dicts.
+        state_expanded: Expanded state names (used to discover which axes each
+            ``apply_to`` state carries).
+        axes: Normalized axis definitions.
+    """
+    axis_lookup: dict[str, list[str]] = {
+        ax["name"]: [str(c) for c in ax.get("coords", [])] for ax in axes
+    }
+
+    i = 0
+    while i < len(transitions_raw):
+        tr = transitions_raw[i]
+        if "coord_shift" not in tr:
+            i += 1
+            continue
+
+        axis_name, from_coord, to_coord, apply_to, rate_s = _validate_coord_shift_entry(
+            tr, axis_lookup
+        )
+
+        concrete: list[dict[str, Any]] = []
+        from_frag = f"{axis_name}_{_sanitize_fragment(from_coord)}"
+        to_frag = f"{axis_name}_{_sanitize_fragment(to_coord)}"
+        for base in apply_to:
+            base = str(base).strip()  # noqa: PLW2901
+            concrete.extend(
+                _expand_coord_shift_for_base(
+                    base=base,
+                    from_frag=from_frag,
+                    to_frag=to_frag,
+                    rate_s=rate_s,
+                    state_expanded=state_expanded,
+                )
+            )
+
+        transitions_raw[i : i + 1] = concrete
+        i += len(concrete)
+
+
+def _expand_coord_shift_for_base(
+    *,
+    base: str,
+    from_frag: str,
+    to_frag: str,
+    rate_s: str,
+    state_expanded: list[str],
+) -> list[dict[str, Any]]:
+    """Emit concrete transitions for one ``apply_to`` base state.
+
+    Discovers which axes the base carries by inspecting ``state_expanded``
+    for names starting with ``base__``.  If the base has extra axes beyond
+    the shifted one, a transition is emitted for each coordinate combination
+    of those extra axes.  If only the shifted axis is present, a single
+    transition is emitted.
+
+    Returns:
+        Concrete ``{"from", "to", "rate"}`` transition dicts.
+    """
+    prefix = f"{base}__"
+    matching = [s for s in state_expanded if s.startswith(prefix)]
+
+    if not matching:
+        _raise_invalid_rhs_spec(
+            detail=(
+                f"coord_shift apply_to state {base!r} has no expanded states "
+                f"starting with '{prefix}'"
+            ),
+        )
+
+    concrete: list[dict[str, Any]] = []
+    expanded_set = set(state_expanded)
+
+    for state_name in matching:
+        if from_frag not in state_name:
+            continue
+
+        target = state_name.replace(from_frag, to_frag, 1)
+        if target not in expanded_set:
+            _raise_invalid_rhs_spec(
+                detail=(
+                    f"coord_shift would create transition to {target!r} "
+                    f"which is not an expanded state"
+                ),
+            )
+
+        concrete.append({"from": state_name, "to": target, "rate": rate_s})
+
+    if not concrete:
+        _raise_invalid_rhs_spec(
+            detail=(
+                f"coord_shift apply_to state {base!r} has no expanded states "
+                f"with fragment {from_frag!r}"
+            ),
+        )
+
+    return concrete
+
+
 # -----------------------------------------------------------------------------
 # Public normalization entrypoint
 # -----------------------------------------------------------------------------
@@ -2044,6 +2211,12 @@ def normalize_transitions_rhs(
             transitions_raw=transitions_raw,
             state_set=state_set,
         )
+
+    _apply_coord_shifts(
+        transitions_raw=transitions_raw,
+        state_expanded=state_expanded,
+        axes=axes_meta,
+    )
 
     for state_name in state_expanded:
         d_terms.setdefault(state_name, [])

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -937,3 +937,175 @@ def test_expr_templated_initial_state_expands() -> None:
     out = normalize_expr_rhs(spec)
     expected = {"u__loc_a": "u0__loc_a", "u__loc_b": "u0__loc_b"}
     assert out.meta["initial_state"] == expected
+
+
+# ---------------------------------------------------------------------------
+# coord_shift tests
+# ---------------------------------------------------------------------------
+
+
+def test_coord_shift_single_axis() -> None:
+    """A single-axis coord_shift expands to concrete transitions."""
+    spec = {
+        "kind": "transitions",
+        "axes": [{"name": "vax", "coords": ["u", "v"]}],
+        "state": ["S[vax]", "R[vax]"],
+        "transitions": [
+            {"from": "S[vax]", "to": "R[vax]", "rate": "gamma"},
+            {
+                "coord_shift": {"vax": "u -> v"},
+                "apply_to": ["S", "R"],
+                "rate": "nu",
+            },
+        ],
+    }
+    out = normalize_transitions_rhs(spec)
+
+    tr = out.meta["transitions"]
+    # Original template expands: 2 states x 1 transition = 2.
+    # coord_shift: 2 apply_to bases x 1 from_coord = 2.
+    # Total: 4 expanded transitions.
+    assert len(tr) == 4
+
+    shift_pairs = [(t["from"], t["to"]) for t in tr if t["rate"] == "nu"]
+    assert ("S__vax_u", "S__vax_v") in shift_pairs
+    assert ("R__vax_u", "R__vax_v") in shift_pairs
+    assert len(shift_pairs) == 2
+
+
+def test_coord_shift_multi_axis_expands_over_non_shifted() -> None:
+    """coord_shift expands over non-shifted axis coords."""
+    spec = {
+        "kind": "transitions",
+        "axes": [
+            {"name": "age", "coords": ["y", "o"]},
+            {"name": "vax", "coords": ["u", "v"]},
+        ],
+        "state": ["S[age,vax]"],
+        "transitions": [
+            {
+                "coord_shift": {"vax": "u -> v"},
+                "apply_to": ["S"],
+                "rate": "nu",
+            },
+        ],
+    }
+    out = normalize_transitions_rhs(spec)
+
+    tr = out.meta["transitions"]
+    shift_pairs = [(t["from"], t["to"]) for t in tr]
+    assert ("S__age_y__vax_u", "S__age_y__vax_v") in shift_pairs
+    assert ("S__age_o__vax_u", "S__age_o__vax_v") in shift_pairs
+    assert len(shift_pairs) == 2
+
+
+def test_coord_shift_preserves_regular_transitions() -> None:
+    """Regular transitions coexist with coord_shift entries."""
+    spec = {
+        "kind": "transitions",
+        "axes": [{"name": "vax", "coords": ["u", "v"]}],
+        "state": ["S[vax]", "I[vax]", "R[vax]"],
+        "aliases": {"N": "S__vax_u + S__vax_v + I__vax_u + I__vax_v"},
+        "transitions": [
+            {"from": "S[vax]", "to": "I[vax]", "rate": "beta"},
+            {"from": "I[vax]", "to": "R[vax]", "rate": "gamma"},
+            {
+                "coord_shift": {"vax": "u -> v"},
+                "apply_to": ["S", "R"],
+                "rate": "nu",
+            },
+        ],
+    }
+    out = normalize_transitions_rhs(spec)
+
+    tr = out.meta["transitions"]
+    # 2 template transitions * 2 coords + 2 coord_shift = 6
+    assert len(tr) == 6
+
+
+def test_coord_shift_rejects_missing_axis() -> None:
+    """coord_shift with an unknown axis raises."""
+    spec = {
+        "kind": "transitions",
+        "axes": [{"name": "vax", "coords": ["u", "v"]}],
+        "state": ["S[vax]"],
+        "transitions": [
+            {
+                "coord_shift": {"age": "y -> o"},
+                "apply_to": ["S"],
+                "rate": "nu",
+            },
+        ],
+    }
+    with pytest.raises(ValueError, match=r"axis.*age.*not defined"):
+        normalize_transitions_rhs(spec)
+
+
+def test_coord_shift_rejects_bad_coord() -> None:
+    """coord_shift with a coordinate not in the axis raises."""
+    spec = {
+        "kind": "transitions",
+        "axes": [{"name": "vax", "coords": ["u", "v"]}],
+        "state": ["S[vax]"],
+        "transitions": [
+            {
+                "coord_shift": {"vax": "u -> z"},
+                "apply_to": ["S"],
+                "rate": "nu",
+            },
+        ],
+    }
+    with pytest.raises(ValueError, match=r"coordinate.*z.*not in"):
+        normalize_transitions_rhs(spec)
+
+
+def test_coord_shift_rejects_missing_apply_to() -> None:
+    """coord_shift without apply_to raises."""
+    spec = {
+        "kind": "transitions",
+        "axes": [{"name": "vax", "coords": ["u", "v"]}],
+        "state": ["S[vax]"],
+        "transitions": [
+            {
+                "coord_shift": {"vax": "u -> v"},
+                "rate": "nu",
+            },
+        ],
+    }
+    with pytest.raises(ValueError, match="apply_to"):
+        normalize_transitions_rhs(spec)
+
+
+def test_coord_shift_rejects_missing_rate() -> None:
+    """coord_shift without rate raises."""
+    spec = {
+        "kind": "transitions",
+        "axes": [{"name": "vax", "coords": ["u", "v"]}],
+        "state": ["S[vax]"],
+        "transitions": [
+            {
+                "coord_shift": {"vax": "u -> v"},
+                "apply_to": ["S"],
+            },
+        ],
+    }
+    with pytest.raises(ValueError, match="rate"):
+        normalize_transitions_rhs(spec)
+
+
+def test_coord_shift_rejects_bad_arrow_syntax() -> None:
+    """coord_shift with malformed arrow raises."""
+    spec = {
+        "kind": "transitions",
+        "axes": [{"name": "vax", "coords": ["u", "v"]}],
+        "state": ["S[vax]"],
+        "transitions": [
+            {
+                "coord_shift": {"vax": "u to v"},
+                "apply_to": ["S"],
+                "rate": "nu",
+            },
+        ],
+    }
+    with pytest.raises(ValueError, match="from_coord -> to_coord"):
+        normalize_transitions_rhs(spec)


### PR DESCRIPTION
Closes #47

## Summary

Introduces `coord_shift` entries in the transitions list as a concise way to specify axis-coordinate-shifting transitions across a set of states.

## What changed

- **New transition type** `coord_shift`: instead of writing individual `from`/`to` transitions for every state and every non-shifted axis combination, a single `coord_shift` entry expands to all concrete transitions automatically.
- **Expansion logic** runs at the same pipeline stage as chain expansion — mutating `transitions_raw` before template expansion — so the generated transitions are treated identically to any hand-written concrete transition.
- **Validation** covers: axis must exist, both coordinates must be valid members of that axis, `apply_to` must be a non-empty list, `rate` must be a string, all target states must already exist in the expanded state list.

## Example

```yaml
transitions:
  - coord_shift: {vax: u -> v}
    apply_to: [S, R]
    rate: nu
```

Expands to:

```yaml
- {from: S__vax_u, to: S__vax_v, rate: nu}
- {from: R__vax_u, to: R__vax_v, rate: nu}
```

For states with additional axes, transitions are emitted for each combination of the non-shifted axis coordinates.

## Tests

8 new tests:
- Single-axis expansion (correct pairs, correct count)
- Multi-axis expansion over non-shifted coordinates
- Coexistence with regular and templated transitions
- Validation errors: unknown axis, bad coordinate, missing `apply_to`, missing `rate`, malformed arrow syntax