### PR TITLE
feat: enhanced operators schema validation

### DIFF
--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -199,7 +199,7 @@ def multi_operator_spec() -> dict[str, object]:
         "equations": {"u[loc,age]": "-u[loc,age]"},
         "operators": [
             {"kind": "diffusion", "axis": "loc"},
-            {"kind": "advection", "axis": "age"},
+            {"kind": "advection", "axis": "age", "velocity": "v_age"},
         ],
     }
 

--- a/src/op_system/specs.py
+++ b/src/op_system/specs.py
@@ -867,10 +867,210 @@ def _normalize_kernels(
     return out
 
 
+def _validate_op_apply_to(
+    apply_to_raw: object,
+    idx: int,
+    state_set: set[str] | None,
+) -> list[str]:
+    if not isinstance(apply_to_raw, (list, tuple)) or not apply_to_raw:
+        _raise_invalid_rhs_spec(
+            detail=(
+                f"operators[{idx}].apply_to must be a non-empty list "
+                "of state names if provided"
+            )
+        )
+    result: list[str] = []
+    for j, state_name in enumerate(apply_to_raw):
+        if not isinstance(state_name, str) or not state_name.strip():
+            _raise_invalid_rhs_spec(
+                detail=f"operators[{idx}].apply_to[{j}] must be a non-empty string"
+            )
+        state_name_s = state_name.strip()
+        if state_set is not None and state_name_s not in state_set:
+            _raise_invalid_rhs_spec(
+                detail=(f"operators[{idx}].apply_to[{j}]={state_name_s!r} not in state")
+            )
+        result.append(state_name_s)
+    return result
+
+
+def _validate_scalar_or_expr(value: object, field: str) -> None:
+    """Raise if *value* is not a non-empty string or a finite number."""
+    if isinstance(value, str):
+        if not value.strip():
+            _raise_invalid_rhs_spec(
+                detail=f"{field} must be a non-empty string or number"
+            )
+    elif isinstance(value, bool) or not isinstance(value, (int, float)):
+        _raise_invalid_rhs_spec(detail=f"{field} must be a non-empty string or number")
+
+
+def _validate_op_advection(op_map: Mapping[str, Any], idx: int, kind_s: str) -> None:
+    velocity_val = op_map.get("velocity")
+    if velocity_val is None:
+        _raise_invalid_rhs_spec(
+            detail=f"operators[{idx}].velocity is required for {kind_s!r}"
+        )
+    _validate_scalar_or_expr(velocity_val, f"operators[{idx}].velocity")
+
+
+def _validate_op_jump_integral(op_map: Mapping[str, Any], idx: int) -> None:
+    rate_val = op_map.get("rate")
+    if rate_val is None:
+        _raise_invalid_rhs_spec(
+            detail=f"operators[{idx}].rate is required for 'jump_integral'"
+        )
+    _validate_scalar_or_expr(rate_val, f"operators[{idx}].rate")
+
+    kernel_val = op_map.get("kernel")
+    if not isinstance(kernel_val, dict):
+        _raise_invalid_rhs_spec(
+            detail=f"operators[{idx}].kernel must be a mapping for 'jump_integral'"
+        )
+    kernel_form = kernel_val.get("form")
+    if not isinstance(kernel_form, str) or not kernel_form.strip():
+        _raise_invalid_rhs_spec(
+            detail=(
+                f"operators[{idx}].kernel.form must be a non-empty "
+                "string for 'jump_integral'"
+            )
+        )
+    kernel_params = kernel_val.get("params")
+    if kernel_params is not None and not isinstance(kernel_params, dict):
+        _raise_invalid_rhs_spec(
+            detail=(
+                f"operators[{idx}].kernel.params must be a mapping if "
+                "provided for 'jump_integral'"
+            )
+        )
+
+    direction_val = op_map.get("direction")
+    if direction_val is not None:
+        if not isinstance(direction_val, str) or not direction_val.strip():
+            _raise_invalid_rhs_spec(
+                detail=(
+                    f"operators[{idx}].direction must be one of 'up', 'down', or 'both'"
+                )
+            )
+        if direction_val.strip().lower() not in {"up", "down", "both"}:
+            _raise_invalid_rhs_spec(
+                detail=(
+                    f"operators[{idx}].direction must be one of 'up', 'down', or 'both'"
+                )
+            )
+
+
+def _validate_op_header(
+    op_map: Mapping[str, Any],
+    idx: int,
+    axis_names: set[str],
+) -> tuple[str | None, str, str, str | None]:
+    """Validate and strip the simple header fields of one operator entry.
+
+    Returns:
+        Tuple of (op_name_s, axis_name_s, kind_s, bc_val_s).
+    """
+    op_name = op_map.get("name")
+    if op_name is not None and (not isinstance(op_name, str) or not op_name.strip()):
+        _raise_invalid_rhs_spec(
+            detail=f"operators[{idx}].name must be a non-empty string if provided"
+        )
+
+    axis_name = op_map.get("axis")
+    if not isinstance(axis_name, str) or not axis_name.strip():
+        _raise_invalid_rhs_spec(
+            detail=f"operators[{idx}].axis must be a non-empty string"
+        )
+    axis_name_s = axis_name.strip()
+    if axis_name_s not in axis_names:
+        _raise_invalid_rhs_spec(
+            detail=f"operators[{idx}] references unknown axis {axis_name_s!r}"
+        )
+
+    kind_val = op_map.get("kind")
+    if not isinstance(kind_val, str) or not kind_val.strip():
+        _raise_invalid_rhs_spec(
+            detail=(
+                f"operators[{idx}].kind must be a non-empty string "
+                "(e.g., advection/jump_integral)"
+            )
+        )
+    kind_s = kind_val.strip().lower()
+
+    bc_val = op_map.get("bc")
+    if bc_val is not None and (not isinstance(bc_val, str) or not bc_val.strip()):
+        _raise_invalid_rhs_spec(
+            detail=f"operators[{idx}].bc must be a non-empty string if provided"
+        )
+
+    op_name_s: str | None = op_name.strip() if isinstance(op_name, str) else None
+    bc_val_s: str | None = bc_val.strip() if isinstance(bc_val, str) else None
+    return op_name_s, axis_name_s, kind_s, bc_val_s
+
+
+def _enrich_op_kind_fields(op_out: dict[str, Any], kind_s: str) -> None:
+    """Normalize kind-specific fields in *op_out* in-place."""
+    if kind_s in {"advection", "transport"}:
+        velocity_val = op_out["velocity"]
+        op_out["velocity"] = (
+            velocity_val.strip()
+            if isinstance(velocity_val, str)
+            else float(velocity_val)
+        )
+    elif kind_s == "jump_integral":
+        rate_val = op_out["rate"]
+        op_out["rate"] = (
+            rate_val.strip() if isinstance(rate_val, str) else float(rate_val)
+        )
+        kernel_val = dict(op_out["kernel"])
+        kernel_val["form"] = str(kernel_val["form"]).strip()
+        op_out["kernel"] = kernel_val
+        if "direction" in op_out and isinstance(op_out["direction"], str):
+            op_out["direction"] = op_out["direction"].strip().lower()
+
+
+def _normalize_single_operator(
+    op: object,
+    idx: int,
+    *,
+    axis_names: set[str],
+    state_set: set[str] | None,
+) -> dict[str, Any]:
+    op_map = _ensure_mapping(op, name=f"operators[{idx}]")
+    op_name_s, axis_name_s, kind_s, bc_val_s = _validate_op_header(
+        op_map, idx, axis_names
+    )
+
+    apply_to_raw = op_map.get("apply_to")
+    apply_to_clean: list[str] | None = (
+        _validate_op_apply_to(apply_to_raw, idx, state_set)
+        if apply_to_raw is not None
+        else None
+    )
+
+    if kind_s in {"advection", "transport"}:
+        _validate_op_advection(op_map, idx, kind_s)
+    elif kind_s == "jump_integral":
+        _validate_op_jump_integral(op_map, idx)
+
+    op_out = dict(op_map)
+    if op_name_s is not None:
+        op_out["name"] = op_name_s
+    op_out["axis"] = axis_name_s
+    op_out["kind"] = kind_s
+    if bc_val_s is not None:
+        op_out["bc"] = bc_val_s
+    if apply_to_clean is not None:
+        op_out["apply_to"] = apply_to_clean
+    _enrich_op_kind_fields(op_out, kind_s)
+    return op_out
+
+
 def _normalize_operators(
     raw_ops: object,
     *,
     axis_names: set[str],
+    state_set: set[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Normalize operator metadata and validate axis references.
 
@@ -881,39 +1081,11 @@ def _normalize_operators(
         return []
     if not isinstance(raw_ops, list):
         _raise_invalid_rhs_spec(detail="operators must be a list")
-    out: list[dict[str, Any]] = []
-    for idx, op in enumerate(raw_ops):
-        op_map = _ensure_mapping(op, name=f"operators[{idx}]")
-        axis_name = op_map.get("axis")
-        if not isinstance(axis_name, str) or not axis_name.strip():
-            _raise_invalid_rhs_spec(
-                detail=f"operators[{idx}].axis must be a non-empty string"
-            )
-        axis_name_s = axis_name.strip()
-        if axis_name_s not in axis_names:
-            _raise_invalid_rhs_spec(
-                detail=f"operators[{idx}] references unknown axis {axis_name_s!r}"
-            )
-        kind_val = op_map.get("kind")
-        if not isinstance(kind_val, str) or not kind_val.strip():
-            _raise_invalid_rhs_spec(
-                detail=(
-                    f"operators[{idx}].kind must be a non-empty string "
-                    "(e.g., diffusion/advection)"
-                )
-            )
-        bc_val = op_map.get("bc")
-        if bc_val is not None and (not isinstance(bc_val, str) or not bc_val.strip()):
-            _raise_invalid_rhs_spec(
-                detail=f"operators[{idx}].bc must be a non-empty string if provided"
-            )
-        op_out = dict(op_map)
-        op_out["axis"] = axis_name_s
-        op_out["kind"] = kind_val.strip()
-        if bc_val is not None:
-            op_out["bc"] = bc_val.strip()
-        out.append(op_out)
-    return out
+
+    return [
+        _normalize_single_operator(op, idx, axis_names=axis_names, state_set=state_set)
+        for idx, op in enumerate(raw_ops)
+    ]
 
 
 def _get_meta_field(spec: Mapping[str, Any], key: str) -> object:
@@ -928,6 +1100,7 @@ def _normalize_common_meta(
     *,
     axis_names: set[str],
     state_set: set[str] | None,
+    operator_state_set: set[str] | None = None,
 ) -> tuple[
     dict[str, str],
     dict[str, tuple[str, ...]],
@@ -948,7 +1121,11 @@ def _normalize_common_meta(
     )
     operators_raw = spec.get("operators") or _get_meta_field(spec, "operators")
     operators_meta = (
-        _normalize_operators(operators_raw, axis_names=axis_names)
+        _normalize_operators(
+            operators_raw,
+            axis_names=axis_names,
+            state_set=operator_state_set,
+        )
         if isinstance(operators_raw, list)
         else operators_raw
     )
@@ -2034,6 +2211,7 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:
         spec,
         axis_names={"subgroup"} | {ax["name"] for ax in axes_meta},
         state_set=set(state_raw),
+        operator_state_set=set(state_raw),
     )
 
     meta: dict[str, Any] = {
@@ -2221,7 +2399,10 @@ def normalize_transitions_rhs(
     axes_meta = _normalize_axes(spec.get("axes"))
 
     meta_parts = _normalize_common_meta(
-        spec, axis_names={"subgroup"} | {ax["name"] for ax in axes_meta}, state_set=None
+        spec,
+        axis_names={"subgroup"} | {ax["name"] for ax in axes_meta},
+        state_set=None,
+        operator_state_set=set(state_raw),
     )
 
     meta: dict[str, Any] = {

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -397,7 +397,13 @@ def test_operator_requires_kind_and_preserves_bc() -> None:
             },
         ],
         "operators": [
-            {"name": "op0", "axis": "x", "kind": "advection", "bc": "periodic"},
+            {
+                "name": "op0",
+                "axis": "x",
+                "kind": "advection",
+                "bc": "periodic",
+                "velocity": "v",
+            },
         ],
         "state": ["u"],
         "equations": {"u": "0.0"},
@@ -408,6 +414,94 @@ def test_operator_requires_kind_and_preserves_bc() -> None:
     assert isinstance(operators_meta, list)
     assert operators_meta[0]["kind"] == "advection"
     assert operators_meta[0]["bc"] == "periodic"
+
+
+def test_operator_apply_to_validation() -> None:
+    """Operator apply_to should be validated against known top-level states."""
+    spec_bad_apply_to = {
+        "kind": "expr",
+        "axes": [{"name": "x", "coords": ["a"]}],
+        "state": ["S", "I"],
+        "operators": [
+            {
+                "name": "adv",
+                "axis": "x",
+                "kind": "advection",
+                "velocity": "v",
+                "apply_to": ["X"],
+            }
+        ],
+        "equations": {
+            "S": "0.0",
+            "I": "0.0",
+        },
+    }
+    with pytest.raises(ValueError, match=r"apply_to\[0\]='X' not in state"):
+        normalize_expr_rhs(spec_bad_apply_to)
+
+
+def test_operator_advection_requires_velocity() -> None:
+    """Advection/transport operators must include a velocity field."""
+    spec_missing_velocity = {
+        "kind": "expr",
+        "axes": [{"name": "x", "coords": ["a"]}],
+        "state": ["S"],
+        "operators": [
+            {
+                "name": "adv",
+                "axis": "x",
+                "kind": "advection",
+                "apply_to": ["S"],
+            }
+        ],
+        "equations": {"S": "0.0"},
+    }
+    with pytest.raises(ValueError, match=r"velocity is required"):
+        normalize_expr_rhs(spec_missing_velocity)
+
+
+def test_operator_jump_integral_requires_kernel_and_normalizes_direction() -> None:
+    """jump_integral operators require kernel/rate and normalize direction."""
+    spec_bad_jump = {
+        "kind": "expr",
+        "axes": [{"name": "x", "coords": ["a"]}],
+        "state": ["S"],
+        "operators": [
+            {
+                "name": "jump",
+                "axis": "x",
+                "kind": "jump_integral",
+                "rate": "nu",
+                "apply_to": ["S"],
+            }
+        ],
+        "equations": {"S": "0.0"},
+    }
+    with pytest.raises(ValueError, match=r"kernel must be a mapping"):
+        normalize_expr_rhs(spec_bad_jump)
+
+    spec_ok_jump = {
+        "kind": "expr",
+        "axes": [{"name": "x", "coords": ["a"]}],
+        "state": ["S"],
+        "operators": [
+            {
+                "name": "jump",
+                "axis": "x",
+                "kind": "jump_integral",
+                "rate": "nu",
+                "kernel": {"form": "gaussian", "params": {"sigma": 0.1}},
+                "direction": "UP",
+                "apply_to": ["S"],
+            }
+        ],
+        "equations": {"S": "0.0"},
+    }
+    out = normalize_expr_rhs(spec_ok_jump)
+    ops = out.meta.get("operators")
+    assert isinstance(ops, list)
+    assert ops[0]["kind"] == "jump_integral"
+    assert ops[0]["direction"] == "up"
 
 
 def test_state_axes_validation_errors() -> None:


### PR DESCRIPTION
## Summary

Adds thorough schema validation for the `operators` block in RHS specs, covering all currently-supported kinds (`advection`/`transport` and `jump_integral`) and the new `apply_to` list.

## Changes

### `src/op_system/specs.py`

The monolithic `_normalize_operators` function has been broken into focused helpers to stay within ruff complexity limits (C901/PLR0912/PLR0915/PLR0914):

| Helper | Responsibility |
|---|---|
| `_validate_op_header` | Validates and strips `name`, `axis`, `kind`, `bc`; returns 4-tuple |
| `_validate_op_apply_to` | Validates each entry in `apply_to` against the expanded state set |
| `_validate_scalar_or_expr` | Shared non-empty string-or-number check |
| `_validate_op_advection` | Requires `velocity` for `advection`/`transport` |
| `_validate_op_jump_integral` | Requires `rate` + `kernel` (with `form`); validates `direction` values |
| `_enrich_op_kind_fields` | Normalizes kind-specific output fields in-place |
| `_normalize_single_operator` | Thin orchestrator calling the above |
| `_normalize_operators` | Unchanged public API; now a one-liner list comprehension |

New semantic validations:
- `apply_to` entries are checked against the fully-expanded state set (passed in via `operator_state_set` kwarg on `_normalize_common_meta`)
- `velocity` is required for `kind: advection` / `kind: transport`
- `rate` and `kernel` (mapping with non-empty `form`) are required for `kind: jump_integral`
- `direction` must be one of `'up'`, `'down'`, `'both'` when present

### `tests/op_system/test_op_system_specs.py`

- Updated `advection` boundary-condition test to include required `velocity` field
- Added tests for `apply_to` validation, `advection` velocity requirement, and `jump_integral` rate/kernel requirements

### `flepimop2-op_system/tests/test_system.py`

- Added `"velocity": "v_age"` to the `advection` operator in the `multi_operator_spec` fixture (was missing the now-required field)

## Related

Closes #28 (operators pass-through design — this implements the agreed validation contract)
