### PR TITLE
Feature/issue 90 vectorized compile

### DIFF
--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -69,6 +69,42 @@ _ALLOWED_KERNEL_FORMS: dict[str, tuple[str, ...]] = {
 
 
 @dataclass(frozen=True, slots=True)
+class StateTemplate:
+    """Structural record for a state template prior to scalar expansion.
+
+    A spec like ``state: ["S[age, vax]"]`` over axes ``age`` (size 4) and
+    ``vax`` (size 2) produces a single `StateTemplate` with `base="S"`,
+    `axes=("age", "vax")`, `shape=(4, 2)`, and `expanded_names` listing the
+    eight scalar state names in cartesian-product order (`age` outer,
+    `vax` inner — matching `itertools.product` and the order used to expand
+    the flat state vector).
+
+    Non-templated entries (e.g. a bare ``"D"`` in `state`) are also reported
+    as `StateTemplate` records with ``axes=()``, ``shape=()``, and a single
+    `expanded_names = ("D",)` so consumers can iterate templates uniformly.
+
+    Attributes:
+        base: Compartment name without selector brackets (e.g. ``"S"``).
+        axes: Wildcard axes in declaration order. Empty for scalar templates.
+        shape: Per-axis sizes in `axes` order. Empty for scalar templates.
+        expanded_names: Flat scalar state names, in cartesian-product order
+            over `axes` (consistent with `state_names`).
+        coord_assignments: For each entry in `expanded_names`, the
+            ``axis -> coord`` mapping. Empty dict for scalar templates.
+        offset: Index of `expanded_names[0]` within the parent
+            `NormalizedRhs.state_names` tuple (i.e. where this template's
+            slice starts in the flat state vector).
+    """
+
+    base: str
+    axes: tuple[str, ...]
+    shape: tuple[int, ...]
+    expanded_names: tuple[str, ...]
+    coord_assignments: tuple[Mapping[str, str], ...]
+    offset: int
+
+
+@dataclass(frozen=True, slots=True)
 class NormalizedRhs:
     """Normalized RHS representation suitable for compilation/execution."""
 
@@ -79,6 +115,7 @@ class NormalizedRhs:
     param_names: tuple[str, ...]
     all_symbols: frozenset[str]
     meta: Mapping[str, Any]
+    state_templates: tuple[StateTemplate, ...] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -694,6 +731,84 @@ def _collect_alias_symbols(
         tree = _parse_expr(expr_s)
         symbols |= _collect_names(tree)
     return symbols
+
+
+def _build_state_templates(
+    state_raw: list[str],
+    *,
+    axes: list[dict[str, Any]],
+    state_template_map: Mapping[str, list[tuple[str, dict[str, str]]]],
+    state_expanded: list[str],
+) -> tuple[StateTemplate, ...]:
+    """Build per-template structural records aligned with `state_expanded`.
+
+    Walks the user-declared `state_raw` in order. For each entry, looks up
+    the template in `state_template_map` (if present) or treats it as a
+    scalar. Records the offset of each template's first expanded name in
+    the flat `state_expanded` list so consumers can recover contiguous
+    per-template slices of the state vector.
+
+    Returns:
+        Tuple of `StateTemplate`, one per entry in `state_raw`, in order.
+
+    Notes:
+        Pinned-only templates (e.g. `S[vax=u]`) are reported as scalar
+        templates because they expand to exactly one cell each. Only
+        wildcard templates carry shape information used by vectorized
+        evaluation.
+    """
+    axis_size = {ax["name"]: len(ax.get("coords", ())) for ax in axes}
+    name_to_idx = {n: i for i, n in enumerate(state_expanded)}
+    templates: list[StateTemplate] = []
+    for entry in state_raw:
+        base, tokens = parse_selector(entry)
+        wildcards = [t for t in tokens if isinstance(t, WildcardToken)]
+        pinned = [t for t in tokens if isinstance(t, PinnedToken)]
+        if wildcards:
+            # Canonical key matches what `_expand_state_templates` builds.
+            template_key = f"{base}[{','.join(wt.axis for wt in wildcards)}]"
+            results = state_template_map.get(template_key, [])
+            ax_names = tuple(wt.axis for wt in wildcards)
+            shape = tuple(axis_size[a] for a in ax_names)
+            expanded_names = tuple(name for name, _ in results)
+            coords = tuple(dict(coord_map) for _, coord_map in results)
+            offset = name_to_idx[expanded_names[0]] if expanded_names else 0
+            templates.append(
+                StateTemplate(
+                    base=base,
+                    axes=ax_names,
+                    shape=shape,
+                    expanded_names=expanded_names,
+                    coord_assignments=coords,
+                    offset=offset,
+                )
+            )
+        elif pinned:
+            template_key = f"{base}[{','.join(f'{t.axis}={t.coord}' for t in pinned)}]"
+            results = state_template_map.get(template_key, [])
+            for scalar_name, coord_map in results:
+                templates.append(
+                    StateTemplate(
+                        base=base,
+                        axes=(),
+                        shape=(),
+                        expanded_names=(scalar_name,),
+                        coord_assignments=(dict(coord_map),),
+                        offset=name_to_idx[scalar_name],
+                    )
+                )
+        else:
+            templates.append(
+                StateTemplate(
+                    base=base,
+                    axes=(),
+                    shape=(),
+                    expanded_names=(base,),
+                    coord_assignments=({},),
+                    offset=name_to_idx[base],
+                )
+            )
+    return tuple(templates)
 
 
 def _expand_state_templates(
@@ -1873,11 +1988,13 @@ def _apply_transition_chains(
 
         if entry_cfg is not None:
             entry_from, entry_rate = entry_cfg
-            transitions_raw.append({
-                "from": entry_from,
-                "to": stage_names[0],
-                "rate": entry_rate,
-            })
+            transitions_raw.append(
+                {
+                    "from": entry_from,
+                    "to": stage_names[0],
+                    "rate": entry_rate,
+                }
+            )
 
         transitions_raw.extend(
             {
@@ -1890,11 +2007,13 @@ def _apply_transition_chains(
 
         if exit_cfg is not None:
             sink_s, sink_rate = exit_cfg
-            transitions_raw.append({
-                "from": stage_names[-1],
-                "to": sink_s,
-                "rate": sink_rate or forward_rates[-1],
-            })
+            transitions_raw.append(
+                {
+                    "from": stage_names[-1],
+                    "to": sink_s,
+                    "rate": sink_rate or forward_rates[-1],
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -2211,6 +2330,12 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:
         ),
         all_symbols=frozenset(all_syms | set(aliases.keys())),
         meta=meta,
+        state_templates=_build_state_templates(
+            state_raw,
+            axes=axes_meta,
+            state_template_map=state_template_map,
+            state_expanded=state_expanded,
+        ),
     )
 
 
@@ -2311,9 +2436,9 @@ def normalize_transitions_rhs(
         "kernels": meta_parts[2],
         "operators": meta_parts[3],
     }
-    meta.update({
-        k: spec[k] for k in ("sources", "couplings", "constraints") if k in spec
-    })
+    meta.update(
+        {k: spec[k] for k in ("sources", "couplings", "constraints") if k in spec}
+    )
 
     chain_block = spec.get("chain")
     if chain_block:
@@ -2387,4 +2512,10 @@ def normalize_transitions_rhs(
         ),
         all_symbols=frozenset(all_syms | set(aliases.keys())),
         meta={**meta, "transitions": transitions_expanded},
+        state_templates=_build_state_templates(
+            state_raw,
+            axes=axes_meta,
+            state_template_map=state_template_map,
+            state_expanded=state_expanded,
+        ),
     )

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -1988,13 +1988,11 @@ def _apply_transition_chains(
 
         if entry_cfg is not None:
             entry_from, entry_rate = entry_cfg
-            transitions_raw.append(
-                {
-                    "from": entry_from,
-                    "to": stage_names[0],
-                    "rate": entry_rate,
-                }
-            )
+            transitions_raw.append({
+                "from": entry_from,
+                "to": stage_names[0],
+                "rate": entry_rate,
+            })
 
         transitions_raw.extend(
             {
@@ -2007,13 +2005,11 @@ def _apply_transition_chains(
 
         if exit_cfg is not None:
             sink_s, sink_rate = exit_cfg
-            transitions_raw.append(
-                {
-                    "from": stage_names[-1],
-                    "to": sink_s,
-                    "rate": sink_rate or forward_rates[-1],
-                }
-            )
+            transitions_raw.append({
+                "from": stage_names[-1],
+                "to": sink_s,
+                "rate": sink_rate or forward_rates[-1],
+            })
 
 
 # ---------------------------------------------------------------------------
@@ -2436,9 +2432,9 @@ def normalize_transitions_rhs(
         "kernels": meta_parts[2],
         "operators": meta_parts[3],
     }
-    meta.update(
-        {k: spec[k] for k in ("sources", "couplings", "constraints") if k in spec}
-    )
+    meta.update({
+        k: spec[k] for k in ("sources", "couplings", "constraints") if k in spec
+    })
 
     chain_block = spec.get("chain")
     if chain_block:

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -1,0 +1,978 @@
+"""op_system._vectorize.
+
+Vectorized compile path for templated RHS specifications.
+
+Strategy: emit one shaped tensor expression per state template, operating on
+buffers reshaped from contiguous slices of the flat state vector. For numpy
+this slashes interpreter overhead; for JAX it slashes JIT compile time
+massively because the emitted graph is O(#templates) instead of O(#cells).
+
+Falls back to the scalar compile path if the spec doesn't fit the supported
+subset (mixed scalar/templated states, alias names that can't be parsed,
+expressions whose first cell isn't structurally identical to the last cell,
+etc.).
+
+Supported subset (v1):
+- All states are pure-template wildcard entries (e.g. ``S[age, vax]``).
+- Aliases are either scalar or pure-template wildcard entries whose expanded
+  names parse cleanly as ``base__axis_coord__...``.
+- Equation/alias expressions reference only: scalar params, ``t``, ``np``,
+  templated states, templated aliases, and Python arithmetic operators.
+
+Anything outside that subset triggers fallback.
+"""
+
+from __future__ import annotations
+
+import ast
+import math
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+import numpy as np
+
+from op_system.compile import (
+    _SAFE_BUILTINS,
+    _is_numpy_backend,
+    _parse_expr,
+    _validate_ast,
+)
+
+if TYPE_CHECKING:
+    from types import CodeType
+
+    from numpy.typing import NDArray
+
+    from op_system.compile import EvalFn, Float64Array
+    from op_system.specs import NormalizedRhs
+
+    Float64Array = NDArray[np.float64]
+else:
+    Float64Array = Any
+
+
+# ---------------------------------------------------------------------------
+# Internal data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _BufferTemplate:
+    """Records a templated buffer (state or alias) for the rewriter."""
+
+    base: str
+    axes: tuple[str, ...]
+    shape: tuple[int, ...]
+    expanded_names: tuple[str, ...]
+    coord_assignments: tuple[Mapping[str, str], ...]
+    offset: int  # only meaningful for state templates; 0 otherwise
+
+
+@dataclass(frozen=True, slots=True)
+class _ScalarBinding:
+    """Records a scalar (non-templated) symbol exposed to the env."""
+
+    name: str  # symbol seen by expressions
+    source: str  # state name / alias name / param name
+    kind: str  # "state" | "alias" | "param"
+
+
+@dataclass(frozen=True, slots=True)
+class _EqGroup:
+    """Plan for a single state template's equations.
+
+    Each code yields an array of shape ``vec_shape`` (in ``vec_axes`` order).
+    There are ``prod(unroll_shape)`` codes, one per Cartesian combination of
+    ``unroll_axes`` coords. At eval time the per-code outputs are stacked into
+    shape ``unroll_shape + vec_shape`` then transposed via ``assembly_perm``
+    so the trailing flatten matches the template's natural cell order.
+    """
+
+    base: str
+    codes: tuple["CodeType", ...]
+    vec_axes: tuple[str, ...]
+    vec_shape: tuple[int, ...]
+    unroll_axes: tuple[str, ...]
+    unroll_shape: tuple[int, ...]
+    assembly_perm: tuple[int, ...]
+    full_shape: tuple[int, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _VectorPlan:
+    """Compiled plan for vectorized evaluation of one RHS spec."""
+
+    state_templates: tuple[_BufferTemplate, ...]
+    alias_templates: tuple[_BufferTemplate, ...]
+    param_templates: tuple[_BufferTemplate, ...]
+    alias_codes: tuple[tuple[str, "CodeType", tuple[int, ...]], ...]
+    eq_groups: tuple[_EqGroup, ...]
+    n_state: int
+
+
+# ---------------------------------------------------------------------------
+# Name parsing / template inference
+# ---------------------------------------------------------------------------
+
+
+def _parse_expanded_name(
+    name: str, axes: list[tuple[str, list[str]]]
+) -> tuple[str, dict[str, str]]:
+    """Parse an expanded name like ``base__age_y__vax_u`` -> (base, coords).
+
+    Returns ``(name, {})`` if the name does not match the expected pattern.
+    """
+    parts = name.split("__")
+    if len(parts) < 2:
+        return name, {}
+    base = parts[0]
+    coords: dict[str, str] = {}
+    for piece in parts[1:]:
+        matched = False
+        for ax_name, ax_coords in axes:
+            prefix = ax_name + "_"
+            if piece.startswith(prefix):
+                coord_val = piece[len(prefix) :]
+                if coord_val in ax_coords:
+                    if ax_name in coords:
+                        return name, {}
+                    coords[ax_name] = coord_val
+                    matched = True
+                    break
+        if not matched:
+            return name, {}
+    return base, coords
+
+
+def _infer_templates_from_names(
+    names: "Iterable[str]", axes: list[tuple[str, list[str]]]
+) -> dict[str, _BufferTemplate] | None:
+    """Group names by inferred template base. Returns None if any group is
+    inconsistent (mismatched axes, missing cartesian-product members, etc.).
+
+    A name with no parseable axis suffixes becomes a scalar template
+    (axes=(), shape=()).
+    """
+    by_base: dict[str, list[tuple[str, dict[str, str]]]] = {}
+    for name in names:
+        base, coords = _parse_expanded_name(name, axes)
+        by_base.setdefault(base, []).append((name, coords))
+
+    axis_size = {ax: len(coord_list) for ax, coord_list in axes}
+    axis_index = {
+        ax: {c: i for i, c in enumerate(coord_list)} for ax, coord_list in axes
+    }
+
+    templates: dict[str, _BufferTemplate] = {}
+    for base, members in by_base.items():
+        if len(members) == 1 and not members[0][1]:
+            templates[base] = _BufferTemplate(
+                base=base,
+                axes=(),
+                shape=(),
+                expanded_names=(members[0][0],),
+                coord_assignments=({},),
+                offset=0,
+            )
+            continue
+        first_axes = tuple(members[0][1].keys())
+        if not first_axes:
+            return None
+        for _, c in members:
+            if tuple(c.keys()) != first_axes:
+                return None
+        shape = tuple(axis_size[a] for a in first_axes)
+        if len(members) != math.prod(shape):
+            return None
+        members.sort(
+            key=lambda item: tuple(axis_index[a][item[1][a]] for a in first_axes)
+        )
+        templates[base] = _BufferTemplate(
+            base=base,
+            axes=first_axes,
+            shape=shape,
+            expanded_names=tuple(n for n, _ in members),
+            coord_assignments=tuple(c for _, c in members),
+            offset=0,
+        )
+    return templates
+
+
+def _infer_alias_templates(
+    aliases: "Mapping[str, str]", axes: list[tuple[str, list[str]]]
+) -> tuple[dict[str, _BufferTemplate], dict[str, str]] | None:
+    """Group aliases by inferred template base.
+
+    Returns ``(templates_by_base, name_to_base)`` or ``None`` on failure.
+    """
+    templates = _infer_templates_from_names(aliases.keys(), axes)
+    if templates is None:
+        return None
+    name_to_base = {n: t.base for t in templates.values() for n in t.expanded_names}
+    return templates, name_to_base
+
+
+# ---------------------------------------------------------------------------
+# AST rewriter
+# ---------------------------------------------------------------------------
+
+
+def _build_access_ast(
+    *,
+    src_base: str,
+    src_axes: tuple[str, ...],
+    src_coords: Mapping[str, str],
+    src_axis_index: Mapping[str, Mapping[str, int]],
+    target_axes: tuple[str, ...],
+    cell_coords: Mapping[str, str],
+) -> ast.expr:
+    """Build an AST node accessing a templated buffer for one cell of a target.
+
+    Returns an expression with shape broadcastable to ``target_axes``' shape.
+    Returns the bare buffer name when src and target axes match exactly.
+    """
+    buf_name = ast.Name(id=f"{src_base}_buf", ctx=ast.Load())
+    if not src_axes:
+        return buf_name
+
+    # Step 1: index the src buffer. Tied axes (axis in target_axes and same
+    # coord as cell_coords[axis]) become slice(None); fixed axes become an
+    # integer index.
+    index_parts: list[ast.expr] = []
+    tied_axis_order: list[str] = []  # in src axes order
+    for ax in src_axes:
+        coord_val = src_coords[ax]
+        if ax in target_axes and cell_coords.get(ax) == coord_val:
+            index_parts.append(ast.Slice(lower=None, upper=None, step=None))
+            tied_axis_order.append(ax)
+        else:
+            idx = src_axis_index[ax][coord_val]
+            index_parts.append(ast.Constant(value=idx))
+
+    if len(index_parts) == 1:
+        slice_node = index_parts[0]
+    else:
+        slice_node = ast.Tuple(elts=index_parts, ctx=ast.Load())
+    accessed: ast.expr = ast.Subscript(value=buf_name, slice=slice_node, ctx=ast.Load())
+
+    if not tied_axis_order:
+        # Pure scalar after indexing.
+        return accessed
+
+    # Step 2: align tied axes to target_axes order, inserting size-1 dims for
+    # target axes not in src.
+    if tuple(tied_axis_order) == target_axes:
+        return accessed
+
+    # Build a tuple subscript with slice(None) for kept axes and None for
+    # broadcast axes, plus a transpose if needed.
+    if set(tied_axis_order) == set(target_axes):
+        # Pure transpose to target order.
+        perm = tuple(tied_axis_order.index(a) for a in target_axes)
+        return ast.Call(
+            func=ast.Attribute(
+                value=ast.Name(id="np", ctx=ast.Load()),
+                attr="transpose",
+                ctx=ast.Load(),
+            ),
+            args=[
+                accessed,
+                ast.Tuple(elts=[ast.Constant(value=p) for p in perm], ctx=ast.Load()),
+            ],
+            keywords=[],
+        )
+
+    # tied is a strict subset of target; transpose then add None axes.
+    if not set(tied_axis_order).issubset(set(target_axes)):
+        # src has axes target doesn't; should have been fully fixed above.
+        msg = "internal: untied axis not in target"
+        raise RuntimeError(msg)
+
+    # Transpose tied axes into the order they appear within target_axes.
+    target_kept_order = tuple(a for a in target_axes if a in tied_axis_order)
+    if tuple(tied_axis_order) != target_kept_order:
+        perm = tuple(tied_axis_order.index(a) for a in target_kept_order)
+        accessed = ast.Call(
+            func=ast.Attribute(
+                value=ast.Name(id="np", ctx=ast.Load()),
+                attr="transpose",
+                ctx=ast.Load(),
+            ),
+            args=[
+                accessed,
+                ast.Tuple(elts=[ast.Constant(value=p) for p in perm], ctx=ast.Load()),
+            ],
+            keywords=[],
+        )
+
+    # Now insert size-1 axes via subscript with None placeholders.
+    elts: list[ast.expr] = []
+    for ax in target_axes:
+        if ax in tied_axis_order:
+            elts.append(ast.Slice(lower=None, upper=None, step=None))
+        else:
+            elts.append(ast.Constant(value=None))
+    return ast.Subscript(
+        value=accessed,
+        slice=ast.Tuple(elts=elts, ctx=ast.Load()),
+        ctx=ast.Load(),
+    )
+
+
+class _NameRewriter(ast.NodeTransformer):
+    """Rewrites Name nodes in a per-cell expression into shaped buffer access.
+
+    Unrecognized names are left as-is (treated as scalar params / specials).
+    """
+
+    def __init__(
+        self,
+        *,
+        target_axes: tuple[str, ...],
+        cell_coords: Mapping[str, str],
+        name_to_template: Mapping[str, _BufferTemplate],
+        name_to_coords: Mapping[str, Mapping[str, str]],
+        axis_index: Mapping[str, Mapping[str, int]],
+    ) -> None:
+        self._target_axes = target_axes
+        self._cell_coords = cell_coords
+        self._name_to_template = name_to_template
+        self._name_to_coords = name_to_coords
+        self._axis_index = axis_index
+
+    def visit_Name(self, node: ast.Name) -> ast.AST:  # noqa: N802
+        tpl = self._name_to_template.get(node.id)
+        if tpl is None:
+            return node
+        if not tpl.axes:
+            return ast.Name(id=f"{tpl.base}_buf", ctx=ast.Load())
+        return _build_access_ast(
+            src_base=tpl.base,
+            src_axes=tpl.axes,
+            src_coords=self._name_to_coords[node.id],
+            src_axis_index=self._axis_index,
+            target_axes=self._target_axes,
+            cell_coords=self._cell_coords,
+        )
+
+
+def _rewrite_cell_to_vector(
+    *,
+    expr: str,
+    target_axes: tuple[str, ...],
+    cell_coords: Mapping[str, str],
+    name_to_template: Mapping[str, _BufferTemplate],
+    name_to_coords: Mapping[str, Mapping[str, str]],
+    axis_index: Mapping[str, Mapping[str, int]],
+) -> ast.Expression:
+    tree = _parse_expr(expr)
+    _validate_ast(tree, expr=expr)
+    rewriter = _NameRewriter(
+        target_axes=target_axes,
+        cell_coords=cell_coords,
+        name_to_template=name_to_template,
+        name_to_coords=name_to_coords,
+        axis_index=axis_index,
+    )
+    new_tree = cast("ast.Expression", rewriter.visit(tree))
+    ast.fix_missing_locations(new_tree)
+    return new_tree
+
+
+# ---------------------------------------------------------------------------
+# Sum-pattern recognizer
+# ---------------------------------------------------------------------------
+
+
+def _flatten_addsub(node: ast.expr) -> list[tuple[int, ast.expr]]:
+    """Flatten an Add/Sub tree into (sign, leaf-expr) terms (iterative)."""
+    terms: list[tuple[int, ast.expr]] = []
+    stack: list[tuple[ast.expr, int]] = [(node, 1)]
+    while stack:
+        n, sign = stack.pop()
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Add):
+            stack.append((n.right, sign))
+            stack.append((n.left, sign))
+        elif isinstance(n, ast.BinOp) and isinstance(n.op, ast.Sub):
+            stack.append((n.right, -sign))
+            stack.append((n.left, sign))
+        elif isinstance(n, ast.UnaryOp) and isinstance(n.op, ast.USub):
+            stack.append((n.operand, -sign))
+        elif isinstance(n, ast.UnaryOp) and isinstance(n.op, ast.UAdd):
+            stack.append((n.operand, sign))
+        else:
+            terms.append((sign, n))
+    return terms
+
+
+def _classify_buf_subscript(
+    node: ast.expr,
+) -> tuple[str, tuple[int, ...]] | None:
+    """If ``node`` is ``<name>_buf[<int_tuple>]``, return (name, indices)."""
+    if not isinstance(node, ast.Subscript):
+        return None
+    if not isinstance(node.value, ast.Name):
+        return None
+    name = node.value.id
+    if not name.endswith("_buf"):
+        return None
+    slc = node.slice
+    if isinstance(slc, ast.Constant) and isinstance(slc.value, int):
+        return name, (slc.value,)
+    if isinstance(slc, ast.Tuple):
+        idxs: list[int] = []
+        for elt in slc.elts:
+            if isinstance(elt, ast.Constant) and isinstance(elt.value, int):
+                idxs.append(elt.value)
+            else:
+                return None
+        return name, tuple(idxs)
+    return None
+
+
+def _make_sum_call(buf_name: str) -> ast.expr:
+    return ast.Call(
+        func=ast.Attribute(
+            value=ast.Name(id="np", ctx=ast.Load()),
+            attr="sum",
+            ctx=ast.Load(),
+        ),
+        args=[ast.Name(id=buf_name, ctx=ast.Load())],
+        keywords=[],
+    )
+
+
+def _reassemble_addsub(terms: list[tuple[int, ast.expr]]) -> ast.expr:
+    if not terms:
+        return ast.Constant(value=0.0)
+    sign, expr = terms[0]
+    out: ast.expr = expr if sign > 0 else ast.UnaryOp(op=ast.USub(), operand=expr)
+    for s, e in terms[1:]:
+        op: ast.operator = ast.Add() if s > 0 else ast.Sub()
+        out = ast.BinOp(left=out, op=op, right=e)
+    return out
+
+
+def _collapse_full_buffer_sums(
+    tree: ast.Expression, buf_shapes: Mapping[str, tuple[int, ...]]
+) -> ast.Expression:
+    """Replace sums-over-all-cells of a buffer with ``np.sum(buf)``.
+
+    Operates iteratively to avoid blowing Python's recursion limit on the
+    very long Add chains produced by aggregator aliases (e.g. an alias that
+    sums every cell of a templated state). Within each Add/Sub chain found in
+    the tree, pure ``<name>_buf[<int_tuple>]`` terms are grouped by
+    ``(name, sign)``; if the set of indices for a group exhausts the full
+    Cartesian product of the buffer's shape, those terms are collapsed into a
+    single ``np.sum(buf)`` call. Other terms in the chain are left untouched.
+    """
+
+    def collapse_chain(node: ast.expr) -> ast.expr:
+        terms = _flatten_addsub(node)
+        groups: dict[tuple[str, int], list[tuple[int, ...]]] = {}
+        other: list[tuple[int, ast.expr]] = []
+        order: list[tuple[str, int]] = []
+        for sign, leaf in terms:
+            cls = _classify_buf_subscript(leaf)
+            if cls is None or cls[0] not in buf_shapes:
+                other.append((sign, leaf))
+                continue
+            key = (cls[0], sign)
+            if key not in groups:
+                groups[key] = []
+                order.append(key)
+            groups[key].append(cls[1])
+        collapsed: list[tuple[int, ast.expr]] = list(other)
+        changed = False
+        for key in order:
+            name, sign = key
+            idxs = groups[key]
+            shape = buf_shapes[name]
+            expected = math.prod(shape) if shape else 1
+            if (
+                len(idxs) == expected
+                and len(set(idxs)) == expected
+                and all(
+                    len(t) == len(shape)
+                    and all(0 <= ti < si for ti, si in zip(t, shape))
+                    for t in idxs
+                )
+            ):
+                collapsed.append((sign, _make_sum_call(name)))
+                changed = True
+            else:
+                for t in idxs:
+                    slice_node: ast.expr
+                    if len(t) == 1:
+                        slice_node = ast.Constant(value=t[0])
+                    else:
+                        slice_node = ast.Tuple(
+                            elts=[ast.Constant(value=v) for v in t],
+                            ctx=ast.Load(),
+                        )
+                    collapsed.append(
+                        (
+                            sign,
+                            ast.Subscript(
+                                value=ast.Name(id=name, ctx=ast.Load()),
+                                slice=slice_node,
+                                ctx=ast.Load(),
+                            ),
+                        )
+                    )
+        if not changed:
+            return node
+        return _reassemble_addsub(collapsed)
+
+    def is_addsub(n: ast.AST) -> bool:
+        return isinstance(n, ast.BinOp) and isinstance(n.op, (ast.Add, ast.Sub))
+
+    # Collapse the root expression, then iteratively descend into the
+    # collapsed body's non-Add/Sub children to find embedded chains. We
+    # carefully avoid recursing into the original (uncollapsed) Add chain.
+    body = tree.body
+    if is_addsub(body):
+        body = collapse_chain(body)
+    new_tree = ast.Expression(body=body)
+
+    stack: list[ast.AST] = [body]
+    while stack:
+        node = stack.pop()
+        for fld, val in ast.iter_fields(node):
+            if isinstance(val, list):
+                for i, child in enumerate(val):
+                    if not isinstance(child, ast.AST):
+                        continue
+                    if is_addsub(child):
+                        new_child = collapse_chain(child)
+                        val[i] = new_child
+                        stack.append(new_child)
+                    else:
+                        stack.append(child)
+            elif isinstance(val, ast.AST):
+                if is_addsub(val):
+                    new_child = collapse_chain(val)
+                    setattr(node, fld, new_child)
+                    stack.append(new_child)
+                else:
+                    stack.append(val)
+
+    ast.fix_missing_locations(new_tree)
+    return new_tree
+
+
+def _vectorize_template_equations(
+    *,
+    template: _BufferTemplate,
+    equations: tuple[str, ...],
+    name_to_template: Mapping[str, _BufferTemplate],
+    name_to_coords: Mapping[str, Mapping[str, str]],
+    axis_index: Mapping[str, Mapping[str, int]],
+) -> (
+    tuple[
+        tuple["CodeType", ...],
+        tuple[str, ...],  # vec_axes
+        tuple[int, ...],  # vec_shape
+        tuple[str, ...],  # unroll_axes
+        tuple[int, ...],  # unroll_shape
+        tuple[int, ...],  # assembly_perm
+    ]
+    | None
+):
+    """Build shaped code object(s) for a state template's equations.
+
+    Tries vectorized axis subsets in increasing complexity:
+    1. All axes vectorized (no unrolling).
+    2. Each single axis unrolled, all others vectorized — handles boundary
+       conditions on one axis (e.g. the X compartment's ``imm`` axis).
+    3. Pairs of axes unrolled (rare).
+    Within each candidate subset, the first and last cell of every unroll
+    bin must produce structurally identical AST after rewriting.
+    """
+    size = math.prod(template.shape) if template.shape else 1
+    cell_exprs = equations[template.offset : template.offset + size]
+    if len(cell_exprs) != size or size == 0:
+        return None
+    n_axes = len(template.axes)
+
+    # Enumerate candidate unroll-axis index subsets, smallest first.
+    from itertools import combinations as _comb
+
+    candidates: list[tuple[int, ...]] = []
+    for k in range(n_axes + 1):
+        for combo in _comb(range(n_axes), k):
+            candidates.append(combo)
+
+    # Strides for converting (axis-coord-index tuple) → flat cell index in
+    # ``coord_assignments`` (template.axes order, last varies fastest).
+    strides: list[int] = [0] * n_axes
+    s = 1
+    for i in range(n_axes - 1, -1, -1):
+        strides[i] = s
+        s *= template.shape[i]
+
+    for unroll_idx in candidates:
+        unroll_set = set(unroll_idx)
+        vec_idx = tuple(i for i in range(n_axes) if i not in unroll_set)
+        unroll_axes = tuple(template.axes[i] for i in unroll_idx)
+        vec_axes = tuple(template.axes[i] for i in vec_idx)
+        unroll_shape = tuple(template.shape[i] for i in unroll_idx)
+        vec_shape = tuple(template.shape[i] for i in vec_idx)
+        unroll_size = math.prod(unroll_shape) if unroll_shape else 1
+        vec_size = math.prod(vec_shape) if vec_shape else 1
+
+        # Iterate unroll bins in row-major over unroll_axes.
+        codes: list[CodeType] = []
+        ok = True
+        for u in range(unroll_size):
+            # Decode u into per-unroll-axis coord indices.
+            u_coord_idx: list[int] = []
+            rem = u
+            for j in range(len(unroll_axes) - 1, -1, -1):
+                u_coord_idx.insert(0, rem % unroll_shape[j])
+                rem //= unroll_shape[j]
+            # Compute the "base" flat index contribution from unroll axes.
+            base_flat = 0
+            for k_pos, ax_pos in enumerate(unroll_idx):
+                base_flat += u_coord_idx[k_pos] * strides[ax_pos]
+
+            # First and last cells of the bin = vec_axes coord indices all
+            # zero / all (size-1).
+            def _bin_flat(vec_coord_idx: list[int]) -> int:
+                f = base_flat
+                for k_pos, ax_pos in enumerate(vec_idx):
+                    f += vec_coord_idx[k_pos] * strides[ax_pos]
+                return f
+
+            first_idx = _bin_flat([0] * len(vec_idx))
+            last_idx = _bin_flat([vec_shape[k] - 1 for k in range(len(vec_idx))])
+
+            try:
+                first_tree = _rewrite_cell_to_vector(
+                    expr=cell_exprs[first_idx],
+                    target_axes=vec_axes,
+                    cell_coords=template.coord_assignments[first_idx],
+                    name_to_template=name_to_template,
+                    name_to_coords=name_to_coords,
+                    axis_index=axis_index,
+                )
+            except (ValueError, RuntimeError):
+                ok = False
+                break
+            if vec_size > 1:
+                try:
+                    last_tree = _rewrite_cell_to_vector(
+                        expr=cell_exprs[last_idx],
+                        target_axes=vec_axes,
+                        cell_coords=template.coord_assignments[last_idx],
+                        name_to_template=name_to_template,
+                        name_to_coords=name_to_coords,
+                        axis_index=axis_index,
+                    )
+                except (ValueError, RuntimeError):
+                    ok = False
+                    break
+                if ast.dump(first_tree) != ast.dump(last_tree):
+                    ok = False
+                    break
+            try:
+                codes.append(
+                    compile(first_tree, filename="<op_system_vec>", mode="eval")
+                )
+            except (ValueError, TypeError, SyntaxError):
+                ok = False
+                break
+        if not ok:
+            continue
+
+        # Build assembly_perm: source axis order is unroll_axes + vec_axes,
+        # target is template.axes. perm[i] = position-in-source of template.axes[i].
+        source_order = list(unroll_axes) + list(vec_axes)
+        source_pos = {a: i for i, a in enumerate(source_order)}
+        assembly_perm = tuple(source_pos[a] for a in template.axes)
+        return (
+            tuple(codes),
+            vec_axes,
+            vec_shape,
+            unroll_axes,
+            unroll_shape,
+            assembly_perm,
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Plan construction
+# ---------------------------------------------------------------------------
+
+
+def build_vector_plan(rhs: NormalizedRhs) -> _VectorPlan | None:
+    """Try to build a vectorized plan for ``rhs``. Returns None on fallback."""
+    if not rhs.state_templates:
+        return None
+    # Require all states to be wildcard templates (have axes).
+    if any(not tpl.shape for tpl in rhs.state_templates):
+        return None
+    # Require axes meta to be present.
+    axes_meta = rhs.meta.get("axes") if isinstance(rhs.meta, Mapping) else None
+    if not axes_meta:
+        return None
+
+    axes_pairs: list[tuple[str, list[str]]] = []
+    for ax in axes_meta:
+        if not isinstance(ax, Mapping):
+            return None
+        coords = ax.get("coords")
+        if not coords:
+            return None
+        axes_pairs.append((ax["name"], list(coords)))
+    axis_index = {ax: {c: i for i, c in enumerate(coords)} for ax, coords in axes_pairs}
+
+    state_buffers: list[_BufferTemplate] = []
+    name_to_template: dict[str, _BufferTemplate] = {}
+    name_to_coords: dict[str, Mapping[str, str]] = {}
+    for tpl in rhs.state_templates:
+        buf = _BufferTemplate(
+            base=tpl.base,
+            axes=tpl.axes,
+            shape=tpl.shape,
+            expanded_names=tpl.expanded_names,
+            coord_assignments=tpl.coord_assignments,
+            offset=tpl.offset,
+        )
+        state_buffers.append(buf)
+        for nm, coord_map in zip(tpl.expanded_names, tpl.coord_assignments):
+            name_to_template[nm] = buf
+            name_to_coords[nm] = coord_map
+
+    alias_inference = _infer_alias_templates(rhs.aliases, axes_pairs)
+    if alias_inference is None:
+        return None
+    alias_buffers_by_base, _ = alias_inference
+    alias_buffers = list(alias_buffers_by_base.values())
+    for buf in alias_buffers:
+        for nm, coord_map in zip(buf.expanded_names, buf.coord_assignments):
+            name_to_template[nm] = buf
+            name_to_coords[nm] = coord_map
+
+    # Param templates: same name-parsing approach as aliases. These are
+    # gathered from caller-supplied scalar params at eval time into shaped
+    # buffers exposed under ``<base>_buf``.
+    param_templates_by_base = _infer_templates_from_names(rhs.param_names, axes_pairs)
+    if param_templates_by_base is None:
+        return None
+    param_buffers = list(param_templates_by_base.values())
+    for buf in param_buffers:
+        # Skip scalars — they remain available under their original name.
+        if not buf.axes:
+            continue
+        for nm, coord_map in zip(buf.expanded_names, buf.coord_assignments):
+            name_to_template[nm] = buf
+            name_to_coords[nm] = coord_map
+
+    # Buffer-name → shape table, used by the sum-pattern collapser to
+    # recognize sums-over-all-cells of a buffer and rewrite them as
+    # ``np.sum(buf)``.
+    buf_shapes: dict[str, tuple[int, ...]] = {}
+    for buf in (*state_buffers, *alias_buffers, *param_buffers):
+        if buf.axes:
+            buf_shapes[f"{buf.base}_buf"] = buf.shape
+
+    # Vectorize aliases (in declaration order — best-effort dependency order).
+    alias_codes: list[tuple[str, CodeType, tuple[int, ...]]] = []
+    for buf in alias_buffers:
+        try:
+            if buf.axes:
+                tree = _rewrite_cell_to_vector(
+                    expr=rhs.aliases[buf.expanded_names[0]],
+                    target_axes=buf.axes,
+                    cell_coords=buf.coord_assignments[0],
+                    name_to_template=name_to_template,
+                    name_to_coords=name_to_coords,
+                    axis_index=axis_index,
+                )
+                if len(buf.expanded_names) > 1:
+                    last_tree = _rewrite_cell_to_vector(
+                        expr=rhs.aliases[buf.expanded_names[-1]],
+                        target_axes=buf.axes,
+                        cell_coords=buf.coord_assignments[-1],
+                        name_to_template=name_to_template,
+                        name_to_coords=name_to_coords,
+                        axis_index=axis_index,
+                    )
+                    if ast.dump(tree) != ast.dump(last_tree):
+                        return None
+            else:
+                # Scalar alias: rewrite through the same engine so referenced
+                # templated state cells become buffer-index accesses.
+                tree = _rewrite_cell_to_vector(
+                    expr=rhs.aliases[buf.expanded_names[0]],
+                    target_axes=(),
+                    cell_coords={},
+                    name_to_template=name_to_template,
+                    name_to_coords=name_to_coords,
+                    axis_index=axis_index,
+                )
+            tree = _collapse_full_buffer_sums(tree, buf_shapes)
+            code = compile(tree, filename="<op_system_vec>", mode="eval")
+        except (ValueError, RuntimeError, TypeError, SyntaxError):
+            return None
+        alias_codes.append((buf.base, code, buf.shape))
+
+    # Vectorize per-template equations.
+    eq_groups: list[_EqGroup] = []
+    for buf in state_buffers:
+        result = _vectorize_template_equations(
+            template=buf,
+            equations=rhs.equations,
+            name_to_template=name_to_template,
+            name_to_coords=name_to_coords,
+            axis_index=axis_index,
+        )
+        if result is None:
+            return None
+        codes, vec_axes, vec_shape, unroll_axes, unroll_shape, assembly_perm = result
+        eq_groups.append(
+            _EqGroup(
+                base=buf.base,
+                codes=codes,
+                vec_axes=vec_axes,
+                vec_shape=vec_shape,
+                unroll_axes=unroll_axes,
+                unroll_shape=unroll_shape,
+                assembly_perm=assembly_perm,
+                full_shape=buf.shape,
+            )
+        )
+
+    return _VectorPlan(
+        state_templates=tuple(state_buffers),
+        alias_templates=tuple(alias_buffers),
+        param_templates=tuple(param_buffers),
+        alias_codes=tuple(alias_codes),
+        eq_groups=tuple(eq_groups),
+        n_state=len(rhs.state_names),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Runtime eval function
+# ---------------------------------------------------------------------------
+
+
+def make_vectorized_eval_fn(plan: _VectorPlan, *, xp: object) -> EvalFn:
+    """Return an ``eval_fn(t, y, **params)`` driven by ``plan``."""
+    state_templates = plan.state_templates
+    alias_codes = plan.alias_codes
+    eq_groups = plan.eq_groups
+    n_state = plan.n_state
+    is_numpy = _is_numpy_backend(xp)
+
+    # Pre-compute param buffer assembly recipes: (base, expanded_names, shape)
+    # — at eval time we stack the corresponding param values.
+    param_recipes: list[tuple[str, tuple[str, ...], tuple[int, ...]]] = [
+        (buf.base, buf.expanded_names, buf.shape)
+        for buf in plan.param_templates
+        if buf.axes
+    ]
+
+    def eval_fn(t: object, y: object, **params: object) -> Float64Array:
+        if is_numpy:
+            y_in = np.asarray(y, dtype=np.float64)
+            t_val: object = np.float64(cast("Any", t))
+        else:
+            y_in = cast("Any", xp).asarray(y)
+            t_val = cast("Any", xp).asarray(t)
+        if y_in.shape != (n_state,):
+            msg = (
+                f"state has an invalid shape/value. expected (n_state={n_state},), "
+                f"got {y_in.shape}"
+            )
+            raise ValueError(msg)
+
+        env: dict[str, object] = {"np": xp, "t": t_val}
+        env.update(params)
+
+        # Assemble templated param buffers from caller-supplied scalars.
+        for base, names, shape in param_recipes:
+            try:
+                vals = [params[n] for n in names]
+            except KeyError as exc:
+                msg = f"missing param {exc!s} for templated buffer {base!r}"
+                raise ValueError(msg) from exc
+            if is_numpy:
+                env[f"{base}_buf"] = np.asarray(vals, dtype=np.float64).reshape(shape)
+            else:
+                xp_ns = cast("Any", xp)
+                env[f"{base}_buf"] = xp_ns.reshape(xp_ns.asarray(vals), shape)
+
+        # Build state buffers via reshape on contiguous slices.
+        for tpl in state_templates:
+            size = math.prod(tpl.shape)
+            slc = y_in[tpl.offset : tpl.offset + size]
+            env[f"{tpl.base}_buf"] = (
+                slc.reshape(tpl.shape)
+                if is_numpy
+                else cast("Any", xp).reshape(slc, tpl.shape)
+            )
+
+        # Eval alias buffers in declaration order.
+        for base, code, shape in alias_codes:
+            try:
+                val = eval(code, {"__builtins__": _SAFE_BUILTINS}, env)  # noqa: S307
+            except (NameError, ValueError, TypeError, ArithmeticError) as exc:
+                msg = f"alias {base!r} evaluation failed: {exc!r}"
+                raise ValueError(msg) from exc
+            if shape:
+                if is_numpy:
+                    val = np.broadcast_to(val, shape)
+                else:
+                    val = cast("Any", xp).broadcast_to(val, shape)
+            env[f"{base}_buf"] = val
+
+        # Eval per-template equation buffers and concatenate.
+        pieces: list[object] = []
+        for grp in eq_groups:
+            bin_results: list[object] = []
+            for code in grp.codes:
+                try:
+                    val = eval(code, {"__builtins__": _SAFE_BUILTINS}, env)  # noqa: S307
+                except (NameError, ValueError, TypeError, ArithmeticError) as exc:
+                    msg = f"equation {grp.base!r} evaluation failed: {exc!r}"
+                    raise ValueError(msg) from exc
+                if is_numpy:
+                    arr = np.broadcast_to(
+                        np.asarray(val, dtype=np.float64), grp.vec_shape
+                    )
+                else:
+                    xp_ns = cast("Any", xp)
+                    arr = xp_ns.broadcast_to(xp_ns.asarray(val), grp.vec_shape)
+                bin_results.append(arr)
+
+            if not grp.unroll_axes:
+                # Fully vectorized — single result already in template order.
+                whole = bin_results[0]
+            else:
+                if is_numpy:
+                    stacked = np.stack(cast("Any", bin_results), axis=0).reshape(
+                        grp.unroll_shape + grp.vec_shape
+                    )
+                    whole = np.transpose(stacked, grp.assembly_perm)
+                else:
+                    xp_ns = cast("Any", xp)
+                    stacked = xp_ns.reshape(
+                        xp_ns.stack(bin_results, axis=0),
+                        grp.unroll_shape + grp.vec_shape,
+                    )
+                    whole = xp_ns.transpose(stacked, grp.assembly_perm)
+            if is_numpy:
+                pieces.append(np.asarray(whole).reshape(-1))
+            else:
+                pieces.append(cast("Any", xp).reshape(whole, (-1,)))
+
+        if is_numpy:
+            return cast("Float64Array", np.concatenate(pieces))
+        return cast("Float64Array", cast("Any", xp).concatenate(pieces))
+
+    return eval_fn

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -28,6 +28,7 @@ import ast
 import math
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from itertools import combinations as _comb
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
@@ -42,12 +43,8 @@ from op_system.compile import (
 if TYPE_CHECKING:
     from types import CodeType
 
-    from numpy.typing import NDArray
-
     from op_system.compile import EvalFn, Float64Array
     from op_system.specs import NormalizedRhs
-
-    Float64Array = NDArray[np.float64]
 else:
     Float64Array = Any
 
@@ -90,7 +87,7 @@ class _EqGroup:
     """
 
     base: str
-    codes: tuple["CodeType", ...]
+    codes: tuple[CodeType, ...]
     vec_axes: tuple[str, ...]
     vec_shape: tuple[int, ...]
     unroll_axes: tuple[str, ...]
@@ -106,7 +103,7 @@ class _VectorPlan:
     state_templates: tuple[_BufferTemplate, ...]
     alias_templates: tuple[_BufferTemplate, ...]
     param_templates: tuple[_BufferTemplate, ...]
-    alias_codes: tuple[tuple[str, "CodeType", tuple[int, ...]], ...]
+    alias_codes: tuple[tuple[str, CodeType, tuple[int, ...]], ...]
     eq_groups: tuple[_EqGroup, ...]
     n_state: int
 
@@ -122,6 +119,10 @@ def _parse_expanded_name(
     """Parse an expanded name like ``base__age_y__vax_u`` -> (base, coords).
 
     Returns ``(name, {})`` if the name does not match the expected pattern.
+
+    Returns:
+        Tuple ``(base, coords)`` where ``coords`` maps axis name to coord
+        value. Falls back to ``(name, {})`` if parsing fails.
     """
     parts = name.split("__")
     if len(parts) < 2:
@@ -146,13 +147,19 @@ def _parse_expanded_name(
 
 
 def _infer_templates_from_names(
-    names: "Iterable[str]", axes: list[tuple[str, list[str]]]
+    names: Iterable[str], axes: list[tuple[str, list[str]]]
 ) -> dict[str, _BufferTemplate] | None:
-    """Group names by inferred template base. Returns None if any group is
-    inconsistent (mismatched axes, missing cartesian-product members, etc.).
+    """Group names by inferred template base.
+
+    Returns ``None`` if any group is inconsistent (mismatched axes, missing
+    cartesian-product members, etc.).
 
     A name with no parseable axis suffixes becomes a scalar template
     (axes=(), shape=()).
+
+    Returns:
+        A mapping from base name to ``_BufferTemplate`` on success, or
+        ``None`` if the names cannot be grouped consistently.
     """
     by_base: dict[str, list[tuple[str, dict[str, str]]]] = {}
     for name in names:
@@ -200,11 +207,13 @@ def _infer_templates_from_names(
 
 
 def _infer_alias_templates(
-    aliases: "Mapping[str, str]", axes: list[tuple[str, list[str]]]
+    aliases: Mapping[str, str], axes: list[tuple[str, list[str]]]
 ) -> tuple[dict[str, _BufferTemplate], dict[str, str]] | None:
     """Group aliases by inferred template base.
 
-    Returns ``(templates_by_base, name_to_base)`` or ``None`` on failure.
+    Returns:
+        ``(templates_by_base, name_to_base)`` on success or ``None`` on
+        failure.
     """
     templates = _infer_templates_from_names(aliases.keys(), axes)
     if templates is None:
@@ -218,7 +227,7 @@ def _infer_alias_templates(
 # ---------------------------------------------------------------------------
 
 
-def _build_access_ast(
+def _build_access_ast(  # noqa: C901, PLR0912, PLR0913
     *,
     src_base: str,
     src_axes: tuple[str, ...],
@@ -231,6 +240,14 @@ def _build_access_ast(
 
     Returns an expression with shape broadcastable to ``target_axes``' shape.
     Returns the bare buffer name when src and target axes match exactly.
+
+    Returns:
+        An ``ast.expr`` node accessing the source buffer in a way that
+        broadcasts/transposes to the target template's cell layout.
+
+    Raises:
+        RuntimeError: If a source axis is not tied to and not fixed against
+            the target axes (an internal inconsistency).
     """
     buf_name = ast.Name(id=f"{src_base}_buf", ctx=ast.Load())
     if not src_axes:
@@ -341,7 +358,7 @@ class _NameRewriter(ast.NodeTransformer):
         self._name_to_coords = name_to_coords
         self._axis_index = axis_index
 
-    def visit_Name(self, node: ast.Name) -> ast.AST:  # noqa: N802
+    def visit_Name(self, node: ast.Name) -> ast.AST:
         tpl = self._name_to_template.get(node.id)
         if tpl is None:
             return node
@@ -357,7 +374,7 @@ class _NameRewriter(ast.NodeTransformer):
         )
 
 
-def _rewrite_cell_to_vector(
+def _rewrite_cell_to_vector(  # noqa: PLR0913
     *,
     expr: str,
     target_axes: tuple[str, ...],
@@ -366,6 +383,12 @@ def _rewrite_cell_to_vector(
     name_to_coords: Mapping[str, Mapping[str, str]],
     axis_index: Mapping[str, Mapping[str, int]],
 ) -> ast.Expression:
+    """Rewrite a per-cell expression string into a shaped buffer expression.
+
+    Returns:
+        An ``ast.Expression`` whose body evaluates to an array shaped per
+        ``target_axes`` (or a scalar when ``target_axes`` is empty).
+    """
     tree = _parse_expr(expr)
     _validate_ast(tree, expr=expr)
     rewriter = _NameRewriter(
@@ -386,17 +409,20 @@ def _rewrite_cell_to_vector(
 
 
 def _flatten_addsub(node: ast.expr) -> list[tuple[int, ast.expr]]:
-    """Flatten an Add/Sub tree into (sign, leaf-expr) terms (iterative)."""
+    """Flatten an Add/Sub tree into (sign, leaf-expr) terms (iterative).
+
+    Returns:
+        A list of ``(sign, leaf_expr)`` pairs in the original left-to-right
+        order of the flattened tree.
+    """
     terms: list[tuple[int, ast.expr]] = []
     stack: list[tuple[ast.expr, int]] = [(node, 1)]
     while stack:
         n, sign = stack.pop()
         if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Add):
-            stack.append((n.right, sign))
-            stack.append((n.left, sign))
+            stack.extend(((n.right, sign), (n.left, sign)))
         elif isinstance(n, ast.BinOp) and isinstance(n.op, ast.Sub):
-            stack.append((n.right, -sign))
-            stack.append((n.left, sign))
+            stack.extend(((n.right, -sign), (n.left, sign)))
         elif isinstance(n, ast.UnaryOp) and isinstance(n.op, ast.USub):
             stack.append((n.operand, -sign))
         elif isinstance(n, ast.UnaryOp) and isinstance(n.op, ast.UAdd):
@@ -406,10 +432,15 @@ def _flatten_addsub(node: ast.expr) -> list[tuple[int, ast.expr]]:
     return terms
 
 
-def _classify_buf_subscript(
+def _classify_buf_subscript(  # noqa: PLR0911
     node: ast.expr,
 ) -> tuple[str, tuple[int, ...]] | None:
-    """If ``node`` is ``<name>_buf[<int_tuple>]``, return (name, indices)."""
+    """If ``node`` is ``<name>_buf[<int_tuple>]``, return (name, indices).
+
+    Returns:
+        ``(buffer_name, index_tuple)`` if the node matches the expected
+        constant-indexed buffer subscript pattern, otherwise ``None``.
+    """
     if not isinstance(node, ast.Subscript):
         return None
     if not isinstance(node.value, ast.Name):
@@ -454,7 +485,7 @@ def _reassemble_addsub(terms: list[tuple[int, ast.expr]]) -> ast.expr:
     return out
 
 
-def _collapse_full_buffer_sums(
+def _collapse_full_buffer_sums(  # noqa: C901, PLR0915
     tree: ast.Expression, buf_shapes: Mapping[str, tuple[int, ...]]
 ) -> ast.Expression:
     """Replace sums-over-all-cells of a buffer with ``np.sum(buf)``.
@@ -466,6 +497,10 @@ def _collapse_full_buffer_sums(
     ``(name, sign)``; if the set of indices for a group exhausts the full
     Cartesian product of the buffer's shape, those terms are collapsed into a
     single ``np.sum(buf)`` call. Other terms in the chain are left untouched.
+
+    Returns:
+        A possibly-rewritten ``ast.Expression`` equivalent to ``tree`` but
+        with full-buffer sums collapsed where detected.
     """
 
     def collapse_chain(node: ast.expr) -> ast.expr:
@@ -495,7 +530,7 @@ def _collapse_full_buffer_sums(
                 and len(set(idxs)) == expected
                 and all(
                     len(t) == len(shape)
-                    and all(0 <= ti < si for ti, si in zip(t, shape))
+                    and all(0 <= ti < si for ti, si in zip(t, shape, strict=True))
                     for t in idxs
                 )
             ):
@@ -511,16 +546,14 @@ def _collapse_full_buffer_sums(
                             elts=[ast.Constant(value=v) for v in t],
                             ctx=ast.Load(),
                         )
-                    collapsed.append(
-                        (
-                            sign,
-                            ast.Subscript(
-                                value=ast.Name(id=name, ctx=ast.Load()),
-                                slice=slice_node,
-                                ctx=ast.Load(),
-                            ),
-                        )
-                    )
+                    collapsed.append((
+                        sign,
+                        ast.Subscript(
+                            value=ast.Name(id=name, ctx=ast.Load()),
+                            slice=slice_node,
+                            ctx=ast.Load(),
+                        ),
+                    ))
         if not changed:
             return node
         return _reassemble_addsub(collapsed)
@@ -545,14 +578,14 @@ def _collapse_full_buffer_sums(
                     if not isinstance(child, ast.AST):
                         continue
                     if is_addsub(child):
-                        new_child = collapse_chain(child)
+                        new_child = collapse_chain(cast("ast.expr", child))
                         val[i] = new_child
                         stack.append(new_child)
                     else:
                         stack.append(child)
             elif isinstance(val, ast.AST):
                 if is_addsub(val):
-                    new_child = collapse_chain(val)
+                    new_child = collapse_chain(cast("ast.expr", val))
                     setattr(node, fld, new_child)
                     stack.append(new_child)
                 else:
@@ -562,7 +595,7 @@ def _collapse_full_buffer_sums(
     return new_tree
 
 
-def _vectorize_template_equations(
+def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0914, PLR0915
     *,
     template: _BufferTemplate,
     equations: tuple[str, ...],
@@ -571,7 +604,7 @@ def _vectorize_template_equations(
     axis_index: Mapping[str, Mapping[str, int]],
 ) -> (
     tuple[
-        tuple["CodeType", ...],
+        tuple[CodeType, ...],
         tuple[str, ...],  # vec_axes
         tuple[int, ...],  # vec_shape
         tuple[str, ...],  # unroll_axes
@@ -589,6 +622,11 @@ def _vectorize_template_equations(
     3. Pairs of axes unrolled (rare).
     Within each candidate subset, the first and last cell of every unroll
     bin must produce structurally identical AST after rewriting.
+
+    Returns:
+        A tuple of ``(codes, vec_axes, vec_shape, unroll_axes,
+        unroll_shape, assembly_perm)`` describing the chosen vectorization
+        plan, or ``None`` if no candidate succeeds.
     """
     size = math.prod(template.shape) if template.shape else 1
     cell_exprs = equations[template.offset : template.offset + size]
@@ -597,12 +635,9 @@ def _vectorize_template_equations(
     n_axes = len(template.axes)
 
     # Enumerate candidate unroll-axis index subsets, smallest first.
-    from itertools import combinations as _comb
-
     candidates: list[tuple[int, ...]] = []
     for k in range(n_axes + 1):
-        for combo in _comb(range(n_axes), k):
-            candidates.append(combo)
+        candidates.extend(_comb(range(n_axes), k))
 
     # Strides for converting (axis-coord-index tuple) → flat cell index in
     # ``coord_assignments`` (template.axes order, last varies fastest).
@@ -639,7 +674,11 @@ def _vectorize_template_equations(
 
             # First and last cells of the bin = vec_axes coord indices all
             # zero / all (size-1).
-            def _bin_flat(vec_coord_idx: list[int]) -> int:
+            def _bin_flat(
+                vec_coord_idx: list[int],
+                base_flat: int = base_flat,
+                vec_idx: tuple[int, ...] = vec_idx,
+            ) -> int:
                 f = base_flat
                 for k_pos, ax_pos in enumerate(vec_idx):
                     f += vec_coord_idx[k_pos] * strides[ax_pos]
@@ -707,8 +746,14 @@ def _vectorize_template_equations(
 # ---------------------------------------------------------------------------
 
 
-def build_vector_plan(rhs: NormalizedRhs) -> _VectorPlan | None:
-    """Try to build a vectorized plan for ``rhs``. Returns None on fallback."""
+def build_vector_plan(rhs: NormalizedRhs) -> _VectorPlan | None:  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
+    """Try to build a vectorized plan for ``rhs``.
+
+    Returns:
+        A ``_VectorPlan`` describing the vectorized layout, or ``None`` to
+        signal that the spec is unsupported and the caller should fall back
+        to the scalar engine.
+    """
     if not rhs.state_templates:
         return None
     # Require all states to be wildcard templates (have axes).
@@ -742,7 +787,9 @@ def build_vector_plan(rhs: NormalizedRhs) -> _VectorPlan | None:
             offset=tpl.offset,
         )
         state_buffers.append(buf)
-        for nm, coord_map in zip(tpl.expanded_names, tpl.coord_assignments):
+        for nm, coord_map in zip(
+            tpl.expanded_names, tpl.coord_assignments, strict=True
+        ):
             name_to_template[nm] = buf
             name_to_coords[nm] = coord_map
 
@@ -752,7 +799,9 @@ def build_vector_plan(rhs: NormalizedRhs) -> _VectorPlan | None:
     alias_buffers_by_base, _ = alias_inference
     alias_buffers = list(alias_buffers_by_base.values())
     for buf in alias_buffers:
-        for nm, coord_map in zip(buf.expanded_names, buf.coord_assignments):
+        for nm, coord_map in zip(
+            buf.expanded_names, buf.coord_assignments, strict=True
+        ):
             name_to_template[nm] = buf
             name_to_coords[nm] = coord_map
 
@@ -767,7 +816,9 @@ def build_vector_plan(rhs: NormalizedRhs) -> _VectorPlan | None:
         # Skip scalars — they remain available under their original name.
         if not buf.axes:
             continue
-        for nm, coord_map in zip(buf.expanded_names, buf.coord_assignments):
+        for nm, coord_map in zip(
+            buf.expanded_names, buf.coord_assignments, strict=True
+        ):
             name_to_template[nm] = buf
             name_to_coords[nm] = coord_map
 
@@ -861,7 +912,7 @@ def build_vector_plan(rhs: NormalizedRhs) -> _VectorPlan | None:
 # ---------------------------------------------------------------------------
 
 
-def make_vectorized_eval_fn(plan: _VectorPlan, *, xp: object) -> EvalFn:
+def make_vectorized_eval_fn(plan: _VectorPlan, *, xp: object) -> EvalFn:  # noqa: C901, PLR0915
     """Return an ``eval_fn(t, y, **params)`` driven by ``plan``."""
     state_templates = plan.state_templates
     alias_codes = plan.alias_codes
@@ -877,7 +928,7 @@ def make_vectorized_eval_fn(plan: _VectorPlan, *, xp: object) -> EvalFn:
         if buf.axes
     ]
 
-    def eval_fn(t: object, y: object, **params: object) -> Float64Array:
+    def eval_fn(t: object, y: object, **params: object) -> Float64Array:  # noqa: C901, PLR0912, PLR0915
         if is_numpy:
             y_in = np.asarray(y, dtype=np.float64)
             t_val: object = np.float64(cast("Any", t))
@@ -920,7 +971,9 @@ def make_vectorized_eval_fn(plan: _VectorPlan, *, xp: object) -> EvalFn:
         # Eval alias buffers in declaration order.
         for base, code, shape in alias_codes:
             try:
-                val = eval(code, {"__builtins__": _SAFE_BUILTINS}, env)  # noqa: S307
+                val = eval(  # noqa: S307
+                    code, {"__builtins__": _SAFE_BUILTINS}, env
+                )
             except (NameError, ValueError, TypeError, ArithmeticError) as exc:
                 msg = f"alias {base!r} evaluation failed: {exc!r}"
                 raise ValueError(msg) from exc
@@ -937,7 +990,9 @@ def make_vectorized_eval_fn(plan: _VectorPlan, *, xp: object) -> EvalFn:
             bin_results: list[object] = []
             for code in grp.codes:
                 try:
-                    val = eval(code, {"__builtins__": _SAFE_BUILTINS}, env)  # noqa: S307
+                    val = eval(  # noqa: S307
+                        code, {"__builtins__": _SAFE_BUILTINS}, env
+                    )
                 except (NameError, ValueError, TypeError, ArithmeticError) as exc:
                     msg = f"equation {grp.base!r} evaluation failed: {exc!r}"
                     raise ValueError(msg) from exc
@@ -953,26 +1008,25 @@ def make_vectorized_eval_fn(plan: _VectorPlan, *, xp: object) -> EvalFn:
             if not grp.unroll_axes:
                 # Fully vectorized — single result already in template order.
                 whole = bin_results[0]
+            elif is_numpy:
+                stacked = np.stack(cast("Any", bin_results), axis=0).reshape(
+                    grp.unroll_shape + grp.vec_shape
+                )
+                whole = np.transpose(stacked, grp.assembly_perm)
             else:
-                if is_numpy:
-                    stacked = np.stack(cast("Any", bin_results), axis=0).reshape(
-                        grp.unroll_shape + grp.vec_shape
-                    )
-                    whole = np.transpose(stacked, grp.assembly_perm)
-                else:
-                    xp_ns = cast("Any", xp)
-                    stacked = xp_ns.reshape(
-                        xp_ns.stack(bin_results, axis=0),
-                        grp.unroll_shape + grp.vec_shape,
-                    )
-                    whole = xp_ns.transpose(stacked, grp.assembly_perm)
+                xp_ns = cast("Any", xp)
+                stacked = xp_ns.reshape(
+                    xp_ns.stack(bin_results, axis=0),
+                    grp.unroll_shape + grp.vec_shape,
+                )
+                whole = xp_ns.transpose(stacked, grp.assembly_perm)
             if is_numpy:
                 pieces.append(np.asarray(whole).reshape(-1))
             else:
                 pieces.append(cast("Any", xp).reshape(whole, (-1,)))
 
         if is_numpy:
-            return cast("Float64Array", np.concatenate(pieces))
+            return cast("Float64Array", np.concatenate(cast("Any", pieces)))
         return cast("Float64Array", cast("Any", xp).concatenate(pieces))
 
     return eval_fn

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -20,6 +20,7 @@ whitelist, and evaluation runs with empty builtins.
 from __future__ import annotations
 
 import ast
+import importlib
 from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import (
@@ -220,33 +221,31 @@ _ALLOWED_NODES: tuple[type[ast.AST], ...] = (
 )
 
 _ALLOWED_CALL_ROOTS: tuple[str, ...] = ("np",)
-_ALLOWED_CALL_FUNCS: frozenset[str] = frozenset(
-    {
-        # NumPy scalar math; keep small initially.
-        "abs",
-        "exp",
-        "expm1",
-        "log",
-        "log1p",
-        "log2",
-        "log10",
-        "sqrt",
-        "maximum",
-        "minimum",
-        "clip",
-        "where",
-        # Trig and hyperbolic.
-        "sin",
-        "cos",
-        "tan",
-        "sinh",
-        "cosh",
-        "tanh",
-        # Geometry-ish.
-        "hypot",
-        "arctan2",
-    }
-)
+_ALLOWED_CALL_FUNCS: frozenset[str] = frozenset({
+    # NumPy scalar math; keep small initially.
+    "abs",
+    "exp",
+    "expm1",
+    "log",
+    "log1p",
+    "log2",
+    "log10",
+    "sqrt",
+    "maximum",
+    "minimum",
+    "clip",
+    "where",
+    # Trig and hyperbolic.
+    "sin",
+    "cos",
+    "tan",
+    "sinh",
+    "cosh",
+    "tanh",
+    # Geometry-ish.
+    "hypot",
+    "arctan2",
+})
 
 _ALLOWED_HELPER_FUNCS: frozenset[str] = frozenset({"sum_state", "sum_prefix"})
 
@@ -541,11 +540,12 @@ def compile_rhs(
 
     eval_fn: EvalFn | None = None
     if vectorized:
-        from op_system._vectorize import build_vector_plan, make_vectorized_eval_fn
-
-        plan = build_vector_plan(rhs)
+        # Lazy load via importlib to avoid a static circular import
+        # (op_system._vectorize imports helpers from this module).
+        vec = importlib.import_module("op_system._vectorize")
+        plan = vec.build_vector_plan(rhs)
         if plan is not None:
-            eval_fn = make_vectorized_eval_fn(plan, xp=xp)
+            eval_fn = vec.make_vectorized_eval_fn(plan, xp=xp)
 
     if eval_fn is None:
         eval_fn = _make_eval_fn(

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -516,18 +516,16 @@ def _make_eval_fn(  # noqa: C901
 # -----------------------------------------------------------------------------
 
 
-def compile_rhs(
-    rhs: NormalizedRhs, *, xp: object, vectorized: bool = False
-) -> CompiledRhs:
+def compile_rhs(rhs: NormalizedRhs, *, xp: object) -> CompiledRhs:
     """Compile a normalized RHS into a runnable evaluation function.
+
+    Always attempts the vectorized eval path that operates on shaped buffers
+    (one tensor expression per state template) and falls back automatically
+    to the scalar path when the spec falls outside the supported subset.
 
     Args:
         rhs: Normalized RHS produced by `op_system.specs.normalize_rhs`.
         xp: Array backend namespace.
-        vectorized: If True, attempt to compile a vectorized eval path that
-            operates on shaped buffers (one tensor expression per state
-            template). Falls back to the scalar path automatically if the spec
-            doesn't fit the supported subset. Defaults to False.
 
     Returns:
         A `CompiledRhs` containing an `eval_fn(t, y, **params) -> dydt`.
@@ -538,14 +536,13 @@ def compile_rhs(
             detail="Only 'expr' and 'transitions' are supported in v1.",
         )
 
-    eval_fn: EvalFn | None = None
-    if vectorized:
-        # Lazy load via importlib to avoid a static circular import
-        # (op_system._vectorize imports helpers from this module).
-        vec = importlib.import_module("op_system._vectorize")
-        plan = vec.build_vector_plan(rhs)
-        if plan is not None:
-            eval_fn = vec.make_vectorized_eval_fn(plan, xp=xp)
+    # Lazy load via importlib to avoid a static circular import
+    # (op_system._vectorize imports helpers from this module).
+    vec = importlib.import_module("op_system._vectorize")
+    plan = vec.build_vector_plan(rhs)
+    eval_fn: EvalFn | None = (
+        vec.make_vectorized_eval_fn(plan, xp=xp) if plan is not None else None
+    )
 
     if eval_fn is None:
         eval_fn = _make_eval_fn(

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -220,31 +220,33 @@ _ALLOWED_NODES: tuple[type[ast.AST], ...] = (
 )
 
 _ALLOWED_CALL_ROOTS: tuple[str, ...] = ("np",)
-_ALLOWED_CALL_FUNCS: frozenset[str] = frozenset({
-    # NumPy scalar math; keep small initially.
-    "abs",
-    "exp",
-    "expm1",
-    "log",
-    "log1p",
-    "log2",
-    "log10",
-    "sqrt",
-    "maximum",
-    "minimum",
-    "clip",
-    "where",
-    # Trig and hyperbolic.
-    "sin",
-    "cos",
-    "tan",
-    "sinh",
-    "cosh",
-    "tanh",
-    # Geometry-ish.
-    "hypot",
-    "arctan2",
-})
+_ALLOWED_CALL_FUNCS: frozenset[str] = frozenset(
+    {
+        # NumPy scalar math; keep small initially.
+        "abs",
+        "exp",
+        "expm1",
+        "log",
+        "log1p",
+        "log2",
+        "log10",
+        "sqrt",
+        "maximum",
+        "minimum",
+        "clip",
+        "where",
+        # Trig and hyperbolic.
+        "sin",
+        "cos",
+        "tan",
+        "sinh",
+        "cosh",
+        "tanh",
+        # Geometry-ish.
+        "hypot",
+        "arctan2",
+    }
+)
 
 _ALLOWED_HELPER_FUNCS: frozenset[str] = frozenset({"sum_state", "sum_prefix"})
 
@@ -515,12 +517,18 @@ def _make_eval_fn(  # noqa: C901
 # -----------------------------------------------------------------------------
 
 
-def compile_rhs(rhs: NormalizedRhs, *, xp: object) -> CompiledRhs:
+def compile_rhs(
+    rhs: NormalizedRhs, *, xp: object, vectorized: bool = False
+) -> CompiledRhs:
     """Compile a normalized RHS into a runnable evaluation function.
 
     Args:
         rhs: Normalized RHS produced by `op_system.specs.normalize_rhs`.
         xp: Array backend namespace.
+        vectorized: If True, attempt to compile a vectorized eval path that
+            operates on shaped buffers (one tensor expression per state
+            template). Falls back to the scalar path automatically if the spec
+            doesn't fit the supported subset. Defaults to False.
 
     Returns:
         A `CompiledRhs` containing an `eval_fn(t, y, **params) -> dydt`.
@@ -531,12 +539,21 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object) -> CompiledRhs:
             detail="Only 'expr' and 'transitions' are supported in v1.",
         )
 
-    eval_fn = _make_eval_fn(
-        state_names=rhs.state_names,
-        aliases=rhs.aliases,
-        equations=rhs.equations,
-        xp=xp,
-    )
+    eval_fn: EvalFn | None = None
+    if vectorized:
+        from op_system._vectorize import build_vector_plan, make_vectorized_eval_fn
+
+        plan = build_vector_plan(rhs)
+        if plan is not None:
+            eval_fn = make_vectorized_eval_fn(plan, xp=xp)
+
+    if eval_fn is None:
+        eval_fn = _make_eval_fn(
+            state_names=rhs.state_names,
+            aliases=rhs.aliases,
+            equations=rhs.equations,
+            xp=xp,
+        )
 
     return CompiledRhs(
         state_names=rhs.state_names,

--- a/src/op_system/specs.py
+++ b/src/op_system/specs.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from op_system._normalize import (
     NormalizedRhs,
+    StateTemplate,
     normalize_expr_rhs,
     normalize_rhs,
     normalize_transitions_rhs,
@@ -28,6 +29,7 @@ __all__ = [
     "NormalizedRhs",
     "PinnedToken",
     "SelectorToken",
+    "StateTemplate",
     "WildcardToken",
     "normalize_expr_rhs",
     "normalize_rhs",

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import re
 
 import pytest
+
 from op_system._constraints import _ConstraintRule, _normalize_constraints
 from op_system.specs import (
     NormalizedRhs,
@@ -1383,8 +1384,10 @@ def test_state_templates_mixed_scalar_and_wildcard() -> None:
     out = normalize_transitions_rhs(spec)
     assert len(out.state_templates) == 2
     s_tpl, d_tpl = out.state_templates
-    assert s_tpl.axes == ("age",) and s_tpl.shape == (2,)
-    assert d_tpl.axes == () and d_tpl.shape == ()
+    assert s_tpl.axes == ("age",)
+    assert s_tpl.shape == (2,)
+    assert d_tpl.axes == ()
+    assert d_tpl.shape == ()
     assert d_tpl.expanded_names == ("D",)
     assert d_tpl.offset == out.state_names.index("D")
 

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -13,10 +13,10 @@ from __future__ import annotations
 import re
 
 import pytest
-
 from op_system._constraints import _ConstraintRule, _normalize_constraints
 from op_system.specs import (
     NormalizedRhs,
+    StateTemplate,
     normalize_expr_rhs,
     normalize_rhs,
     normalize_transitions_rhs,
@@ -1339,3 +1339,92 @@ def test_transitions_pinned_from_endpoint_expands_correctly() -> None:
     assert to_states == {"R__age_y__vax_u", "R__age_y__vax_v"}
     # Old-age states exist in state_names but are untouched by this transition.
     assert "S__age_o__vax_u" in out.state_names
+
+
+def test_state_templates_wildcard_only_records_shape_and_offset() -> None:
+    """Pure-wildcard state entries produce a single shaped StateTemplate."""
+    spec = {
+        "kind": "transitions",
+        "state": ["S[age, vax]", "I[age, vax]", "R[age, vax]"],
+        "axes": [
+            {"name": "age", "kind": "categorical", "coords": ["y", "o"]},
+            {"name": "vax", "kind": "categorical", "coords": ["u", "v"]},
+        ],
+        "transitions": [
+            {"from": "S[age, vax]", "to": "I[age, vax]", "rate": "beta"},
+        ],
+    }
+    out = normalize_transitions_rhs(spec)
+    assert len(out.state_templates) == 3
+    s_tpl = out.state_templates[0]
+    assert isinstance(s_tpl, StateTemplate)
+    assert s_tpl.base == "S"
+    assert s_tpl.axes == ("age", "vax")
+    assert s_tpl.shape == (2, 2)
+    assert len(s_tpl.expanded_names) == 4
+    assert s_tpl.offset == out.state_names.index(s_tpl.expanded_names[0])
+    # Templates cover the full state vector contiguously in declared order.
+    flat = tuple(n for tpl in out.state_templates for n in tpl.expanded_names)
+    assert flat == out.state_names
+
+
+def test_state_templates_mixed_scalar_and_wildcard() -> None:
+    """A bare scalar state next to a wildcard template yields scalar+shaped."""
+    spec = {
+        "kind": "transitions",
+        "state": ["S[age]", "D"],
+        "axes": [
+            {"name": "age", "kind": "categorical", "coords": ["y", "o"]},
+        ],
+        "transitions": [
+            {"from": "S[age]", "to": "D", "rate": "mu"},
+        ],
+    }
+    out = normalize_transitions_rhs(spec)
+    assert len(out.state_templates) == 2
+    s_tpl, d_tpl = out.state_templates
+    assert s_tpl.axes == ("age",) and s_tpl.shape == (2,)
+    assert d_tpl.axes == () and d_tpl.shape == ()
+    assert d_tpl.expanded_names == ("D",)
+    assert d_tpl.offset == out.state_names.index("D")
+
+
+def test_state_templates_pinned_only_treated_as_scalar() -> None:
+    """Pinned-only selectors expand to a single scalar StateTemplate."""
+    spec = {
+        "kind": "transitions",
+        "state": ["S[age=y]", "S[age=o]", "I[age]"],
+        "axes": [
+            {"name": "age", "kind": "categorical", "coords": ["y", "o"]},
+        ],
+        "transitions": [
+            {"from": "S[age]", "to": "I[age]", "rate": "beta"},
+        ],
+    }
+    out = normalize_transitions_rhs(spec)
+    assert len(out.state_templates) == 3
+    assert out.state_templates[0].axes == ()
+    assert out.state_templates[0].shape == ()
+    assert out.state_templates[0].expanded_names == ("S__age_y",)
+    assert out.state_templates[1].expanded_names == ("S__age_o",)
+    assert out.state_templates[2].axes == ("age",)
+    assert out.state_templates[2].shape == (2,)
+
+
+def test_state_templates_expr_kind_populated() -> None:
+    """expr-kind RHS also exposes state_templates aligned with state_names."""
+    spec = {
+        "kind": "expr",
+        "state": ["S[age]", "I[age]"],
+        "axes": [
+            {"name": "age", "kind": "categorical", "coords": ["y", "o"]},
+        ],
+        "equations": {
+            "S[age]": "0",
+            "I[age]": "0",
+        },
+    }
+    out = normalize_expr_rhs(spec)
+    assert len(out.state_templates) == 2
+    flat = tuple(n for tpl in out.state_templates for n in tpl.expanded_names)
+    assert flat == out.state_names

--- a/tests/op_system/test_op_system_vectorize.py
+++ b/tests/op_system/test_op_system_vectorize.py
@@ -1,0 +1,142 @@
+"""Unit tests for the vectorized compile path (``op_system._vectorize``).
+
+Covers:
+- Numerical equivalence between scalar and vectorized eval on a templated SIR.
+- Sum-pattern recognition (alias summing over all cells of a template).
+- Partial unrolling for templates with structural variation along one axis.
+- Templated param buffer assembly from per-cell scalars.
+- Silent fallback when the spec is unsupported.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from op_system._vectorize import build_vector_plan
+from op_system.compile import compile_rhs
+from op_system.specs import normalize_rhs
+
+
+def _sir_two_axis_spec() -> dict[str, object]:
+    """Templated SIR over (age, loc) with a sum-over-all-cells alias."""
+    return {
+        "kind": "expr",
+        "axes": [
+            {"name": "age", "coords": ["y", "o"]},
+            {"name": "loc", "coords": ["a", "b", "c"]},
+        ],
+        "state": ["S[age, loc]", "I[age, loc]", "R[age, loc]"],
+        "params": ["beta", "gamma"],
+        "aliases": {
+            # Pure sum across all cells of the I template — this is the
+            # pattern the recognizer should collapse to ``np.sum(I_buf)``.
+            "I_total": (
+                "I__age_y__loc_a + I__age_y__loc_b + I__age_y__loc_c + "
+                "I__age_o__loc_a + I__age_o__loc_b + I__age_o__loc_c"
+            ),
+        },
+        "equations": {
+            "S[age, loc]": "-beta * S[age, loc] * I_total",
+            "I[age, loc]": "beta * S[age, loc] * I_total - gamma * I[age, loc]",
+            "R[age, loc]": "gamma * I[age, loc]",
+        },
+    }
+
+
+def _sir_templated_param_spec() -> dict[str, object]:
+    """SIR with templated param ``gamma`` per (age,) — exercises param buffer."""
+    return {
+        "kind": "expr",
+        "axes": [{"name": "age", "coords": ["y", "o"]}],
+        "state": ["S[age]", "I[age]"],
+        "params": ["beta", "gamma[age]"],
+        "equations": {
+            "S[age]": "-beta * S[age] * I[age]",
+            "I[age]": "beta * S[age] * I[age] - gamma[age] * I[age]",
+        },
+    }
+
+
+def _eval_equal(spec: dict[str, object], **call_params: float) -> None:
+    rhs = normalize_rhs(spec)
+    c_s = compile_rhs(rhs, xp=np)
+    c_v = compile_rhs(rhs, xp=np, vectorized=True)
+    rng = np.random.RandomState(0)
+    y = rng.rand(len(rhs.state_names))
+    out_s = c_s.eval_fn(0.0, y, **call_params)
+    out_v = c_v.eval_fn(0.0, y, **call_params)
+    assert np.allclose(out_s, out_v, atol=1e-12, rtol=0.0), (
+        f"max abs diff = {np.max(np.abs(out_s - out_v))}"
+    )
+
+
+def test_vectorized_matches_scalar_two_axis_sir() -> None:
+    _eval_equal(_sir_two_axis_spec(), beta=0.3, gamma=0.1)
+
+
+def test_vectorized_matches_scalar_templated_param() -> None:
+    _eval_equal(
+        _sir_templated_param_spec(),
+        beta=0.4,
+        **{"gamma__age_y": 0.1, "gamma__age_o": 0.2},
+    )
+
+
+def test_sum_pattern_recognized_for_alias_over_full_template() -> None:
+    """The ``I_total`` alias should collapse to a single ``np.sum`` call."""
+    rhs = normalize_rhs(_sir_two_axis_spec())
+    plan = build_vector_plan(rhs)
+    assert plan is not None
+    alias_codes = {base: code for base, code, _shape in plan.alias_codes}
+    assert "I_total" in alias_codes
+    code = alias_codes["I_total"]
+    # After collapse, the only buffer name referenced is ``I_buf``.
+    assert "I_buf" in code.co_names
+    # Bytecode should be very small after collapse (compared to the dozens
+    # of indexed loads the un-collapsed version would emit).
+    assert len(code.co_code) < 50, (
+        f"alias bytecode unexpectedly large: {len(code.co_code)}"
+    )
+
+
+def test_full_vectorization_when_no_structural_variation() -> None:
+    """When all cells of a template are structurally identical, the
+    vectorizer should fully vectorize (no unrolling).
+    """
+    rhs = normalize_rhs(_sir_two_axis_spec())
+    plan = build_vector_plan(rhs)
+    assert plan is not None
+    for grp in plan.eq_groups:
+        assert grp.unroll_axes == ()
+        assert len(grp.codes) == 1
+
+
+def test_fallback_on_non_templated_spec() -> None:
+    """A purely scalar (non-templated) RHS yields ``None`` for the plan and
+    the compile path silently falls back to the scalar engine.
+    """
+    spec = {
+        "kind": "expr",
+        "state": ["x", "y"],
+        "equations": {"x": "-x", "y": "x - y"},
+    }
+    rhs = normalize_rhs(spec)
+    assert build_vector_plan(rhs) is None
+    # Compiling with ``vectorized=True`` must not raise.
+    c = compile_rhs(rhs, xp=np, vectorized=True)
+    out = c.eval_fn(0.0, np.array([1.0, 2.0]))
+    assert np.allclose(out, np.array([-1.0, -1.0]))
+
+
+@pytest.mark.parametrize("vectorized", [False, True])
+def test_compile_rhs_vectorized_kwarg(vectorized: bool) -> None:
+    """Both ``vectorized=False`` and ``vectorized=True`` produce eval_fns
+    that yield finite, correctly-shaped output for a supported spec.
+    """
+    rhs = normalize_rhs(_sir_two_axis_spec())
+    c = compile_rhs(rhs, xp=np, vectorized=vectorized)
+    rng = np.random.RandomState(1)
+    y = rng.rand(len(rhs.state_names))
+    out = c.eval_fn(0.0, y, beta=0.3, gamma=0.1)
+    assert out.shape == (len(rhs.state_names),)
+    assert np.all(np.isfinite(out))

--- a/tests/op_system/test_op_system_vectorize.py
+++ b/tests/op_system/test_op_system_vectorize.py
@@ -12,13 +12,18 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+
 from op_system._vectorize import build_vector_plan
 from op_system.compile import compile_rhs
 from op_system.specs import normalize_rhs
 
 
 def _sir_two_axis_spec() -> dict[str, object]:
-    """Templated SIR over (age, loc) with a sum-over-all-cells alias."""
+    """Templated SIR over (age, loc) with a sum-over-all-cells alias.
+
+    Returns:
+        A spec dict suitable for passing to ``normalize_rhs``.
+    """
     return {
         "kind": "expr",
         "axes": [
@@ -44,7 +49,11 @@ def _sir_two_axis_spec() -> dict[str, object]:
 
 
 def _sir_templated_param_spec() -> dict[str, object]:
-    """SIR with templated param ``gamma`` per (age,) — exercises param buffer."""
+    """SIR with templated param ``gamma`` per (age,) — exercises param buffer.
+
+    Returns:
+        A spec dict suitable for passing to ``normalize_rhs``.
+    """
     return {
         "kind": "expr",
         "axes": [{"name": "age", "coords": ["y", "o"]}],
@@ -71,14 +80,17 @@ def _eval_equal(spec: dict[str, object], **call_params: float) -> None:
 
 
 def test_vectorized_matches_scalar_two_axis_sir() -> None:
+    """Vectorized eval matches scalar eval on a two-axis templated SIR."""
     _eval_equal(_sir_two_axis_spec(), beta=0.3, gamma=0.1)
 
 
 def test_vectorized_matches_scalar_templated_param() -> None:
+    """Vectorized eval matches scalar eval with a per-axis templated param."""
     _eval_equal(
         _sir_templated_param_spec(),
         beta=0.4,
-        **{"gamma__age_y": 0.1, "gamma__age_o": 0.2},
+        gamma__age_y=0.1,
+        gamma__age_o=0.2,
     )
 
 
@@ -100,8 +112,10 @@ def test_sum_pattern_recognized_for_alias_over_full_template() -> None:
 
 
 def test_full_vectorization_when_no_structural_variation() -> None:
-    """When all cells of a template are structurally identical, the
-    vectorizer should fully vectorize (no unrolling).
+    """Fully-vectorize when all cells of a template are structurally identical.
+
+    The vectorizer should produce a single shaped code per template (no
+    unrolling) when no axis introduces structural variation.
     """
     rhs = normalize_rhs(_sir_two_axis_spec())
     plan = build_vector_plan(rhs)
@@ -112,8 +126,10 @@ def test_full_vectorization_when_no_structural_variation() -> None:
 
 
 def test_fallback_on_non_templated_spec() -> None:
-    """A purely scalar (non-templated) RHS yields ``None`` for the plan and
-    the compile path silently falls back to the scalar engine.
+    """Silently fall back to the scalar engine for non-templated specs.
+
+    A purely scalar (non-templated) RHS yields ``None`` for the plan and the
+    compile path silently falls back to the scalar engine.
     """
     spec = {
         "kind": "expr",
@@ -129,9 +145,11 @@ def test_fallback_on_non_templated_spec() -> None:
 
 
 @pytest.mark.parametrize("vectorized", [False, True])
-def test_compile_rhs_vectorized_kwarg(vectorized: bool) -> None:
-    """Both ``vectorized=False`` and ``vectorized=True`` produce eval_fns
-    that yield finite, correctly-shaped output for a supported spec.
+def test_compile_rhs_vectorized_kwarg(vectorized: bool) -> None:  # noqa: FBT001
+    """Both ``vectorized`` settings produce well-shaped finite eval output.
+
+    Both ``vectorized=False`` and ``vectorized=True`` produce eval_fns that
+    yield finite, correctly-shaped output for a supported spec.
     """
     rhs = normalize_rhs(_sir_two_axis_spec())
     c = compile_rhs(rhs, xp=np, vectorized=vectorized)

--- a/tests/op_system/test_op_system_vectorize.py
+++ b/tests/op_system/test_op_system_vectorize.py
@@ -11,10 +11,9 @@ Covers:
 from __future__ import annotations
 
 import numpy as np
-import pytest
 
 from op_system._vectorize import build_vector_plan
-from op_system.compile import compile_rhs
+from op_system.compile import _make_eval_fn, compile_rhs
 from op_system.specs import normalize_rhs
 
 
@@ -68,11 +67,19 @@ def _sir_templated_param_spec() -> dict[str, object]:
 
 def _eval_equal(spec: dict[str, object], **call_params: float) -> None:
     rhs = normalize_rhs(spec)
-    c_s = compile_rhs(rhs, xp=np)
-    c_v = compile_rhs(rhs, xp=np, vectorized=True)
+    # ``compile_rhs`` always attempts the vectorized path; bypass it via
+    # ``_make_eval_fn`` to keep an independent scalar reference for this
+    # equivalence check.
+    scalar_eval = _make_eval_fn(
+        state_names=rhs.state_names,
+        aliases=rhs.aliases,
+        equations=rhs.equations,
+        xp=np,
+    )
+    c_v = compile_rhs(rhs, xp=np)
     rng = np.random.RandomState(0)
     y = rng.rand(len(rhs.state_names))
-    out_s = c_s.eval_fn(0.0, y, **call_params)
+    out_s = scalar_eval(0.0, y, **call_params)
     out_v = c_v.eval_fn(0.0, y, **call_params)
     assert np.allclose(out_s, out_v, atol=1e-12, rtol=0.0), (
         f"max abs diff = {np.max(np.abs(out_s - out_v))}"
@@ -138,21 +145,20 @@ def test_fallback_on_non_templated_spec() -> None:
     }
     rhs = normalize_rhs(spec)
     assert build_vector_plan(rhs) is None
-    # Compiling with ``vectorized=True`` must not raise.
-    c = compile_rhs(rhs, xp=np, vectorized=True)
+    # Compiling must transparently fall back and not raise.
+    c = compile_rhs(rhs, xp=np)
     out = c.eval_fn(0.0, np.array([1.0, 2.0]))
     assert np.allclose(out, np.array([-1.0, -1.0]))
 
 
-@pytest.mark.parametrize("vectorized", [False, True])
-def test_compile_rhs_vectorized_kwarg(vectorized: bool) -> None:  # noqa: FBT001
-    """Both ``vectorized`` settings produce well-shaped finite eval output.
+def test_compile_rhs_returns_finite_output() -> None:
+    """``compile_rhs`` produces a finite, correctly-shaped eval output.
 
-    Both ``vectorized=False`` and ``vectorized=True`` produce eval_fns that
-    yield finite, correctly-shaped output for a supported spec.
+    Exercises the default (vectorized-with-fallback) path on a supported
+    templated spec.
     """
     rhs = normalize_rhs(_sir_two_axis_spec())
-    c = compile_rhs(rhs, xp=np, vectorized=vectorized)
+    c = compile_rhs(rhs, xp=np)
     rng = np.random.RandomState(1)
     y = rng.rand(len(rhs.state_names))
     out = c.eval_fn(0.0, y, beta=0.3, gamma=0.1)


### PR DESCRIPTION
This pull request introduces a new structural abstraction for state templates and adds a vectorized evaluation path to the op_system module. The main changes include the addition of the `StateTemplate` dataclass, its integration into the normalization pipeline, support for vectorized evaluation in `compile_rhs`, and comprehensive tests for both the new abstraction and the vectorized path.

**State template abstraction and normalization:**

* Introduced the `StateTemplate` dataclass in `src/op_system/_normalize.py`, representing the structure of state templates (base, axes, shape, expanded names, coordinate assignments, and offset). This enables consumers to uniformly handle both scalar and templated states.
* Added the `state_templates` attribute to the `NormalizedRhs` dataclass and populated it in both `normalize_expr_rhs` and `normalize_transitions_rhs` by implementing the `_build_state_templates` helper. [[1]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531R118) [[2]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531R2329-R2334) [[3]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531R2511-R2516)

**Vectorized evaluation support:**

* Updated `compile_rhs` in `src/op_system/compile.py` to accept a `vectorized` keyword argument. When set, it attempts to compile a vectorized evaluation path using the new vectorizer module, with automatic fallback to the scalar path if unsupported. [[1]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71L518-R530) [[2]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R541-R550)
* Added lazy import logic for the vectorizer to avoid circular imports.

**Public API and test coverage:**

* Exposed `StateTemplate` in the public API (`src/op_system/specs.py`) and in test imports. [[1]](diffhunk://#diff-e7347f5d6678762d5e06831993041c5299fedd3852fb3fd368c3de26dd09b66cR21) [[2]](diffhunk://#diff-e7347f5d6678762d5e06831993041c5299fedd3852fb3fd368c3de26dd09b66cR32) [[3]](diffhunk://#diff-36e364ac2850dcbaf98a9d8947baec052b6fc82135b5733a3a53e387c1803fe0R20)
* Added comprehensive unit tests for the new state template abstraction, ensuring correct structure and alignment with state names across scalar, wildcard, and pinned selectors.
* Added a new test module for the vectorized evaluation path, covering correctness, sum pattern recognition, structural variation, parameter templating, fallback behavior, and the new `vectorized` keyword argument.