### PR TITLE
Make op_system callable JAX-native for diffrax/NUTS workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ dydt = compiled.eval_fn(0.0, jnp.asarray([999.0, 1.0, 0.0]), beta=0.3, gamma=0.1
 
 If you do not pass `xp`, `op_system` defaults to NumPy behavior.
 
+For diffrax-native solves and NUTS/HMC workflows, install the inference extra:
+
+```shell
+pip install "op_system[jax-inference]"
+```
+
+This includes `diffrax` and `blackjax` for end-to-end tracing workflows.
+
 ## YAML examples (organized and API-current)
 
 The example set below is intentionally small but complete: each core modeling pattern is shown for both `expr` and `transitions` pathways where applicable.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,28 @@ spec = {
 compiled = compile_spec(spec)
 dydt = compiled.eval_fn(0.0, [999.0, 1.0, 0.0], beta=0.3, gamma=0.1)
 ```
+
+## Optional JAX Backend
+
+Install the optional dependency group if you want to compile RHS callables
+for JAX-native tracing and integration workflows:
+
+```shell
+pip install "op_system[jax]"
+```
+
+Then pass the backend namespace when compiling:
+
+```python
+import jax.numpy as jnp
+from op_system import compile_spec
+
+compiled = compile_spec(spec, xp=jnp)
+dydt = compiled.eval_fn(0.0, jnp.asarray([999.0, 1.0, 0.0]), beta=0.3, gamma=0.1)
+```
+
+If you do not pass `xp`, `op_system` defaults to NumPy behavior.
+
 ## YAML examples (organized and API-current)
 
 The example set below is intentionally small but complete: each core modeling pattern is shown for both `expr` and `transitions` pathways where applicable.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,15 @@ for JAX-native tracing and integration workflows:
 pip install "op_system[jax]"
 ```
 
-Then pass the backend namespace when compiling:
+Then choose JAX using the backend selector:
+
+```python
+from op_system import compile_spec
+
+compiled = compile_spec(spec, backend="jax")
+```
+
+You can also pass an explicit array namespace when needed:
 
 ```python
 import jax.numpy as jnp

--- a/flepimop2-op_system/pyproject.toml
+++ b/flepimop2-op_system/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 license = { file = "LICENSE" }
 dependencies = [
   "op-system>=0.1.0",
-  "flepimop2>=0.1.0",
+  "flepimop2>=0.2.0",
   "pydantic>=2.0,<3",
   "numpy>=1.26",
   "PyYAML>=6.0",
@@ -78,7 +78,7 @@ convention = "google"
 dev = [
   "pytest>=8.4.2",
   "ruff>=0.13.3",
-  "mypy>=1.18.2",
+  "mypy>=1.20.2",
 ]
 
 [[tool.mypy.overrides]]

--- a/flepimop2-op_system/pyproject.toml
+++ b/flepimop2-op_system/pyproject.toml
@@ -34,6 +34,14 @@ classifiers = [
 [project.urls]
 Repository = "https://github.com/ACCIDDA/op_system"
 
+[project.optional-dependencies]
+jax = [
+  "op-system[jax]>=0.1.0",
+]
+jax-inference = [
+  "op-system[jax-inference]>=0.1.0",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -30,7 +30,7 @@ import functools
 import importlib
 import sys
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 import numpy as np
 from flepimop2.configuration import ModuleModel
@@ -127,7 +127,10 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
                     compiled.eval_fn(np.float64(time), state_arr, **params),
                     dtype=np.float64,
                 )
-            return cast("Float64NDArray", compiled.eval_fn(time, state_arr, **params))
+            result = compiled.eval_fn(time, state_arr, **params)
+            if TYPE_CHECKING:
+                return np.asarray(result, dtype=np.float64)
+            return result
 
         self._stepper = _stepper
         self._compiled_rhs = compiled  # handy for debugging/adapters

--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -30,7 +30,7 @@ import functools
 import importlib
 import sys
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 
 import numpy as np
 from flepimop2.configuration import ModuleModel
@@ -66,7 +66,6 @@ class _AxesMeta(NamedTuple):
 class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
     module: Literal["flepimop2.system.op_system"] = "flepimop2.system.op_system"
     state_change: StateChangeEnum = StateChangeEnum.FLOW
-    backend: Literal["numpy", "jax"] = "numpy"
 
     spec: dict[str, object] = Field(
         default=..., description="Inline op_system RHS specification (already loaded)"
@@ -79,7 +78,9 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
         del context
 
         spec_obj = self.spec
-        xp = self._get_backend_namespace(self.backend)
+        existing_options = dict(getattr(self, "options", {}) or {})
+        array_backend = self._resolve_array_backend(existing_options)
+        xp = self._get_array_namespace(array_backend)
         compiled = compile_spec(spec_obj, xp=xp)
         n_state = len(compiled.state_names)
 
@@ -92,6 +93,7 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
         operators = self._extract_operators(compiled)
         operator_axis = self._extract_operator_axis(compiled)
         self.options = {
+            **existing_options,
             "axis_order": axes_meta.axis_order,
             "axis_sizes": axes_meta.axis_sizes,
             "axis_coords": axes_meta.axis_coords,
@@ -103,6 +105,7 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
             "mixing_kernels": mixing_kernels,
             "operators": operators,
             "operator_axis": operator_axis,
+            "array_backend": array_backend,
         }
 
         def _stepper(
@@ -110,7 +113,7 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
             state: Float64NDArray,
             **kwargs: Any,  # noqa: ANN401
         ) -> Float64NDArray:
-            if self.backend == "numpy":
+            if array_backend == "numpy":
                 state_arr = np.asarray(state, dtype=np.float64)
             else:
                 state_arr = xp.asarray(state)
@@ -122,7 +125,7 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
                 raise ValueError(msg)
             params = dict(mixing_kernels)
             params.update(kwargs)
-            if self.backend == "numpy":
+            if array_backend == "numpy":
                 return np.asarray(
                     compiled.eval_fn(np.float64(time), state_arr, **params),
                     dtype=np.float64,
@@ -170,13 +173,23 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
         )
 
     @staticmethod
-    def _get_backend_namespace(backend: Literal["numpy", "jax"]) -> Any:  # noqa: ANN401
+    def _resolve_array_backend(
+        options: dict[str, object],
+    ) -> Literal["numpy", "jax"]:
+        backend = str(options.get("array_backend", "numpy"))
+        if backend not in {"numpy", "jax"}:
+            msg = "options.array_backend must be one of {'numpy', 'jax'}"
+            raise ValueError(msg)
+        return cast("Literal['numpy', 'jax']", backend)
+
+    @staticmethod
+    def _get_array_namespace(backend: Literal["numpy", "jax"]) -> Any:  # noqa: ANN401
         if backend == "numpy":
             return np
         try:
             jnp = importlib.import_module("jax.numpy")
         except ImportError as exc:
-            msg = "backend='jax' requires jax to be installed"
+            msg = "options.array_backend='jax' requires jax to be installed"
             raise ImportError(msg) from exc
         return jnp
 

--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -30,7 +30,7 @@ import functools
 import importlib
 import sys
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 
 import numpy as np
 from flepimop2.configuration import ModuleModel
@@ -127,7 +127,7 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
                     compiled.eval_fn(np.float64(time), state_arr, **params),
                     dtype=np.float64,
                 )
-            return compiled.eval_fn(time, state_arr, **params)
+            return cast("Float64NDArray", compiled.eval_fn(time, state_arr, **params))
 
         self._stepper = _stepper
         self._compiled_rhs = compiled  # handy for debugging/adapters

--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -27,6 +27,7 @@ pydantic BaseModel subclass is defined here, flepimop2 auto-generates a
 from __future__ import annotations
 
 import functools
+import importlib
 import sys
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple
@@ -65,6 +66,7 @@ class _AxesMeta(NamedTuple):
 class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
     module: Literal["flepimop2.system.op_system"] = "flepimop2.system.op_system"
     state_change: StateChangeEnum = StateChangeEnum.FLOW
+    backend: Literal["numpy", "jax"] = "numpy"
 
     spec: dict[str, object] = Field(
         default=..., description="Inline op_system RHS specification (already loaded)"
@@ -77,7 +79,8 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
         del context
 
         spec_obj = self.spec
-        compiled = compile_spec(spec_obj)
+        xp = self._get_backend_namespace(self.backend)
+        compiled = compile_spec(spec_obj, xp=xp)
         n_state = len(compiled.state_names)
 
         axes_meta = self._extract_axes_meta(compiled)
@@ -107,7 +110,10 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
             state: Float64NDArray,
             **kwargs: Any,  # noqa: ANN401
         ) -> Float64NDArray:
-            state_arr = np.asarray(state, dtype=np.float64)
+            if self.backend == "numpy":
+                state_arr = np.asarray(state, dtype=np.float64)
+            else:
+                state_arr = xp.asarray(state)
             if state_arr.ndim != 1 or state_arr.size != n_state:
                 msg = (
                     "state must be a 1D array matching the spec state length; "
@@ -116,10 +122,12 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
                 raise ValueError(msg)
             params = dict(mixing_kernels)
             params.update(kwargs)
-            return np.asarray(
-                compiled.eval_fn(np.float64(time), state_arr, **params),
-                dtype=np.float64,
-            )
+            if self.backend == "numpy":
+                return np.asarray(
+                    compiled.eval_fn(np.float64(time), state_arr, **params),
+                    dtype=np.float64,
+                )
+            return compiled.eval_fn(time, state_arr, **params)
 
         self._stepper = _stepper
         self._compiled_rhs = compiled  # handy for debugging/adapters
@@ -157,6 +165,17 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
         return _AxesMeta(
             axis_order=tuple(axis_order), axis_sizes=axis_sizes, axis_coords=axis_coords
         )
+
+    @staticmethod
+    def _get_backend_namespace(backend: Literal["numpy", "jax"]) -> Any:  # noqa: ANN401
+        if backend == "numpy":
+            return np
+        try:
+            jnp = importlib.import_module("jax.numpy")
+        except ImportError as exc:
+            msg = "backend='jax' requires jax to be installed"
+            raise ImportError(msg) from exc
+        return jnp
 
     @staticmethod
     def _extract_operators(

--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -30,7 +30,15 @@ import functools
 import importlib
 import sys
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    NamedTuple,
+    SupportsFloat,
+    SupportsIndex,
+    cast,
+)
 
 import numpy as np
 from flepimop2.configuration import ModuleModel
@@ -78,9 +86,14 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
         del context
 
         spec_obj = self.spec
-        existing_options = dict(getattr(self, "options", {}) or {})
-        array_backend = self._resolve_array_backend(existing_options)
-        xp = self._get_array_namespace(array_backend)
+        array_backend = self._resolve_array_backend(
+            self.option("array_backend", "numpy")
+        )
+        xp, state_coerce, time_coerce, output_coerce = self._build_backend_runtime(
+            array_backend
+        )
+        self._array_namespace = xp
+
         compiled = compile_spec(spec_obj, xp=xp)
         n_state = len(compiled.state_names)
 
@@ -93,7 +106,7 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
         operators = self._extract_operators(compiled)
         operator_axis = self._extract_operator_axis(compiled)
         self.options = {
-            **existing_options,
+            **dict(self.options or {}),
             "axis_order": axes_meta.axis_order,
             "axis_sizes": axes_meta.axis_sizes,
             "axis_coords": axes_meta.axis_coords,
@@ -113,10 +126,7 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
             state: Float64NDArray,
             **kwargs: Any,  # noqa: ANN401
         ) -> Float64NDArray:
-            if array_backend == "numpy":
-                state_arr = np.asarray(state, dtype=np.float64)
-            else:
-                state_arr = xp.asarray(state)
+            state_arr = state_coerce(state)
             if state_arr.ndim != 1 or state_arr.size != n_state:
                 msg = (
                     "state must be a 1D array matching the spec state length; "
@@ -125,15 +135,11 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
                 raise ValueError(msg)
             params = dict(mixing_kernels)
             params.update(kwargs)
-            if array_backend == "numpy":
-                return np.asarray(
-                    compiled.eval_fn(np.float64(time), state_arr, **params),
-                    dtype=np.float64,
-                )
-            result = compiled.eval_fn(time, state_arr, **params)
+            result = compiled.eval_fn(time_coerce(time), state_arr, **params)
+            output = output_coerce(result)
             if TYPE_CHECKING:
-                return np.asarray(result, dtype=np.float64)
-            return result
+                return np.asarray(output, dtype=np.float64)
+            return output
 
         self._stepper = _stepper
         self._compiled_rhs = compiled  # handy for debugging/adapters
@@ -174,9 +180,9 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
 
     @staticmethod
     def _resolve_array_backend(
-        options: dict[str, object],
+        backend_value: object,
     ) -> Literal["numpy", "jax"]:
-        backend = str(options.get("array_backend", "numpy"))
+        backend = str(backend_value)
         if backend not in {"numpy", "jax"}:
             msg = "options.array_backend must be one of {'numpy', 'jax'}"
             raise ValueError(msg)
@@ -192,6 +198,46 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
             msg = "options.array_backend='jax' requires jax to be installed"
             raise ImportError(msg) from exc
         return jnp
+
+    @classmethod
+    def _build_backend_runtime(
+        cls, backend: Literal["numpy", "jax"]
+    ) -> tuple[
+        Any,
+        Callable[[object], Any],
+        Callable[[SupportsFloat | SupportsIndex | str | bytes | None], Any],
+        Callable[[object], Any],
+    ]:
+        xp = cls._get_array_namespace(backend)
+        if backend == "numpy":
+
+            def state_coerce(state: object) -> np.ndarray:
+                return np.asarray(state, dtype=np.float64)
+
+            def time_coerce(
+                time: SupportsFloat | SupportsIndex | str | bytes | None,
+            ) -> np.float64:
+                return np.float64(time)
+
+            def output_coerce(result: object) -> np.ndarray:
+                return np.asarray(result, dtype=np.float64)
+
+            return xp, state_coerce, time_coerce, output_coerce
+
+        def state_coerce_jax(state: object) -> Any:  # noqa: ANN401
+            return xp.asarray(state)
+
+        def passthrough(
+            value: SupportsFloat | SupportsIndex | str | bytes | None,
+        ) -> SupportsFloat | SupportsIndex | str | bytes | None:
+            return value
+
+        return (
+            xp,
+            state_coerce_jax,
+            passthrough,
+            cast("Callable[[object], Any]", passthrough),
+        )
 
     @staticmethod
     def _extract_operators(

--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -133,6 +133,21 @@ def test_bind_delegates_to_step(sir_spec: dict[str, object]) -> None:
     np.testing.assert_allclose(via_bind, via_step, rtol=0.0, atol=0.0)
 
 
+def test_jax_backend_stepper_jittable(sir_spec: dict[str, object]) -> None:
+    """JAX backend returns tracer-compatible outputs under jit."""
+    jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
+
+    sys = OpSystemSystem(spec=sir_spec, backend="jax")
+    stepper = sys.bind(params={"beta": 0.3, "gamma": 0.1})
+    y0 = jnp.asarray([0.999, 0.001, 0.0])
+
+    out = jax.jit(lambda y: stepper(time=0.0, state=y))(y0)
+
+    expected = np.array([-0.0002997, 0.0001997, 0.0001], dtype=np.float64)
+    np.testing.assert_allclose(np.asarray(out), expected, rtol=1e-6, atol=1e-12)
+
+
 # -- Integration: full SystemABC.bind() contract -----------------------------------
 
 

--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -138,7 +138,7 @@ def test_jax_backend_stepper_jittable(sir_spec: dict[str, object]) -> None:
     jax = pytest.importorskip("jax")
     jnp = pytest.importorskip("jax.numpy")
 
-    sys = OpSystemSystem(spec=sir_spec, backend="jax")
+    sys = OpSystemSystem(spec=sir_spec, options={"array_backend": "jax"})
     stepper = sys.bind(params={"beta": 0.3, "gamma": 0.1})
     y0 = jnp.asarray([0.999, 0.001, 0.0])
 
@@ -146,6 +146,20 @@ def test_jax_backend_stepper_jittable(sir_spec: dict[str, object]) -> None:
 
     expected = np.array([-0.0002997, 0.0001997, 0.0001], dtype=np.float64)
     np.testing.assert_allclose(np.asarray(out), expected, rtol=1e-6, atol=1e-12)
+
+
+def test_option_array_backend_defaults_to_numpy(sir_spec: dict[str, object]) -> None:
+    """array_backend option defaults to numpy when omitted."""
+    sys = OpSystemSystem(spec=sir_spec)
+    assert sys.option("array_backend", None) == "numpy"
+
+
+def test_option_array_backend_invalid_value_raises(
+    sir_spec: dict[str, object],
+) -> None:
+    """Reject unsupported array_backend option values."""
+    with pytest.raises(ValueError, match=r"options\.array_backend"):
+        OpSystemSystem(spec=sir_spec, options={"array_backend": "torch"})
 
 
 # -- Integration: full SystemABC.bind() contract -----------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ data = [
 jax = [
     "jax>=0.4",
 ]
+jax-inference = [
+    "jax>=0.4",
+    "diffrax",
+    "blackjax",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ data = [
     "pandas>=2.2",
     "pyarrow>=16.0",
 ]
+jax = [
+    "jax>=0.4",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/src/op_system/__init__.py
+++ b/src/op_system/__init__.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 
 from importlib.metadata import version
 
+import numpy as np
+
 from op_system._identifer_string import IdentifierString
 from op_system._state_string import StateString
 
@@ -50,7 +52,7 @@ EXPERIMENTAL_FEATURES: frozenset[str] = frozenset()  # noqa: RUF067
 # -----------------------------------------------------------------------------
 
 
-def compile_spec(spec: dict[str, object], *, xp: object | None = None) -> CompiledRhs:  # noqa: RUF067
+def compile_spec(spec: dict[str, object], *, xp: object = np) -> CompiledRhs:  # noqa: RUF067
     """
     Validate, normalize, and compile a RHS specification in one call.
 
@@ -58,14 +60,12 @@ def compile_spec(spec: dict[str, object], *, xp: object | None = None) -> Compil
 
     Args:
         spec: Raw RHS specification mapping (YAML/JSON friendly).
-        xp: Optional array backend namespace; defaults to NumPy behavior.
+        xp: Array backend namespace; defaults to NumPy.
 
     Returns:
         CompiledRhs: Runnable RHS callable container.
     """
     rhs = normalize_rhs(spec)
-    if xp is None:
-        return compile_rhs(rhs)
     return compile_rhs(rhs, xp=xp)
 
 

--- a/src/op_system/__init__.py
+++ b/src/op_system/__init__.py
@@ -50,7 +50,7 @@ EXPERIMENTAL_FEATURES: frozenset[str] = frozenset()  # noqa: RUF067
 # -----------------------------------------------------------------------------
 
 
-def compile_spec(spec: dict[str, object]) -> CompiledRhs:  # noqa: RUF067
+def compile_spec(spec: dict[str, object], *, xp: object | None = None) -> CompiledRhs:  # noqa: RUF067
     """
     Validate, normalize, and compile a RHS specification in one call.
 
@@ -58,12 +58,15 @@ def compile_spec(spec: dict[str, object]) -> CompiledRhs:  # noqa: RUF067
 
     Args:
         spec: Raw RHS specification mapping (YAML/JSON friendly).
+        xp: Optional array backend namespace; defaults to NumPy behavior.
 
     Returns:
         CompiledRhs: Runnable RHS callable container.
     """
     rhs = normalize_rhs(spec)
-    return compile_rhs(rhs)
+    if xp is None:
+        return compile_rhs(rhs)
+    return compile_rhs(rhs, xp=xp)
 
 
 # -----------------------------------------------------------------------------

--- a/src/op_system/__init__.py
+++ b/src/op_system/__init__.py
@@ -21,7 +21,9 @@ Design guarantees:
 
 from __future__ import annotations
 
+import importlib
 from importlib.metadata import version
+from typing import Final, Literal
 
 import numpy as np
 
@@ -43,6 +45,7 @@ from .specs import (
 __version__ = version("op_system")
 
 SUPPORTED_RHS_KINDS: tuple[str, ...] = ("expr", "transitions")  # noqa: RUF067
+DEFAULT_ARRAY_BACKEND: Final[Literal["numpy", "jax"]] = "numpy"  # noqa: RUF067
 
 # Reserved for forward compatibility
 EXPERIMENTAL_FEATURES: frozenset[str] = frozenset()  # noqa: RUF067
@@ -52,7 +55,25 @@ EXPERIMENTAL_FEATURES: frozenset[str] = frozenset()  # noqa: RUF067
 # -----------------------------------------------------------------------------
 
 
-def compile_spec(spec: dict[str, object], *, xp: object = np) -> CompiledRhs:  # noqa: RUF067
+def _resolve_xp(backend: Literal["numpy", "jax"]) -> object:  # noqa: RUF067
+    if backend == "numpy":
+        return np
+    try:
+        return importlib.import_module("jax.numpy")
+    except ImportError as exc:
+        msg = (
+            "backend='jax' requires jax to be installed "
+            '(pip install "op_system[jax]")'
+        )
+        raise ImportError(msg) from exc
+
+
+def compile_spec(  # noqa: RUF067
+    spec: dict[str, object],
+    *,
+    xp: object | None = None,
+    backend: Literal["numpy", "jax"] = DEFAULT_ARRAY_BACKEND,
+) -> CompiledRhs:
     """
     Validate, normalize, and compile a RHS specification in one call.
 
@@ -60,13 +81,23 @@ def compile_spec(spec: dict[str, object], *, xp: object = np) -> CompiledRhs:  #
 
     Args:
         spec: Raw RHS specification mapping (YAML/JSON friendly).
-        xp: Array backend namespace; defaults to NumPy.
+        xp: Optional array backend namespace. If provided, takes precedence over
+            backend selection.
+        backend: Backend selector used when xp is not provided.
 
     Returns:
         CompiledRhs: Runnable RHS callable container.
+
+    Raises:
+        ValueError: If both `xp` and a non-default backend are provided.
     """
+    if xp is not None and backend != DEFAULT_ARRAY_BACKEND:
+        msg = "Pass either xp or backend='jax', not both."
+        raise ValueError(msg)
+
+    xp_ns = _resolve_xp(backend) if xp is None else xp
     rhs = normalize_rhs(spec)
-    return compile_rhs(rhs, xp=xp)
+    return compile_rhs(rhs, xp=xp_ns)
 
 
 # -----------------------------------------------------------------------------
@@ -74,6 +105,7 @@ def compile_spec(spec: dict[str, object], *, xp: object = np) -> CompiledRhs:  #
 # -----------------------------------------------------------------------------
 
 __all__ = [
+    "DEFAULT_ARRAY_BACKEND",
     "EXPERIMENTAL_FEATURES",
     "SUPPORTED_RHS_KINDS",
     "CompiledRhs",

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -515,12 +515,12 @@ def _make_eval_fn(  # noqa: C901
 # -----------------------------------------------------------------------------
 
 
-def compile_rhs(rhs: NormalizedRhs, *, xp: object = np) -> CompiledRhs:
+def compile_rhs(rhs: NormalizedRhs, *, xp: object) -> CompiledRhs:
     """Compile a normalized RHS into a runnable evaluation function.
 
     Args:
         rhs: Normalized RHS produced by `op_system.specs.normalize_rhs`.
-        xp: Array backend namespace (default: NumPy).
+        xp: Array backend namespace.
 
     Returns:
         A `CompiledRhs` containing an `eval_fn(t, y, **params) -> dydt`.

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -22,7 +22,15 @@ from __future__ import annotations
 import ast
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, NoReturn, Protocol, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    NoReturn,
+    Protocol,
+    SupportsFloat,
+    SupportsIndex,
+    cast,
+)
 
 import numpy as np
 from numpy.typing import NDArray
@@ -34,7 +42,20 @@ if TYPE_CHECKING:
     from .specs import NormalizedRhs
 
 Float64Array = NDArray[np.float64]
+ScalarLike = SupportsFloat | SupportsIndex | str | bytes | None
 _SAFE_BUILTINS = {"__import__": __import__}
+
+
+class _BackendNamespace(Protocol):
+    def asarray(self, obj: object, dtype: object | None = None) -> object: ...
+
+    def stack(self, arrays: list[object]) -> object: ...
+
+    def sum(self, arr: object) -> object: ...
+
+
+class _Indexable(Protocol):
+    def __getitem__(self, idx: int) -> object: ...
 
 
 def _is_numpy_backend(xp: object) -> bool:
@@ -133,7 +154,7 @@ class EvalFn(Protocol):
 
     def __call__(  # noqa: D102
         self, t: object, y: object, **params: object
-    ) -> object: ...
+    ) -> Float64Array: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -145,7 +166,9 @@ class CompiledRhs:
     eval_fn: EvalFn
     meta: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
 
-    def bind(self, params: Mapping[str, object]) -> Callable[[object, object], object]:
+    def bind(
+        self, params: Mapping[str, object]
+    ) -> Callable[[object, object], Float64Array]:
         """Bind parameter values and return a 2-arg RHS: rhs(t, y) -> dydt.
 
         Args:
@@ -156,7 +179,7 @@ class CompiledRhs:
         """
         params_dict = dict(params)
 
-        def rhs(t: object, y: object) -> object:
+        def rhs(t: object, y: object) -> Float64Array:
             return self.eval_fn(t, y, **params_dict)
 
         return rhs
@@ -400,7 +423,7 @@ def _evaluate_equations(
     eq_code: list[CodeType],
     env: Mapping[str, object],
     xp: object,
-) -> object:
+) -> Float64Array:
     """Evaluate equation code objects against an environment.
 
     Returns:
@@ -418,7 +441,7 @@ def _evaluate_equations(
 
     if _is_numpy_backend(xp):
         return np.asarray(out_vals, dtype=np.float64)
-    return cast("Any", xp).asarray(out_vals)
+    return cast("Float64Array", cast("_BackendNamespace", xp).asarray(out_vals))
 
 
 def _make_eval_fn(  # noqa: C901
@@ -436,38 +459,45 @@ def _make_eval_fn(  # noqa: C901
     def _sum_state(env: Mapping[str, object]) -> object:
         values = [v for k, v in env.items() if k in name_to_idx]
         if not values:
-            return cast("Any", xp).asarray(0.0)
+            return cast("_BackendNamespace", xp).asarray(0.0)
         if _is_numpy_backend(xp):
             return np.float64(np.sum(np.asarray(values, dtype=np.float64)))
-        return cast("Any", xp).sum(cast("Any", xp).stack(values))
+        xp_ns = cast("_BackendNamespace", xp)
+        return xp_ns.sum(xp_ns.stack(values))
 
     def _sum_prefix(prefix: str, env: Mapping[str, object]) -> object:
         values = [
             v for k, v in env.items() if k.startswith(prefix) and k in name_to_idx
         ]
         if not values:
-            return cast("Any", xp).asarray(0.0)
+            return cast("_BackendNamespace", xp).asarray(0.0)
         if _is_numpy_backend(xp):
             return np.float64(np.sum(np.asarray(values, dtype=np.float64)))
-        return cast("Any", xp).sum(cast("Any", xp).stack(values))
+        xp_ns = cast("_BackendNamespace", xp)
+        return xp_ns.sum(xp_ns.stack(values))
 
     def _build_env(
         t: object, y_arr: object, params: Mapping[str, object]
     ) -> dict[str, object]:
-        t_val = np.float64(t) if _is_numpy_backend(xp) else cast("Any", xp).asarray(t)
+        t_val = (
+            np.float64(cast("ScalarLike", t))
+            if _is_numpy_backend(xp)
+            else cast("_BackendNamespace", xp).asarray(t)
+        )
         env: dict[str, object] = {"np": xp, "t": t_val}
         for s, i in name_to_idx.items():
-            env[s] = cast("Any", y_arr)[i]
+            env[s] = cast("_Indexable", y_arr)[i]
         env.update(params)
         env["sum_state"] = lambda: _sum_state(env)
         env["sum_prefix"] = lambda prefix: _sum_prefix(str(prefix), env)
         return env
 
-    def eval_fn(t: object, y: object, **params: object) -> object:
+    def eval_fn(t: object, y: object, **params: object) -> Float64Array:
+        y_in: object
         if _is_numpy_backend(xp):
             y_in = np.asarray(y, dtype=np.float64)
         else:
-            y_in = cast("Any", xp).asarray(y)
+            y_in = cast("_BackendNamespace", xp).asarray(y)
         y_arr = _validate_state_vector(y_in, n_state=n_state)
 
         env = _build_env(t, y_arr, params)

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -37,6 +37,10 @@ Float64Array = NDArray[np.float64]
 _SAFE_BUILTINS = {"__import__": __import__}
 
 
+def _is_numpy_backend(xp: object) -> bool:
+    return xp is np or getattr(xp, "__name__", "") == "numpy"
+
+
 # -----------------------------------------------------------------------------
 # Error message constants
 # -----------------------------------------------------------------------------
@@ -128,8 +132,8 @@ class EvalFn(Protocol):
     """Callable RHS evaluator supporting runtime parameter kwargs."""
 
     def __call__(  # noqa: D102
-        self, t: np.float64, y: Float64Array, **params: object
-    ) -> Float64Array: ...
+        self, t: object, y: object, **params: object
+    ) -> object: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -141,9 +145,7 @@ class CompiledRhs:
     eval_fn: EvalFn
     meta: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
 
-    def bind(
-        self, params: Mapping[str, object]
-    ) -> Callable[[np.float64, Float64Array], Float64Array]:
+    def bind(self, params: Mapping[str, object]) -> Callable[[object, object], object]:
         """Bind parameter values and return a 2-arg RHS: rhs(t, y) -> dydt.
 
         Args:
@@ -154,7 +156,7 @@ class CompiledRhs:
         """
         params_dict = dict(params)
 
-        def rhs(t: np.float64, y: Float64Array) -> Float64Array:
+        def rhs(t: object, y: object) -> object:
             return self.eval_fn(t, y, **params_dict)
 
         return rhs
@@ -379,15 +381,17 @@ def _resolve_aliases(
     )
 
 
-def _validate_state_vector(y_arr: np.ndarray, *, n_state: int) -> np.ndarray:
+def _validate_state_vector(y_arr: object, *, n_state: int) -> object:
     """Validate shape of the state vector.
 
     Returns:
         State vector coerced to shape (n_state,).
     """
     expected_shape = (n_state,)
-    if tuple(y_arr.shape) != expected_shape:
-        _raise_state_shape_error(expected=f"(n_state={n_state},)", got=y_arr.shape)
+    shape = getattr(y_arr, "shape", None)
+    shape_tuple = tuple(shape) if shape is not None else None
+    if shape_tuple != expected_shape:
+        _raise_state_shape_error(expected=f"(n_state={n_state},)", got=shape)
     return y_arr
 
 
@@ -395,72 +399,83 @@ def _evaluate_equations(
     *,
     eq_code: list[CodeType],
     env: Mapping[str, object],
-    n_state: int,
-) -> Float64Array:
+    xp: object,
+) -> object:
     """Evaluate equation code objects against an environment.
 
     Returns:
         Derivative vector aligned to the provided state ordering.
     """
-    out = np.empty((n_state,), dtype=np.float64)
-    for i, codeobj in enumerate(eq_code):
+    out_vals: list[object] = []
+    for codeobj in eq_code:
         try:
             val = eval(codeobj, {"__builtins__": _SAFE_BUILTINS}, env)  # noqa: S307
         except NameError as exc:
             _raise_parameter_error(detail=f"unknown symbol in equation: {exc!s}")
         except (ValueError, TypeError, ArithmeticError) as exc:
             _raise_invalid_expression(detail=f"equation evaluation failed: {exc!r}")
-        out[i] = np.float64(val)
-    return out
+        out_vals.append(val)
+
+    if _is_numpy_backend(xp):
+        return np.asarray(out_vals, dtype=np.float64)
+    return cast("Any", xp).asarray(out_vals)
 
 
-def _make_eval_fn(
+def _make_eval_fn(  # noqa: C901
     *,
     state_names: tuple[str, ...],
     aliases: Mapping[str, str],
     equations: tuple[str, ...],
+    xp: object,
 ) -> EvalFn:
     n_state = len(state_names)
     name_to_idx = {s: i for i, s in enumerate(state_names)}
     alias_code = _collect_alias_code(aliases)
     eq_code = _collect_eq_code(equations)
 
-    def _sum_state(env: Mapping[str, object]) -> np.float64:
-        values = [
-            np.float64(float(cast("Any", v)))
-            for k, v in env.items()
-            if k in name_to_idx
-        ]
-        return np.float64(sum(values))
+    def _sum_state(env: Mapping[str, object]) -> object:
+        values = [v for k, v in env.items() if k in name_to_idx]
+        if not values:
+            return cast("Any", xp).asarray(0.0)
+        if _is_numpy_backend(xp):
+            return np.float64(np.sum(np.asarray(values, dtype=np.float64)))
+        return cast("Any", xp).sum(cast("Any", xp).stack(values))
 
-    def _sum_prefix(prefix: str, env: Mapping[str, object]) -> np.float64:
+    def _sum_prefix(prefix: str, env: Mapping[str, object]) -> object:
         values = [
-            np.float64(float(cast("Any", v)))
-            for k, v in env.items()
-            if k.startswith(prefix) and k in name_to_idx
+            v for k, v in env.items() if k.startswith(prefix) and k in name_to_idx
         ]
-        return np.float64(sum(values))
+        if not values:
+            return cast("Any", xp).asarray(0.0)
+        if _is_numpy_backend(xp):
+            return np.float64(np.sum(np.asarray(values, dtype=np.float64)))
+        return cast("Any", xp).sum(cast("Any", xp).stack(values))
 
     def _build_env(
-        t: np.float64, y_arr: Float64Array, params: Mapping[str, object]
+        t: object, y_arr: object, params: Mapping[str, object]
     ) -> dict[str, object]:
-        env: dict[str, object] = {"np": np, "t": np.float64(t)}
+        t_val = np.float64(t) if _is_numpy_backend(xp) else cast("Any", xp).asarray(t)
+        env: dict[str, object] = {"np": xp, "t": t_val}
         for s, i in name_to_idx.items():
-            env[s] = np.float64(y_arr[i])
+            env[s] = cast("Any", y_arr)[i]
         env.update(params)
         env["sum_state"] = lambda: _sum_state(env)
         env["sum_prefix"] = lambda prefix: _sum_prefix(str(prefix), env)
         return env
 
-    def eval_fn(t: np.float64, y: Float64Array, **params: object) -> Float64Array:
-        y_arr = _validate_state_vector(np.asarray(y, dtype=np.float64), n_state=n_state)
+    def eval_fn(t: object, y: object, **params: object) -> object:
+        if _is_numpy_backend(xp):
+            y_in = np.asarray(y, dtype=np.float64)
+        else:
+            y_in = cast("Any", xp).asarray(y)
+        y_arr = _validate_state_vector(y_in, n_state=n_state)
 
-        env = _build_env(np.float64(t), y_arr, params)
+        env = _build_env(t, y_arr, params)
 
         if alias_code:
             env.update(_resolve_aliases(alias_code, base_env=env))
 
-        return _evaluate_equations(eq_code=eq_code, env=env, n_state=n_state)
+        return _evaluate_equations(eq_code=eq_code, env=env, xp=xp)
 
     return eval_fn
 
@@ -470,11 +485,12 @@ def _make_eval_fn(
 # -----------------------------------------------------------------------------
 
 
-def compile_rhs(rhs: NormalizedRhs) -> CompiledRhs:
+def compile_rhs(rhs: NormalizedRhs, *, xp: object = np) -> CompiledRhs:
     """Compile a normalized RHS into a runnable evaluation function.
 
     Args:
         rhs: Normalized RHS produced by `op_system.specs.normalize_rhs`.
+        xp: Array backend namespace (default: NumPy).
 
     Returns:
         A `CompiledRhs` containing an `eval_fn(t, y, **params) -> dydt`.
@@ -489,6 +505,7 @@ def compile_rhs(rhs: NormalizedRhs) -> CompiledRhs:
         state_names=rhs.state_names,
         aliases=rhs.aliases,
         equations=rhs.equations,
+        xp=xp,
     )
 
     return CompiledRhs(

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -66,7 +66,7 @@ def compiled_xy(rhs_xy: NormalizedRhs) -> CompiledRhs:
     Returns:
         CompiledRhs instance.
     """
-    return compile_rhs(rhs_xy)
+    return compile_rhs(rhs_xy, xp=np)
 
 
 def test_compile_rhs_expr_happy_path_and_eval(compiled_xy: CompiledRhs) -> None:
@@ -109,7 +109,7 @@ def test_eval_rejects_non_1d_state_shape() -> None:
     """eval_fn rejects non-1D state arrays with standardized message."""
     spec = {"kind": "expr", "state": ["x"], "equations": {"x": "0.0"}}
     rhs = normalize_rhs(spec)
-    compiled = compile_rhs(rhs)
+    compiled = compile_rhs(rhs, xp=np)
 
     y_bad = np.zeros((1, 1), dtype=np.float64)
     msg = "state has an invalid shape/value. Expected (n_state=1,)."
@@ -125,7 +125,7 @@ def test_eval_rejects_wrong_state_length() -> None:
         "equations": {"x": "0.0", "y": "0.0"},
     }
     rhs = normalize_rhs(spec)
-    compiled = compile_rhs(rhs)
+    compiled = compile_rhs(rhs, xp=np)
 
     msg = "state has an invalid shape/value. Expected (n_state=2,)."
     with pytest.raises(ValueError, match=re.escape(msg)):
@@ -136,7 +136,7 @@ def test_eval_unknown_symbol_raises_parameter_error() -> None:
     """eval_fn raises parameter error for unknown symbols in expressions."""
     spec = {"kind": "expr", "state": ["x"], "equations": {"x": "beta * x"}}
     rhs = normalize_rhs(spec)
-    compiled = compile_rhs(rhs)
+    compiled = compile_rhs(rhs, xp=np)
 
     with pytest.raises(TypeError, match=r"Invalid parameters for op_system"):
         compiled.eval_fn(np.float64(0.0), np.array([1.0], dtype=np.float64))
@@ -154,7 +154,7 @@ def test_compile_rejects_disallowed_function_calls() -> None:
     spec = {"kind": "expr", "state": ["x"], "equations": {"x": "np.floor(x)"}}
     rhs = normalize_rhs(spec)
     with pytest.raises(ValueError, match=r"disallowed function call"):
-        compile_rhs(rhs)
+        compile_rhs(rhs, xp=np)
 
 
 def test_compile_rejects_nonwhitelisted_helper() -> None:
@@ -162,7 +162,7 @@ def test_compile_rejects_nonwhitelisted_helper() -> None:
     spec = {"kind": "expr", "state": ["x"], "equations": {"x": "foo(x)"}}
     rhs = normalize_rhs(spec)
     with pytest.raises(ValueError, match=r"disallowed function call"):
-        compile_rhs(rhs)
+        compile_rhs(rhs, xp=np)
 
 
 def test_compile_rejects_disallowed_attribute_access() -> None:
@@ -170,7 +170,7 @@ def test_compile_rejects_disallowed_attribute_access() -> None:
     spec = {"kind": "expr", "state": ["x"], "equations": {"x": "x.real"}}
     rhs = normalize_rhs(spec)
     with pytest.raises(ValueError, match=r"disallowed attribute access"):
-        compile_rhs(rhs)
+        compile_rhs(rhs, xp=np)
 
 
 def test_eval_allows_whitelisted_np_calls() -> None:
@@ -181,7 +181,7 @@ def test_eval_allows_whitelisted_np_calls() -> None:
         "equations": {"x": "np.maximum(x, 0.0)"},
     }
     rhs = normalize_rhs(spec)
-    compiled = compile_rhs(rhs)
+    compiled = compile_rhs(rhs, xp=np)
     out = compiled.eval_fn(np.float64(0.0), np.array([-2.0], dtype=np.float64))
     assert np.allclose(out, np.array([0.0], dtype=np.float64))
 
@@ -195,7 +195,7 @@ def test_eval_allows_expanded_np_whitelist() -> None:
     )
     spec = {"kind": "expr", "state": ["x"], "equations": {"x": expr}}
     rhs = normalize_rhs(spec)
-    compiled = compile_rhs(rhs)
+    compiled = compile_rhs(rhs, xp=np)
     x_val = np.array([1.0], dtype=np.float64)
     out = compiled.eval_fn(np.float64(0.0), x_val)
     expected = np.array(
@@ -231,7 +231,7 @@ def test_templates_and_sum_over_compile_and_eval() -> None:
         },
     }
     rhs = normalize_rhs(spec)
-    compiled = compile_rhs(rhs)
+    compiled = compile_rhs(rhs, xp=np)
 
     # State ordering after expansion: S__pop_p1, S__pop_p2, I__pop_p1, I__pop_p2
     y = np.array([10.0, 20.0, 1.0, 2.0], dtype=np.float64)
@@ -264,7 +264,7 @@ def test_reducer_helpers_sum_state_and_prefix() -> None:
         },
     }
     rhs = normalize_rhs(spec)
-    compiled = compile_rhs(rhs)
+    compiled = compile_rhs(rhs, xp=np)
     out = compiled.eval_fn(np.float64(0.0), np.array([2.0, 3.0], dtype=np.float64))
     assert np.allclose(out, np.array([5.0, 2.0], dtype=np.float64))
 
@@ -278,7 +278,7 @@ def test_alias_dependency_resolution() -> None:
         "equations": {"x": "b"},
     }
     rhs = normalize_rhs(spec)
-    compiled = compile_rhs(rhs)
+    compiled = compile_rhs(rhs, xp=np)
     out = compiled.eval_fn(np.float64(0.0), np.array([3.0], dtype=np.float64))
     assert np.allclose(out, np.array([6.0], dtype=np.float64))
 
@@ -292,7 +292,7 @@ def test_alias_cycle_is_rejected() -> None:
         "equations": {"x": "a"},
     }
     rhs = normalize_rhs(spec)
-    compiled = compile_rhs(rhs)
+    compiled = compile_rhs(rhs, xp=np)
     with pytest.raises(ValueError, match=r"could not resolve alias dependencies"):
         compiled.eval_fn(np.float64(0.0), np.array([1.0], dtype=np.float64))
 
@@ -309,7 +309,7 @@ def test_transitions_rhs_compiles_and_evaluates() -> None:
         ],
     }
     rhs = normalize_rhs(spec)
-    compiled = compile_rhs(rhs)
+    compiled = compile_rhs(rhs, xp=np)
 
     y = np.array([999.0, 1.0, 0.0], dtype=np.float64)
     out = compiled.eval_fn(np.float64(0.0), y, beta=0.3, gamma=0.1)
@@ -342,7 +342,7 @@ def test_compiled_rhs_meta_from_spec_with_axes_and_kernels() -> None:
         "equations": {"S": "-beta * S", "I": "beta * S"},
     }
     rhs = normalize_rhs(spec)
-    compiled = compile_rhs(rhs)
+    compiled = compile_rhs(rhs, xp=np)
 
     assert "axes" in compiled.meta
     assert len(compiled.meta["axes"]) == 1
@@ -372,6 +372,30 @@ def test_compile_spec_preserves_meta() -> None:
     assert compiled.meta["axes"][0]["name"] == "space"
 
 
+def test_compile_spec_owns_default_backend_policy() -> None:
+    """compile_spec defaults to NumPy without requiring callers to pass xp."""
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "state": ["x"],
+        "equations": {"x": "2.0 * x"},
+    }
+    compiled = compile_spec(spec)
+    out = compiled.eval_fn(np.float64(0.0), np.array([3.0], dtype=np.float64))
+    assert np.allclose(out, np.array([6.0], dtype=np.float64))
+
+
+def test_compile_rhs_requires_explicit_backend_namespace() -> None:
+    """compile_rhs requires explicit xp so default policy is centralized."""
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "state": ["x"],
+        "equations": {"x": "x"},
+    }
+    rhs = normalize_rhs(spec)
+    with pytest.raises(TypeError, match=r"required keyword-only argument: 'xp'"):
+        compile_rhs(rhs)  # type: ignore[call-arg]
+
+
 def test_sum_over_in_filter_evaluates_correctly() -> None:
     """sum_over IN filter compiles and evaluates correctly end-to-end."""
     spec = {
@@ -394,7 +418,7 @@ def test_sum_over_in_filter_evaluates_correctly() -> None:
     assert "S__vax_u" not in rhs.aliases["covered"]
 
     # Compile and run eval_fn: state = [u=10, v=3, w=7], dS/dt = -S
-    compiled = compile_rhs(rhs)
+    compiled = compile_rhs(rhs, xp=np)
     state = np.array([10.0, 3.0, 7.0], dtype=np.float64)
     derivs = compiled.eval_fn(np.float64(0.0), state)
     assert np.allclose(derivs, -state)

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -422,3 +422,75 @@ def test_compile_rhs_with_jax_backend_is_jittable() -> None:
         lambda beta: compiled.eval_fn(0.0, y0, beta=beta)[0],
     )
     assert np.isclose(float(grad_fn(1.5)), 2.0)
+
+
+def test_compile_rhs_with_jax_backend_diffrax_smoke() -> None:
+    """Compiled JAX RHS can be consumed directly by diffrax."""
+    jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
+    diffrax = pytest.importorskip("diffrax")
+
+    spec = {
+        "kind": "expr",
+        "state": ["x"],
+        "equations": {"x": "-beta * x"},
+    }
+    rhs = normalize_rhs(spec)
+    compiled = compile_rhs(rhs, xp=jnp)
+
+    term = diffrax.ODETerm(lambda t, y, args: compiled.eval_fn(t, y, **args))
+    solver = diffrax.Tsit5()
+
+    def solve(beta: float) -> object:
+        return diffrax.diffeqsolve(
+            term,
+            solver,
+            t0=0.0,
+            t1=1.0,
+            dt0=0.1,
+            y0=jnp.asarray([1.0]),
+            args={"beta": beta},
+            saveat=diffrax.SaveAt(t1=True),
+        ).ys[0]
+
+    out = jax.jit(solve)(0.5)
+    expected = np.exp(-0.5)
+    assert np.isclose(float(out), expected, rtol=1e-3)
+
+
+def test_compile_rhs_traces_through_blackjax_nuts() -> None:
+    """A representative NUTS step can trace gradients through RHS eval."""
+    jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
+    jr = pytest.importorskip("jax.random")
+    blackjax = pytest.importorskip("blackjax")
+
+    spec = {
+        "kind": "expr",
+        "state": ["x"],
+        "equations": {"x": "-beta * x"},
+    }
+    rhs = normalize_rhs(spec)
+    compiled = compile_rhs(rhs, xp=jnp)
+
+    y0 = jnp.asarray([1.0])
+    observed_dydt = -0.7
+
+    def logdensity(theta: object) -> object:
+        beta = jnp.exp(theta[0])
+        pred = compiled.eval_fn(0.0, y0, beta=beta)[0]
+        residual = pred - observed_dydt
+        prior = -0.5 * theta[0] ** 2
+        likelihood = -40.0 * residual**2
+        return prior + likelihood
+
+    nuts = blackjax.nuts(
+        logdensity,
+        step_size=0.1,
+        inverse_mass_matrix=jnp.ones((1,)),
+    )
+    state = nuts.init(jnp.asarray([0.0]))
+    key = jr.PRNGKey(0)
+
+    next_state, _info = jax.jit(nuts.step)(key, state)
+    assert np.isfinite(float(next_state.logdensity))

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -476,7 +476,7 @@ def test_compile_rhs_traces_through_blackjax_nuts() -> None:
     y0 = jnp.asarray([1.0])
     observed_dydt = -0.7
 
-    def logdensity(theta: object) -> object:
+    def logdensity(theta: np.ndarray) -> object:
         beta = jnp.exp(theta[0])
         pred = compiled.eval_fn(0.0, y0, beta=beta)[0]
         residual = pred - observed_dydt

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -398,3 +398,27 @@ def test_sum_over_in_filter_evaluates_correctly() -> None:
     state = np.array([10.0, 3.0, 7.0], dtype=np.float64)
     derivs = compiled.eval_fn(np.float64(0.0), state)
     assert np.allclose(derivs, -state)
+
+
+def test_compile_rhs_with_jax_backend_is_jittable() -> None:
+    """JAX backend preserves tracers and can be jitted/differentiated."""
+    jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
+
+    spec = {
+        "kind": "expr",
+        "state": ["x"],
+        "equations": {"x": "beta * x"},
+    }
+    rhs = normalize_rhs(spec)
+    compiled = compile_rhs(rhs, xp=jnp)
+
+    y0 = jnp.asarray([2.0])
+    eval_jit = jax.jit(lambda beta: compiled.eval_fn(0.0, y0, beta=beta))
+    out = eval_jit(1.5)
+    assert np.allclose(np.asarray(out), np.asarray([3.0]))
+
+    grad_fn = jax.grad(
+        lambda beta: compiled.eval_fn(0.0, y0, beta=beta)[0],
+    )
+    assert np.isclose(float(grad_fn(1.5)), 2.0)

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -384,6 +384,33 @@ def test_compile_spec_owns_default_backend_policy() -> None:
     assert np.allclose(out, np.array([6.0], dtype=np.float64))
 
 
+def test_compile_spec_rejects_conflicting_backend_and_xp() -> None:
+    """compile_spec rejects passing backend='jax' with explicit xp."""
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "state": ["x"],
+        "equations": {"x": "x"},
+    }
+    with pytest.raises(ValueError, match=r"Pass either xp or backend='jax'"):
+        compile_spec(spec, xp=np, backend="jax")
+
+
+def test_compile_spec_with_backend_jax_is_jittable() -> None:
+    """compile_spec supports backend='jax' as a public UX path."""
+    jax = pytest.importorskip("jax")
+
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "state": ["x"],
+        "equations": {"x": "beta * x"},
+    }
+    compiled = compile_spec(spec, backend="jax")
+
+    y0 = np.array([2.0], dtype=np.float64)
+    out = jax.jit(lambda beta: compiled.eval_fn(0.0, y0, beta=beta))(1.5)
+    assert np.allclose(np.asarray(out), np.asarray([3.0]))
+
+
 def test_compile_rhs_requires_explicit_backend_namespace() -> None:
     """compile_rhs requires explicit xp so default policy is centralized."""
     spec: dict[str, object] = {


### PR DESCRIPTION
Closes #74

## Summary

Adds a backend-aware compile path so `compile_rhs` (and `compile_spec`) can return RHS callables that are fully traceable by JAX — no forced NumPy concretization.

## Changes

### Core (`op_system`)
- `compile_rhs(..., xp=np)` / `compile_spec(..., xp=None)` — new optional `xp` parameter; defaults to `numpy` (no behaviour change for existing callers)
- `_is_numpy_backend(xp)` guard routes array ops through `xp.sum(xp.stack(...))` / `xp.asarray()` for JAX compatibility
- `_BackendNamespace` / `_Indexable` internal protocols replace `Any` in all public callable signatures
- `eval_fn` skips forced `float64` cast in JAX mode (avoids `x64` config requirement)

### Adapter (`flepimop2-op_system`)
- New `backend: Literal["numpy", "jax"]` field on the stepper model
- `_get_backend_namespace()` lazy-imports `jax.numpy` via `importlib` (optional dep, no import-time cost)
- Stepper coerces arrays via NumPy on numpy path; passes through on JAX path

### Tests
- `test_compile_rhs_with_jax_backend_is_jittable` — verifies `jax.jit` wrapping round-trips
- `test_compile_rhs_with_diffrax_solve` — ODE solve through diffrax `ODETerm`
- `test_compile_rhs_traces_through_blackjax_nuts` — NUTS gradient tracing smoke test
- `test_jax_backend_stepper_jittable` (adapter) — stepper survives `jax.jit`
- All new tests use `pytest.importorskip` and are skipped when JAX/diffrax/blackjax are absent

### Packaging
- `jax` and `jax-inference` optional dependency groups added to `pyproject.toml`
- README updated with install instructions and usage examples