### PR TITLE
Adapter: implement requested_parameters / model_state for new ParameterAPI

### DIFF
--- a/flepimop2-op_system/pyproject.toml
+++ b/flepimop2-op_system/pyproject.toml
@@ -54,6 +54,10 @@ include = ["src/flepimop2/system/op_system/py.typed"]
 # --- uv monorepo wiring: satisfy op-system from the sibling directory ---
 [tool.uv.sources]
 op-system = { path = ".." }
+# flepimop2 0.2.0 (PyPI) predates the ParameterAPI used by this adapter
+# (ModelStateSpecification, ParameterRequest, AxisCollection).  Until the
+# next flepimop2 release, pin to the development tip on main.
+flepimop2 = { git = "https://github.com/ACCIDDA/flepimop2", branch = "main" }
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -34,6 +34,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    Mapping,
     NamedTuple,
     SupportsFloat,
     SupportsIndex,
@@ -41,7 +42,9 @@ from typing import (
 )
 
 import numpy as np
+from flepimop2.axis import AxisCollection
 from flepimop2.configuration import ModuleModel
+from flepimop2.parameter.abc import ModelStateSpecification, ParameterRequest
 from flepimop2.system.abc import SystemABC
 from flepimop2.typing import (
     IdentifierString,
@@ -148,8 +151,99 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
     def _bind_impl(
         self, params: dict[IdentifierString, Any] | None = None
     ) -> SystemProtocol:
-        """Return a stepper with any static parameters partially applied."""
-        return functools.partial(self._stepper, **(params or {}))
+        """Return a stepper with any static parameters partially applied.
+
+        The returned callable additionally exposes ``option(name, default=...)``
+        so that engine plugins (notably the diffrax wrapper engine) can read
+        compiled metadata — ``state_names``, ``initial_state`` map, axis
+        order/coords/sizes, declared operators, etc. — from the bound
+        stepper.  This bridges the WrapperEngine contract (which only forwards
+        the bound callable, not the System object) with op_system's need to
+        publish per-spec layout information to its consumers.
+        """
+        bound = functools.partial(self._stepper, **(params or {}))
+        bound.option = self.option  # type: ignore[attr-defined]
+        return cast("SystemProtocol", bound)
+
+    @override
+    def requested_parameters(
+        self,
+        axes: AxisCollection,  # noqa: ARG002
+    ) -> dict[IdentifierString, ParameterRequest]:
+        """Declare the scalar parameters consumed by the compiled RHS.
+
+        Returns:
+            Mapping of parameter name to a scalar `ParameterRequest`.
+
+        Notes:
+            op_system rewrites axis-indexed selectors like ``theta[imm]`` into
+            per-coord scalar names (``theta__imm_X0`` ...) at compile time, so
+            every entry in `compiled.param_names` is requested as a scalar.
+            Initial-state seed names (referenced from `meta['initial_state']`
+            but not necessarily from any rate expression) are also requested
+            so engine plugins can assemble the state vector from `params`.
+            Mixing-kernel names are computed internally and excluded.
+        """
+        requests: dict[IdentifierString, ParameterRequest] = {}
+        mixing_kernel_names = set((self.options or {}).get("mixing_kernels", {}).keys())
+        # Names provided by the compiled-RHS runtime environment, not by config
+        # (numpy/jax namespace, simulation time, and built-in summation helpers).
+        builtin_names = {"np", "t", "sum_state", "sum_prefix"}
+        for name in self._compiled_rhs.param_names:
+            if name in mixing_kernel_names or name in builtin_names or name in requests:
+                continue
+            requests[name] = ParameterRequest(name=name)
+        init_map = (self.options or {}).get("initial_state") or {}
+        for param_name in init_map.values():
+            if param_name in requests:
+                continue
+            requests[param_name] = ParameterRequest(name=param_name)
+        # Operator velocity/rate fields are consumed by engine plugins (not by
+        # the compiled rhs eval_fn), but still need to be in the params dict.
+        for op in self._compiled_rhs.meta.get("operators") or ():
+            for field in ("velocity", "rate"):
+                value = op.get(field) if isinstance(op, Mapping) else None
+                if isinstance(value, str) and value.isidentifier():
+                    if value in requests or value == "t":
+                        continue
+                    requests[value] = ParameterRequest(name=value)
+            kernel = op.get("kernel") if isinstance(op, Mapping) else None
+            if isinstance(kernel, Mapping):
+                kernel_params = kernel.get("params")
+                if isinstance(kernel_params, Mapping):
+                    for value in kernel_params.values():
+                        if (
+                            isinstance(value, str)
+                            and value.isidentifier()
+                            and value not in requests
+                        ):
+                            requests[value] = ParameterRequest(name=value)
+        return requests
+
+    @override
+    def model_state(  # noqa: PLR6301
+        self,
+        axes: AxisCollection,  # noqa: ARG002
+    ) -> ModelStateSpecification | None:
+        """Declare an empty model-state specification.
+
+        Returns:
+            An empty `ModelStateSpecification`.
+
+        Notes:
+            op_system's compartment vector is not assembled by flepimop2 from
+            `ModelStateSpecification.parameter_names` because seed parameters
+            are reused across many state cells (e.g. one ``zero_init`` for
+            every empty compartment), which `ModelStateSpecification` forbids
+            (`parameter_names must be unique`).  Engine plugins instead
+            consume ``system.options['initial_state']`` (a
+            ``state_name -> param_name`` map) together with the resolved
+            ``params`` dict to build the state vector themselves.  Returning
+            an empty specification here just keeps the simulator's resolve
+            path satisfied without claiming an assembly contract op_system
+            does not own.
+        """
+        return ModelStateSpecification(parameter_names=())
 
     @staticmethod
     def _extract_axes_meta(compiled: CompiledRhs) -> _AxesMeta:

--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -29,12 +29,12 @@ from __future__ import annotations
 import functools
 import importlib
 import sys
+from collections.abc import Mapping
 from types import MappingProxyType
 from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
-    Mapping,
     NamedTuple,
     SupportsFloat,
     SupportsIndex,
@@ -42,7 +42,6 @@ from typing import (
 )
 
 import numpy as np
-from flepimop2.axis import AxisCollection
 from flepimop2.configuration import ModuleModel
 from flepimop2.parameter.abc import ModelStateSpecification, ParameterRequest
 from flepimop2.system.abc import SystemABC
@@ -65,6 +64,7 @@ __version__ = "0.1.0"
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from flepimop2.axis import AxisCollection
     from flepimop2.typing import Float64NDArray
 
 
@@ -168,7 +168,7 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
     @override
     def requested_parameters(
         self,
-        axes: AxisCollection,  # noqa: ARG002
+        axes: AxisCollection,
     ) -> dict[IdentifierString, ParameterRequest]:
         """Declare the scalar parameters consumed by the compiled RHS.
 
@@ -201,29 +201,44 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
         # Operator velocity/rate fields are consumed by engine plugins (not by
         # the compiled rhs eval_fn), but still need to be in the params dict.
         for op in self._compiled_rhs.meta.get("operators") or ():
-            for field in ("velocity", "rate"):
-                value = op.get(field) if isinstance(op, Mapping) else None
-                if isinstance(value, str) and value.isidentifier():
-                    if value in requests or value == "t":
-                        continue
-                    requests[value] = ParameterRequest(name=value)
-            kernel = op.get("kernel") if isinstance(op, Mapping) else None
-            if isinstance(kernel, Mapping):
-                kernel_params = kernel.get("params")
-                if isinstance(kernel_params, Mapping):
-                    for value in kernel_params.values():
-                        if (
-                            isinstance(value, str)
-                            and value.isidentifier()
-                            and value not in requests
-                        ):
-                            requests[value] = ParameterRequest(name=value)
+            self._collect_operator_param_requests(op, requests)
         return requests
 
+    @staticmethod
+    def _collect_operator_param_requests(
+        op: object,
+        requests: dict[IdentifierString, ParameterRequest],
+    ) -> None:
+        """Add velocity/rate/kernel-param names referenced by `op` to `requests`."""
+        if not isinstance(op, Mapping):
+            return
+        for field in ("velocity", "rate"):
+            value = op.get(field)
+            if (
+                isinstance(value, str)
+                and value.isidentifier()
+                and value != "t"
+                and value not in requests
+            ):
+                requests[value] = ParameterRequest(name=value)
+        kernel = op.get("kernel")
+        if not isinstance(kernel, Mapping):
+            return
+        kernel_params = kernel.get("params")
+        if not isinstance(kernel_params, Mapping):
+            return
+        for value in kernel_params.values():
+            if (
+                isinstance(value, str)
+                and value.isidentifier()
+                and value not in requests
+            ):
+                requests[value] = ParameterRequest(name=value)
+
     @override
-    def model_state(  # noqa: PLR6301
+    def model_state(
         self,
-        axes: AxisCollection,  # noqa: ARG002
+        axes: AxisCollection,
     ) -> ModelStateSpecification | None:
         """Declare an empty model-state specification.
 

--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -20,6 +20,8 @@ from types import MappingProxyType
 
 import numpy as np
 import pytest
+from flepimop2.axis import AxisCollection
+from flepimop2.parameter.abc import ModelStateSpecification, ParameterRequest
 from flepimop2.typing import SystemProtocol
 
 from flepimop2.system.op_system import OpSystemSystem
@@ -465,9 +467,6 @@ def test_requested_parameters_returns_compiled_param_names(
     sir_spec: dict[str, object],
 ) -> None:
     """Every name in compiled.param_names becomes a scalar ParameterRequest."""
-    from flepimop2.axis import AxisCollection
-    from flepimop2.parameter.abc import ParameterRequest
-
     sys = OpSystemSystem(spec=sir_spec)
     requests = sys.requested_parameters(AxisCollection())
     assert set(requests.keys()) == {"beta", "gamma"}
@@ -478,8 +477,6 @@ def test_requested_parameters_returns_compiled_param_names(
 
 def test_requested_parameters_includes_initial_state_seeds() -> None:
     """Seed parameter names appear in requested_parameters even if absent from rates."""
-    from flepimop2.axis import AxisCollection
-
     spec: dict[str, object] = {
         "kind": "transitions",
         "axes": [{"name": "vax", "coords": ["u", "v"]}],
@@ -497,8 +494,6 @@ def test_requested_parameters_includes_initial_state_seeds() -> None:
 
 def test_requested_parameters_excludes_mixing_kernels() -> None:
     """Mixing-kernel names are computed internally, not requested from configuration."""
-    from flepimop2.axis import AxisCollection
-
     spec: dict[str, object] = {
         "kind": "expr",
         "axes": [{"name": "loc", "coords": ["0", "1"]}],
@@ -519,9 +514,6 @@ def test_requested_parameters_excludes_mixing_kernels() -> None:
 
 def test_model_state_is_empty_specification(sir_spec: dict[str, object]) -> None:
     """model_state returns an empty ModelStateSpecification (engine assembles state)."""
-    from flepimop2.axis import AxisCollection
-    from flepimop2.parameter.abc import ModelStateSpecification
-
     sys = OpSystemSystem(spec=sir_spec)
     spec = sys.model_state(AxisCollection())
     assert isinstance(spec, ModelStateSpecification)
@@ -530,8 +522,6 @@ def test_model_state_is_empty_specification(sir_spec: dict[str, object]) -> None
 
 def test_requested_parameters_includes_operator_velocity() -> None:
     """Operator velocity/rate parameter symbols are surfaced for engine plugins."""
-    from flepimop2.axis import AxisCollection
-
     spec: dict[str, object] = {
         "kind": "transitions",
         "axes": [{"name": "k", "coords": ["0", "1", "2"]}],

--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -459,3 +459,95 @@ def test_option_initial_state_templated() -> None:
         "S__vax_v": "S0__vax_v",
         "D": "D0",
     }
+
+
+def test_requested_parameters_returns_compiled_param_names(
+    sir_spec: dict[str, object],
+) -> None:
+    """Every name in compiled.param_names becomes a scalar ParameterRequest."""
+    from flepimop2.axis import AxisCollection
+    from flepimop2.parameter.abc import ParameterRequest
+
+    sys = OpSystemSystem(spec=sir_spec)
+    requests = sys.requested_parameters(AxisCollection())
+    assert set(requests.keys()) == {"beta", "gamma"}
+    assert all(isinstance(r, ParameterRequest) for r in requests.values())
+    assert all(r.axes == () for r in requests.values())
+    assert all(not r.broadcast for r in requests.values())
+
+
+def test_requested_parameters_includes_initial_state_seeds() -> None:
+    """Seed parameter names appear in requested_parameters even if absent from rates."""
+    from flepimop2.axis import AxisCollection
+
+    spec: dict[str, object] = {
+        "kind": "transitions",
+        "axes": [{"name": "vax", "coords": ["u", "v"]}],
+        "state": ["S[vax]", "D"],
+        "transitions": [
+            {"from": "S[vax]", "to": "D", "rate": "mu"},
+        ],
+        "initial_state": {"S[vax]": "S0[vax]", "D": "D0"},
+    }
+    sys = OpSystemSystem(spec=spec)
+    names = set(sys.requested_parameters(AxisCollection()).keys())
+    # Rate-expression params + per-coord-expanded seed names + scalar D0
+    assert {"mu", "S0__vax_u", "S0__vax_v", "D0"} <= names
+
+
+def test_requested_parameters_excludes_mixing_kernels() -> None:
+    """Mixing-kernel names are computed internally, not requested from configuration."""
+    from flepimop2.axis import AxisCollection
+
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": ["0", "1"]}],
+        "kernels": [
+            {
+                "name": "contact",
+                "form": "gaussian",
+                "params": {"scale": 1.0, "sigma": 0.5},
+            },
+        ],
+        "state": ["S[loc]"],
+        "equations": {"S[loc]": "-S[loc]"},
+    }
+    sys = OpSystemSystem(spec=spec)
+    requested = set(sys.requested_parameters(AxisCollection()).keys())
+    assert "contact" not in requested
+
+
+def test_model_state_is_empty_specification(sir_spec: dict[str, object]) -> None:
+    """model_state returns an empty ModelStateSpecification (engine assembles state)."""
+    from flepimop2.axis import AxisCollection
+    from flepimop2.parameter.abc import ModelStateSpecification
+
+    sys = OpSystemSystem(spec=sir_spec)
+    spec = sys.model_state(AxisCollection())
+    assert isinstance(spec, ModelStateSpecification)
+    assert spec.parameter_names == ()
+
+
+def test_requested_parameters_includes_operator_velocity() -> None:
+    """Operator velocity/rate parameter symbols are surfaced for engine plugins."""
+    from flepimop2.axis import AxisCollection
+
+    spec: dict[str, object] = {
+        "kind": "transitions",
+        "axes": [{"name": "k", "coords": ["0", "1", "2"]}],
+        "state": ["X[k]"],
+        "transitions": [
+            {"from": "X[k]", "to": "X[k]", "rate": "0.0"},
+        ],
+        "operators": [
+            {
+                "kind": "advection",
+                "axis": "k",
+                "bc": "absorbing",
+                "velocity": "waning_rate",
+            },
+        ],
+    }
+    sys = OpSystemSystem(spec=spec)
+    requested = set(sys.requested_parameters(AxisCollection()).keys())
+    assert "waning_rate" in requested

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -474,7 +474,7 @@ def test_compile_rhs_with_jax_backend_diffrax_smoke() -> None:
             y0=jnp.asarray([1.0]),
             args={"beta": beta},
             saveat=diffrax.SaveAt(t1=True),
-        ).ys[0]
+        ).ys[0, 0]
 
     out = jax.jit(solve)(0.5)
     expected = np.exp(-0.5)


### PR DESCRIPTION
Wires the op_system `SystemABC` adapter to the new structured-parameter
contract introduced upstream (`ParameterRequest` / `ModelStateSpecification`).

## Changes

* **`requested_parameters(axes)`** declares every name in
  `compiled.param_names` as a scalar `ParameterRequest`. op_system rewrites
  axis-indexed selectors (e.g. `theta[imm]`, `nu[age]`) into per-coord scalar
  names (`theta__imm_x0`, ...) at compile time, so all requests are scalar.
  Also surfaces:
  * initial-state seed parameter names from `options['initial_state']`
    (engine plugins consume them to assemble the state vector),
  * operator `velocity` / `rate` symbols and `kernel.params` values
    (consumed by engine plugins, not by the compiled rhs).

  Excludes mixing-kernel names (computed internally) and runtime builtins
  (`np`, `t`, `sum_state`, `sum_prefix`).

* **`model_state(axes)`** returns an empty `ModelStateSpecification`. The
  compartment vector is not assembled by flepimop2 from `parameter_names`
  because seed parameters are reused across many state cells (e.g. one
  `zero_init` for every empty compartment), which `ModelStateSpecification`
  forbids (parameter_names must be unique). Engine plugins instead consume
  `system.options['initial_state']` together with the resolved `params`
  dict to build the state vector themselves.

* **`_bind_impl`** attaches `.option` to the bound `functools.partial` so
  engine plugins (notably `WrapperEngine`, which only forwards the bound
  callable, not the System) can read compiled metadata from the stepper.

## Tests

Adds 5 tests covering each contract:
* `test_requested_parameters_returns_compiled_param_names`
* `test_requested_parameters_includes_initial_state_seeds`
* `test_requested_parameters_excludes_mixing_kernels`
* `test_model_state_is_empty_specification`
* `test_requested_parameters_includes_operator_velocity`

Full suite: 39/39 passing.

## Validation

End-to-end smoke against flepimop2 main with the diffrax wrapper engine on:
* `SIRHD_vax_inference` ✅
* SMH R19 (5-loc subset, 680 states) ✅

This unblocks any flepimop2 simulator path that resolves system parameters
through the new `requested_parameters` / `model_state` hooks.