### PR TITLE
feat: shaped + time-varying parameters

### DIFF
--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -181,15 +181,15 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
         self,
         axes: AxisCollection,
     ) -> dict[IdentifierString, ParameterRequest]:
-        """Declare the scalar parameters consumed by the compiled RHS.
+        """Declare the parameters consumed by the compiled RHS.
 
         Returns:
-            Mapping of parameter name to a scalar `ParameterRequest`.
+            Mapping of parameter name to a `ParameterRequest`. Names that
+            appear as shaped-parameter references (``theta[imm]``) in the
+            spec are requested as shaped (one ndarray); everything else is
+            requested as a scalar.
 
         Notes:
-            op_system rewrites axis-indexed selectors like ``theta[imm]`` into
-            per-coord scalar names (``theta__imm_X0`` ...) at compile time, so
-            every entry in `compiled.param_names` is requested as a scalar.
             Initial-state seed names (referenced from `meta['initial_state']`
             but not necessarily from any rate expression) are also requested
             so engine plugins can assemble the state vector from `params`.
@@ -200,6 +200,17 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
         # Names provided by the compiled-RHS runtime environment, not by config
         # (numpy/jax namespace, simulation time, and built-in summation helpers).
         builtin_names = {"np", "t", "sum_state", "sum_prefix"}
+
+        # Shaped parameters first, so a later scalar-name collision is a hard
+        # error rather than a silent overwrite.
+        shaped_meta = self._compiled_rhs.meta.get("shaped_params") or ()
+        for shaped_name, shaped_axes in shaped_meta:
+            if shaped_name in mixing_kernel_names or shaped_name in builtin_names:
+                continue
+            requests[shaped_name] = ParameterRequest(
+                name=shaped_name, axes=tuple(shaped_axes)
+            )
+
         for name in self._compiled_rhs.param_names:
             if name in mixing_kernel_names or name in builtin_names or name in requests:
                 continue

--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -108,11 +108,22 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
 
         operators = self._extract_operators(compiled)
         operator_axis = self._extract_operator_axis(compiled)
+        # Preserve the user-declared coordinate labels (typically strings
+        # like ``unvaccinated`` / ``age65to100``) alongside the numeric
+        # ``axis_coords`` arrays.  Engine plugins use this to translate
+        # shaped-IC coord assignments back to integer indices.
+        axis_labels: dict[str, tuple[str, ...]] = {}
+        for ax in compiled.meta.get("axes", []) or []:
+            name = ax.get("name")
+            coords = ax.get("coords")
+            if isinstance(name, str) and isinstance(coords, (list, tuple)):
+                axis_labels[name] = tuple(str(c) for c in coords)
         self.options = {
             **dict(self.options or {}),
             "axis_order": axes_meta.axis_order,
             "axis_sizes": axes_meta.axis_sizes,
             "axis_coords": axes_meta.axis_coords,
+            "axis_labels": axis_labels,
             "state_names": compiled.state_names,
             "initial_state": compiled.meta.get("initial_state"),
             "state_shape": shape_dims,
@@ -194,10 +205,38 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
                 continue
             requests[name] = ParameterRequest(name=name)
         init_map = (self.options or {}).get("initial_state") or {}
-        for param_name in init_map.values():
-            if param_name in requests:
-                continue
-            requests[param_name] = ParameterRequest(name=param_name)
+        for entry in init_map.values():
+            if isinstance(entry, str):
+                # Scalar IC entry: a single shared parameter.
+                if entry in requests:
+                    continue
+                requests[entry] = ParameterRequest(name=entry)
+            elif isinstance(entry, Mapping) and "shaped" in entry:
+                # Shaped IC entry: one ParameterRequest per (name, axes)
+                # tuple, requested with the declared shape so the engine
+                # can index into it per state cell using `entry["coords"]`.
+                shaped_name = entry["shaped"]
+                shaped_axes = tuple(entry.get("axes", ()))
+                existing = requests.get(shaped_name)
+                if existing is not None:
+                    if tuple(existing.axes) != shaped_axes:
+                        raise ValueError(
+                            f"initial_state shaped entry for "
+                            f"{shaped_name!r} declares axes "
+                            f"{shaped_axes!r} but the same name was "
+                            f"already requested with axes "
+                            f"{tuple(existing.axes)!r}"
+                        )
+                    continue
+                requests[shaped_name] = ParameterRequest(
+                    name=shaped_name, axes=shaped_axes
+                )
+            else:
+                raise ValueError(
+                    f"initial_state entry has unexpected type "
+                    f"{type(entry).__name__!r}; expected a parameter name "
+                    "string or a shaped-entry mapping"
+                )
         # Operator velocity/rate fields are consumed by engine plugins (not by
         # the compiled rhs eval_fn), but still need to be in the params dict.
         for op in self._compiled_rhs.meta.get("operators") or ():

--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -84,7 +84,7 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
 
     model_config = ConfigDict(extra="allow")
 
-    def model_post_init(self, context: Any) -> None:  # noqa: ANN401
+    def model_post_init(self, context: Any) -> None:  # noqa: ANN401, PLR0914
         """Compile `op_system` specification and prepare stepper and shape helpers."""
         del context
 
@@ -177,7 +177,7 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
         return cast("SystemProtocol", bound)
 
     @override
-    def requested_parameters(
+    def requested_parameters(  # noqa: C901, PLR0912
         self,
         axes: AxisCollection,
     ) -> dict[IdentifierString, ParameterRequest]:
@@ -186,8 +186,14 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
         Returns:
             Mapping of parameter name to a `ParameterRequest`. Names that
             appear as shaped-parameter references (``theta[imm]``) in the
-            spec are requested as shaped (one ndarray); everything else is
-            requested as a scalar.
+            spec are requested as shaped (one ndarray); time-varying
+            parameters (e.g. ``beta[time, age]``) are requested with their
+            full axes including the configured time axis.
+
+        Raises:
+            ValueError: If an `initial_state` entry has an unexpected type,
+                or a shaped IC entry collides with an existing request that
+                declares a different axis tuple for the same parameter name.
 
         Notes:
             Initial-state seed names (referenced from `meta['initial_state']`
@@ -201,15 +207,30 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
         # (numpy/jax namespace, simulation time, and built-in summation helpers).
         builtin_names = {"np", "t", "sum_state", "sum_prefix"}
 
-        # Shaped parameters first, so a later scalar-name collision is a hard
-        # error rather than a silent overwrite.
+        # Non-time-varying shaped parameters first.  ``shaped_params`` in
+        # meta carries reduced (non-time) axes for tv params, but tv names
+        # are emitted separately below with their full axes; skip them here.
         shaped_meta = self._compiled_rhs.meta.get("shaped_params") or ()
+        time_varying_meta = self._compiled_rhs.meta.get("time_varying_params") or ()
+        time_varying_names = {name for name, _ in time_varying_meta}
         for shaped_name, shaped_axes in shaped_meta:
             if shaped_name in mixing_kernel_names or shaped_name in builtin_names:
+                continue
+            if shaped_name in time_varying_names:
                 continue
             requests[shaped_name] = ParameterRequest(
                 name=shaped_name, axes=tuple(shaped_axes)
             )
+
+        # Time-varying parameters: a single ParameterRequest per name with
+        # the full axes tuple (including the configured time axis).  At
+        # call time the compiled wrapper interpolates along the time axis
+        # using the time axis's declared ``coords`` as the grid, so the
+        # supplied array must be shaped exactly as declared in the spec.
+        for tv_name, tv_axes in time_varying_meta:
+            if tv_name in mixing_kernel_names or tv_name in builtin_names:
+                continue
+            requests[tv_name] = ParameterRequest(name=tv_name, axes=tuple(tv_axes))
 
         for name in self._compiled_rhs.param_names:
             if name in mixing_kernel_names or name in builtin_names or name in requests:
@@ -231,23 +252,25 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
                 existing = requests.get(shaped_name)
                 if existing is not None:
                     if tuple(existing.axes) != shaped_axes:
-                        raise ValueError(
+                        msg = (
                             f"initial_state shaped entry for "
                             f"{shaped_name!r} declares axes "
                             f"{shaped_axes!r} but the same name was "
                             f"already requested with axes "
                             f"{tuple(existing.axes)!r}"
                         )
+                        raise ValueError(msg)
                     continue
                 requests[shaped_name] = ParameterRequest(
                     name=shaped_name, axes=shaped_axes
                 )
             else:
-                raise ValueError(
+                msg = (
                     f"initial_state entry has unexpected type "
                     f"{type(entry).__name__!r}; expected a parameter name "
                     "string or a shaped-entry mapping"
                 )
+                raise ValueError(msg)
         # Operator velocity/rate fields are consumed by engine plugins (not by
         # the compiled rhs eval_fn), but still need to be in the params dict.
         for op in self._compiled_rhs.meta.get("operators") or ():

--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -541,3 +541,50 @@ def test_requested_parameters_includes_operator_velocity() -> None:
     sys = OpSystemSystem(spec=spec)
     requested = set(sys.requested_parameters(AxisCollection()).keys())
     assert "waning_rate" in requested
+
+
+def test_requested_parameters_emits_full_axes_for_time_varying() -> None:
+    """Time-varying names emit a single ParameterRequest with full axes."""
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "axes": [
+            {"name": "age", "coords": ["young", "old"]},
+            {
+                "name": "time",
+                "type": "continuous",
+                "domain": {"lb": 0.0, "ub": 1.0},
+                "size": 2,
+            },
+        ],
+        "state": ["S[age]"],
+        "equations": {"S[age]": "-nu[time, age] * S[age] - beta[time] * S[age]"},
+    }
+    sys = OpSystemSystem(spec=spec)
+    requested = sys.requested_parameters(AxisCollection())
+    # Each time-varying name appears once with its declared full axes;
+    # no _grid/_ts pair anymore.
+    assert "nu_grid" not in requested
+    assert "beta_ts" not in requested
+    assert requested["nu"].axes == ("time", "age")
+    assert requested["beta"].axes == ("time",)
+
+
+def test_requested_parameters_honours_time_axis_option() -> None:
+    """The time axis name is configurable via the spec's ``time_axis`` field."""
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "axes": [
+            {
+                "name": "day",
+                "type": "continuous",
+                "domain": {"lb": 0.0, "ub": 1.0},
+                "size": 2,
+            }
+        ],
+        "state": ["S"],
+        "equations": {"S": "-beta[day] * S"},
+        "time_axis": "day",
+    }
+    sys = OpSystemSystem(spec=spec)
+    requested = sys.requested_parameters(AxisCollection())
+    assert requested["beta"].axes == ("day",)

--- a/justfile
+++ b/justfile
@@ -81,7 +81,7 @@ test-provider: provider-sync
 [group('dev')]
 provider-sync:
 	cd {{provider_dir}} && uv venv --clear
-	cd {{provider_dir}} && uv sync --dev
+	cd {{provider_dir}} && uv sync --dev --reinstall-package op-system
 
 # Run type checks in both packages
 [group('dev')]

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -21,7 +21,7 @@ from itertools import product
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterable, Mapping, Sequence
 
 from op_system._axes import (
     _compute_axis_deltas,
@@ -37,6 +37,7 @@ from op_system._helpers import (
 )
 from op_system._symbols import _collect_names, _parse_expr
 from op_system._templates import (
+    _INLINE_TEMPLATE_RE,
     PinnedToken,
     SelectorToken,
     WildcardToken,
@@ -117,6 +118,7 @@ class NormalizedRhs:
     all_symbols: frozenset[str]
     meta: Mapping[str, Any]
     state_templates: tuple[StateTemplate, ...] = ()
+    shaped_params: tuple[tuple[str, tuple[str, ...]], ...] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -734,6 +736,60 @@ def _collect_alias_symbols(
     return symbols
 
 
+_SHAPED_PARAM_BUILTIN_NAMES: frozenset[str] = frozenset(
+    {"np", "t", "sum_state", "sum_prefix"}
+)
+
+
+def _scan_shaped_param_refs(
+    expressions: Iterable[str],
+    *,
+    name_blocklist: set[str],
+    axis_lookup: Mapping[str, list[str]],
+) -> dict[str, tuple[str, ...]]:
+    """Scan expressions for shaped-parameter references.
+
+    A shaped parameter reference is a token of the form ``name[ax1,ax2,...]``
+    where ``name`` is not in ``name_blocklist`` (states, aliases, recognized
+    built-ins) and every bracket entry is a bare axis name (no pinned coords)
+    registered in ``axis_lookup``.  Each such ``name`` is recorded as shaped
+    over the tuple of axes appearing in its first occurrence; subsequent
+    occurrences must use the same axes in the same order.
+
+    Returns:
+        Mapping from base name to its registered axes tuple.
+
+    Raises:
+        InvalidRhsSpecError: If a name is referenced with inconsistent axes.
+    """
+    result: dict[str, tuple[str, ...]] = {}
+    for expr in expressions:
+        if not expr:
+            continue
+        for match in _INLINE_TEMPLATE_RE.finditer(expr):
+            base = match.group(1)
+            if base in name_blocklist or base in _SHAPED_PARAM_BUILTIN_NAMES:
+                continue
+            inner = match.group(2)
+            parts = [p.strip() for p in inner.split(",")]
+            if not parts or any(not p or "=" in p for p in parts):
+                continue
+            if any(p not in axis_lookup for p in parts):
+                continue
+            axes_tuple = tuple(parts)
+            if base in result:
+                if result[base] != axes_tuple:
+                    raise InvalidRhsSpecError(
+                        detail=(
+                            f"shaped parameter {base!r} referenced with "
+                            f"inconsistent axes: {result[base]} vs {axes_tuple}"
+                        )
+                    )
+            else:
+                result[base] = axes_tuple
+    return result
+
+
 def _build_state_templates(
     state_raw: list[str],
     *,
@@ -858,6 +914,8 @@ def _expand_alias_templates(
     *,
     axes: list[dict[str, Any]],
     template_map_seed: Mapping[str, list[tuple[str, dict[str, str]]]],
+    shaped_params: Mapping[str, tuple[str, ...]] | None = None,
+    axis_lookup: Mapping[str, list[str]] | None = None,
 ) -> tuple[dict[str, str], dict[str, list[tuple[str, dict[str, str]]]]]:
     """Expand templated alias names and substitute inline placeholders.
 
@@ -890,6 +948,8 @@ def _expand_alias_templates(
                     expr_s,
                     assignment=assignment,
                     template_map=combined_template_map,
+                    shaped_params=shaped_params,
+                    axis_lookup=axis_lookup,
                 )
                 aliases_out[expanded_name] = substituted
         else:
@@ -1124,6 +1184,7 @@ class _TransitionEndpoints:
     axes: list[dict[str, Any]]
     template_map: Mapping[str, list[tuple[str, dict[str, str]]]]
     axis_lookup: dict[str, list[str]]
+    shaped_params: Mapping[str, tuple[str, ...]] | None = None
 
 
 def _collect_transition_wildcard_axes(
@@ -1140,9 +1201,14 @@ def _collect_transition_wildcard_axes(
         if isinstance(tok, WildcardToken) and tok.axis not in seen:
             wildcard_axes.append(tok.axis)
             seen.add(tok.axis)
-    expr_placeholders = _extract_placeholders_from_expr(endpoints.rate_s)
+    skip = set(endpoints.shaped_params or {})
+    expr_placeholders = _extract_placeholders_from_expr(
+        endpoints.rate_s, shaped_param_names=skip
+    )
     if endpoints.name_s:
-        expr_placeholders |= _extract_placeholders_from_expr(endpoints.name_s)
+        expr_placeholders |= _extract_placeholders_from_expr(
+            endpoints.name_s, shaped_param_names=skip
+        )
     for ph in sorted(expr_placeholders):
         if ph not in seen:
             if ph not in endpoints.axis_lookup:
@@ -1166,7 +1232,11 @@ def _render_transition_combo(
         Expanded transition mapping with concrete from/to/rate fields.
     """
     rate_sub = _apply_template_substitutions(
-        endpoints.rate_s, assignment=assignment, template_map=endpoints.template_map
+        endpoints.rate_s,
+        assignment=assignment,
+        template_map=endpoints.template_map,
+        shaped_params=endpoints.shaped_params,
+        axis_lookup=endpoints.axis_lookup,
     )
     tr_out: dict[str, Any] = dict(tr_base)
     tr_out["from"] = render_selector(
@@ -1184,7 +1254,11 @@ def _render_transition_combo(
     tr_out["rate"] = _expand_helpers(rate_sub, axes=endpoints.axes)
     if endpoints.name_s:
         tr_out["name"] = _apply_template_substitutions(
-            endpoints.name_s, assignment=assignment, template_map=endpoints.template_map
+            endpoints.name_s,
+            assignment=assignment,
+            template_map=endpoints.template_map,
+            shaped_params=endpoints.shaped_params,
+            axis_lookup=endpoints.axis_lookup,
         )
     return tr_out
 
@@ -1195,6 +1269,7 @@ def _expand_single_transition(
     axes: list[dict[str, Any]],
     template_map: Mapping[str, list[tuple[str, dict[str, str]]]],
     axis_lookup: dict[str, list[str]],
+    shaped_params: Mapping[str, tuple[str, ...]] | None = None,
 ) -> list[dict[str, Any]]:
     """Expand one transition template over all wildcard combinations.
 
@@ -1222,6 +1297,7 @@ def _expand_single_transition(
         axes=axes,
         template_map=template_map,
         axis_lookup=axis_lookup,
+        shaped_params=shaped_params,
     )
     wildcard_axes = _collect_transition_wildcard_axes(endpoints)
 
@@ -1251,6 +1327,7 @@ def _expand_transition_templates(
     *,
     axes: list[dict[str, Any]],
     template_map: Mapping[str, list[tuple[str, dict[str, str]]]],
+    shaped_params: Mapping[str, tuple[str, ...]] | None = None,
 ) -> list[dict[str, Any]]:
     """Expand templated transitions over categorical axes.
 
@@ -1271,6 +1348,7 @@ def _expand_transition_templates(
                 axes=axes,
                 template_map=template_map,
                 axis_lookup=axis_lookup,
+                shaped_params=shaped_params,
             )
         )
     return expanded
@@ -1862,6 +1940,8 @@ def _resolve_template_equation(
     axes: list[dict[str, Any]],
     template_map: Mapping[str, list[tuple[str, dict[str, str]]]],
     all_syms: set[str],
+    shaped_params: Mapping[str, tuple[str, ...]] | None = None,
+    axis_lookup: Mapping[str, list[str]] | None = None,
 ) -> str | None:
     """Resolve an equation for a templated state name.
 
@@ -1882,7 +1962,11 @@ def _resolve_template_equation(
                 )
             expr_s = _expand_helpers(expr.strip(), axes=axes)
             expr_s = _apply_template_substitutions(
-                expr_s, assignment=assignment, template_map=template_map
+                expr_s,
+                assignment=assignment,
+                template_map=template_map,
+                shaped_params=shaped_params,
+                axis_lookup=axis_lookup,
             )
             tree = _parse_expr(expr_s)
             all_syms |= _collect_names(tree)
@@ -1897,6 +1981,8 @@ def _gather_equations(
     *,
     axes: list[dict[str, Any]],
     template_map: Mapping[str, list[tuple[str, dict[str, str]]]] | None = None,
+    shaped_params: Mapping[str, tuple[str, ...]] | None = None,
+    axis_lookup: Mapping[str, list[str]] | None = None,
 ) -> list[str]:
     """Gather and expand one equation string per state variable.
 
@@ -1927,6 +2013,8 @@ def _gather_equations(
             axes=axes,
             template_map=template_map,
             all_syms=all_syms,
+            shaped_params=shaped_params,
+            axis_lookup=axis_lookup,
         )
         if expr_res is None:
             raise InvalidRhsSpecError(detail=f"Missing equation for state {name!r}")
@@ -2483,8 +2571,32 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:
     if len(state_expanded) != len(set(state_expanded)):
         raise InvalidRhsSpecError(detail="expanded state contains duplicates")
 
+    # Pre-scan raw aliases + equations for shaped-parameter references before
+    # alias/template expansion mangles bracketed bases into per-coord names.
+    axis_lookup_dict: dict[str, list[str]] = build_axis_lookup(axes_meta)
+    aliases_raw_map = meta_parts[0] or {}
+    name_blocklist = (
+        {parse_selector(s)[0] for s in state_raw}
+        | set(state_expanded)
+        | {parse_selector(_normalize_bracket_key(k))[0] for k in aliases_raw_map}
+        | set(aliases_raw_map.keys())
+    )
+    raw_expressions: list[str] = [
+        v for v in aliases_raw_map.values() if isinstance(v, str)
+    ]
+    raw_expressions.extend(v for v in equations_map.values() if isinstance(v, str))
+    shaped_params = _scan_shaped_param_refs(
+        raw_expressions,
+        name_blocklist=name_blocklist,
+        axis_lookup=axis_lookup_dict,
+    )
+
     aliases, alias_template_map = _expand_alias_templates(
-        meta_parts[0], axes=axes_meta, template_map_seed=state_template_map
+        meta_parts[0],
+        axes=axes_meta,
+        template_map_seed=state_template_map,
+        shaped_params=shaped_params,
+        axis_lookup=axis_lookup_dict,
     )
     template_map_all = {**state_template_map, **alias_template_map}
 
@@ -2515,6 +2627,8 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:
         all_syms,
         axes=axes_meta,
         template_map=template_map_all,
+        shaped_params=shaped_params,
+        axis_lookup=axis_lookup_dict,
     )
 
     _maybe_attach_initial_state(
@@ -2524,6 +2638,9 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:
         template_map=template_map_all,
     )
 
+    meta["shaped_params"] = tuple(sorted(shaped_params.items()))
+
+    shaped_set = set(shaped_params)
     return NormalizedRhs(
         kind="expr",
         state_names=tuple(state_expanded),
@@ -2532,7 +2649,9 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:
         param_names=_sorted_unique(
             sym
             for sym in all_syms
-            if sym not in set(state_expanded) and sym not in aliases
+            if sym not in set(state_expanded)
+            and sym not in aliases
+            and sym not in shaped_set
         ),
         all_symbols=frozenset(all_syms | set(aliases.keys())),
         meta=meta,
@@ -2542,6 +2661,7 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:
             state_template_map=state_template_map,
             state_expanded=state_expanded,
         ),
+        shaped_params=tuple(sorted(shaped_params.items())),
     )
 
 
@@ -2663,8 +2783,38 @@ def normalize_transitions_rhs(
     if len(state_expanded) != len(set(state_expanded)):
         raise InvalidRhsSpecError(detail="expanded state contains duplicates")
 
+    # Pre-scan raw aliases + transition rates for shaped-parameter references.
+    axis_lookup_dict: dict[str, list[str]] = build_axis_lookup(axes_meta)
+    aliases_raw_map = meta_parts[0] or {}
+    name_blocklist = (
+        {parse_selector(s)[0] for s in state_raw}
+        | set(state_expanded)
+        | {parse_selector(_normalize_bracket_key(k))[0] for k in aliases_raw_map}
+        | set(aliases_raw_map.keys())
+    )
+    raw_expressions: list[str] = [
+        v for v in aliases_raw_map.values() if isinstance(v, str)
+    ]
+    for tr in transitions_raw:
+        if isinstance(tr, _MappingABC):
+            r = tr.get("rate")
+            if isinstance(r, str):
+                raw_expressions.append(r)
+            n = tr.get("name")
+            if isinstance(n, str):
+                raw_expressions.append(n)
+    shaped_params = _scan_shaped_param_refs(
+        raw_expressions,
+        name_blocklist=name_blocklist,
+        axis_lookup=axis_lookup_dict,
+    )
+
     aliases, alias_template_map = _expand_alias_templates(
-        meta_parts[0], axes=axes_meta, template_map_seed=state_template_map
+        meta_parts[0],
+        axes=axes_meta,
+        template_map_seed=state_template_map,
+        shaped_params=shaped_params,
+        axis_lookup=axis_lookup_dict,
     )
     template_map_all = {**state_template_map, **alias_template_map}
 
@@ -2690,6 +2840,7 @@ def normalize_transitions_rhs(
         transitions_raw,
         axes=axes_meta,
         template_map=template_map_all,
+        shaped_params=shaped_params,
     )
 
     for idx, tr_map in enumerate(transitions_expanded):
@@ -2708,13 +2859,18 @@ def normalize_transitions_rhs(
         template_map=template_map_all,
     )
 
+    meta["shaped_params"] = tuple(sorted(shaped_params.items()))
+
+    shaped_set = set(shaped_params)
     return NormalizedRhs(
         kind="transitions",
         state_names=tuple(state_expanded),
         equations=tuple(_build_transition_equations(state_expanded, d_terms)),
         aliases=aliases,
         param_names=_sorted_unique(
-            sym for sym in all_syms if sym not in state_set and sym not in aliases
+            sym
+            for sym in all_syms
+            if sym not in state_set and sym not in aliases and sym not in shaped_set
         ),
         all_symbols=frozenset(all_syms | set(aliases.keys())),
         meta={**meta, "transitions": transitions_expanded},
@@ -2724,4 +2880,5 @@ def normalize_transitions_rhs(
             state_template_map=state_template_map,
             state_expanded=state_expanded,
         ),
+        shaped_params=tuple(sorted(shaped_params.items())),
     )

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -119,6 +119,7 @@ class NormalizedRhs:
     meta: Mapping[str, Any]
     state_templates: tuple[StateTemplate, ...] = ()
     shaped_params: tuple[tuple[str, tuple[str, ...]], ...] = ()
+    time_varying_params: tuple[tuple[str, tuple[str, ...]], ...] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -736,9 +737,12 @@ def _collect_alias_symbols(
     return symbols
 
 
-_SHAPED_PARAM_BUILTIN_NAMES: frozenset[str] = frozenset(
-    {"np", "t", "sum_state", "sum_prefix"}
-)
+_SHAPED_PARAM_BUILTIN_NAMES: frozenset[str] = frozenset({
+    "np",
+    "t",
+    "sum_state",
+    "sum_prefix",
+})
 
 
 def _scan_shaped_param_refs(
@@ -788,6 +792,135 @@ def _scan_shaped_param_refs(
             else:
                 result[base] = axes_tuple
     return result
+
+
+def _resolve_time_axis_name(spec: Mapping[str, Any]) -> str:
+    """Return the configured time-axis name (default ``"time"``).
+
+    Raises:
+        InvalidRhsSpecError: If ``time_axis`` is present but not a non-empty
+            string.
+    """
+    raw = spec.get("time_axis", "time")
+    if not isinstance(raw, str) or not raw.strip():
+        raise InvalidRhsSpecError(
+            detail="time_axis must be a non-empty identifier string"
+        )
+    return raw.strip()
+
+
+def _reject_legacy_time_varying_field(spec: Mapping[str, Any]) -> None:
+    """Raise a migration-friendly error if the legacy ``time_varying`` field is present.
+
+    Time-varying parameters are now declared implicitly: any shaped reference
+    such as ``beta[time, age]`` (where ``time`` matches the configured
+    ``time_axis``) is interpolated at runtime.
+
+    Raises:
+        InvalidRhsSpecError: If ``spec`` contains a ``time_varying`` key.
+    """
+    if "time_varying" in spec:
+        raise InvalidRhsSpecError(
+            detail=(
+                "the top-level 'time_varying' field has been removed; declare "
+                "time-varying parameters implicitly by subscripting them with "
+                "the configured time axis (default 'time'), e.g. "
+                "'beta[time, age]'."
+            )
+        )
+
+
+def _partition_time_varying_shaped(
+    shaped_params: Mapping[str, tuple[str, ...]],
+    *,
+    time_axis_name: str,
+    axis_lookup: Mapping[str, list[str]],
+) -> tuple[dict[str, tuple[str, ...]], dict[str, tuple[str, ...]]]:
+    """Split shaped-parameter axes into non-time-varying and time-varying.
+
+    A shaped parameter is "time-varying" when the configured time axis
+    appears in its axes tuple.  The returned ``shaped_reduced`` mapping
+    drops the time axis from each tv parameter so downstream substitution
+    treats it as a shape over the remaining (non-time) axes; the
+    ``time_varying_full`` mapping retains the full axes tuple (with time)
+    for the parameter request and the runtime interpolation wrapper.
+
+    Returns:
+        Pair ``(shaped_reduced, time_varying_full)``.
+
+    Raises:
+        InvalidRhsSpecError: If a parameter declares the time axis but the
+            axis itself was not declared in the spec's ``axes`` block.
+    """
+    shaped_reduced: dict[str, tuple[str, ...]] = {}
+    time_varying_full: dict[str, tuple[str, ...]] = {}
+    for name, axes in shaped_params.items():
+        if time_axis_name not in axes:
+            shaped_reduced[name] = axes
+            continue
+        if time_axis_name not in axis_lookup:
+            raise InvalidRhsSpecError(
+                detail=(
+                    f"parameter {name!r} is subscripted with the time axis "
+                    f"{time_axis_name!r} but no such axis is declared in 'axes'"
+                )
+            )
+        reduced = tuple(ax for ax in axes if ax != time_axis_name)
+        shaped_reduced[name] = reduced
+        time_varying_full[name] = axes
+    return shaped_reduced, time_varying_full
+
+
+def _strip_time_axis_in_expr(
+    expr: str,
+    *,
+    tv_full_axes: Mapping[str, tuple[str, ...]],
+    time_axis_name: str,
+) -> str:
+    """Rewrite ``name[time, age]`` → ``name[age]`` (or bare ``name``) in ``expr``.
+
+    Only matches bracket templates whose base appears in ``tv_full_axes``
+    and whose bracket entries equal the registered full axes tuple.
+
+    Returns:
+        The rewritten expression.
+    """
+    if not tv_full_axes or not expr:
+        return expr
+
+    def _rewrite(match: re.Match[str]) -> str:
+        base = match.group(1)
+        full = tv_full_axes.get(base)
+        if full is None:
+            return match.group(0)
+        parts = tuple(p.strip() for p in match.group(2).split(","))
+        if parts != full:
+            return match.group(0)
+        reduced = tuple(p for p in parts if p != time_axis_name)
+        if not reduced:
+            return base
+        return f"{base}[{', '.join(reduced)}]"
+
+    return _INLINE_TEMPLATE_RE.sub(_rewrite, expr)
+
+
+def _strip_time_axis_in_mapping(
+    mapping: dict[str, Any],
+    *,
+    tv_full_axes: Mapping[str, tuple[str, ...]],
+    time_axis_name: str,
+) -> None:
+    """In-place rewrite of all string values in ``mapping``.
+
+    Delegates to :func:`_strip_time_axis_in_expr` for each value.
+    """
+    if not tv_full_axes:
+        return
+    for key, value in list(mapping.items()):
+        if isinstance(value, str):
+            mapping[key] = _strip_time_axis_in_expr(
+                value, tv_full_axes=tv_full_axes, time_axis_name=time_axis_name
+            )
 
 
 def _build_state_templates(
@@ -960,9 +1093,10 @@ def _expand_alias_templates(
 
 _INITIAL_STATE_SHAPED_KEY = "shaped"
 _INITIAL_STATE_SHAPED_AXES_KEY = "axes"
-_INITIAL_STATE_SHAPED_ALLOWED_KEYS = frozenset(
-    (_INITIAL_STATE_SHAPED_KEY, _INITIAL_STATE_SHAPED_AXES_KEY)
-)
+_INITIAL_STATE_SHAPED_ALLOWED_KEYS = frozenset((
+    _INITIAL_STATE_SHAPED_KEY,
+    _INITIAL_STATE_SHAPED_AXES_KEY,
+))
 
 
 def _normalize_shaped_initial_state_value(
@@ -1573,7 +1707,7 @@ def _select_apply_along_kernel(
     )
 
 
-def _substitute_apply_along_brackets(
+def _substitute_apply_along_brackets(  # noqa: C901
     expr: str,
     bound: Mapping[str, str],
     *,
@@ -1609,8 +1743,11 @@ def _substitute_apply_along_brackets(
         Walks ``__``-separated segments from the right, consuming each one
         whose ``<axis>_`` prefix matches a known axis.  Stops at the first
         non-matching segment; everything to its left is treated as the base
-        name.  Returns ``(base, [(axis, coord), ...])`` where the suffix
-        pairs are in left-to-right (original) order.
+        name.
+
+        Returns:
+            ``(base, [(axis, coord), ...])`` where the suffix pairs are in
+            left-to-right (original) order.
         """
         if not priority:
             return name, []
@@ -1625,9 +1762,12 @@ def _substitute_apply_along_brackets(
             # axis names share a prefix.
             best: str | None = None
             for ax in priority:
-                if tok.startswith(f"{ax}_") and len(tok) > len(ax) + 1:
-                    if best is None or len(ax) > len(best):
-                        best = ax
+                if (
+                    tok.startswith(f"{ax}_")
+                    and len(tok) > len(ax) + 1
+                    and (best is None or len(ax) > len(best))
+                ):
+                    best = ax
             if best is None:
                 break
             coord = tok[len(best) + 1 :]
@@ -1933,7 +2073,7 @@ def _expand_helpers(expr: str, *, axes: list[dict[str, Any]]) -> str:
     return _expand_apply_along(expr, axes=axes)
 
 
-def _resolve_template_equation(
+def _resolve_template_equation(  # noqa: PLR0913
     *,
     name: str,
     equations_map: Mapping[str, Any],
@@ -1974,7 +2114,7 @@ def _resolve_template_equation(
     return None
 
 
-def _gather_equations(
+def _gather_equations(  # noqa: PLR0913
     state: list[str],
     equations_map: Mapping[str, Any],
     all_syms: set[str],
@@ -2282,13 +2422,11 @@ def _apply_transition_chains(
 
         if entry_cfg is not None:
             entry_from, entry_rate = entry_cfg
-            transitions_raw.append(
-                {
-                    "from": entry_from,
-                    "to": stage_names[0],
-                    "rate": entry_rate,
-                }
-            )
+            transitions_raw.append({
+                "from": entry_from,
+                "to": stage_names[0],
+                "rate": entry_rate,
+            })
 
         transitions_raw.extend(
             {
@@ -2301,13 +2439,11 @@ def _apply_transition_chains(
 
         if exit_cfg is not None:
             sink_s, sink_rate = exit_cfg
-            transitions_raw.append(
-                {
-                    "from": stage_names[-1],
-                    "to": sink_s,
-                    "rate": sink_rate or forward_rates[-1],
-                }
-            )
+            transitions_raw.append({
+                "from": stage_names[-1],
+                "to": sink_s,
+                "rate": sink_rate or forward_rates[-1],
+            })
 
 
 # ---------------------------------------------------------------------------
@@ -2524,7 +2660,7 @@ def normalize_rhs(spec: Mapping[str, Any] | None) -> NormalizedRhs:
     return normalize_expr_rhs(spec)  # unreachable; satisfies return type checker
 
 
-def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:
+def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:  # noqa: C901, PLR0914
     """Normalize an expression-based RHS specification.
 
     Args:
@@ -2590,6 +2726,25 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:
         name_blocklist=name_blocklist,
         axis_lookup=axis_lookup_dict,
     )
+    _reject_legacy_time_varying_field(spec)
+    time_axis_name = _resolve_time_axis_name(spec)
+    shaped_params, time_varying_full = _partition_time_varying_shaped(
+        shaped_params,
+        time_axis_name=time_axis_name,
+        axis_lookup=axis_lookup_dict,
+    )
+    if time_varying_full:
+        _strip_time_axis_in_mapping(
+            equations_map,
+            tv_full_axes=time_varying_full,
+            time_axis_name=time_axis_name,
+        )
+        if isinstance(meta_parts[0], dict):
+            _strip_time_axis_in_mapping(
+                meta_parts[0],
+                tv_full_axes=time_varying_full,
+                time_axis_name=time_axis_name,
+            )
 
     aliases, alias_template_map = _expand_alias_templates(
         meta_parts[0],
@@ -2639,8 +2794,11 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:
     )
 
     meta["shaped_params"] = tuple(sorted(shaped_params.items()))
+    meta["time_axis"] = time_axis_name
+    meta["time_varying_params"] = tuple(sorted(time_varying_full.items()))
 
     shaped_set = set(shaped_params)
+    time_varying_set = set(time_varying_full)
     return NormalizedRhs(
         kind="expr",
         state_names=tuple(state_expanded),
@@ -2652,6 +2810,7 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:
             if sym not in set(state_expanded)
             and sym not in aliases
             and sym not in shaped_set
+            and sym not in time_varying_set
         ),
         all_symbols=frozenset(all_syms | set(aliases.keys())),
         meta=meta,
@@ -2662,6 +2821,7 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:
             state_expanded=state_expanded,
         ),
         shaped_params=tuple(sorted(shaped_params.items())),
+        time_varying_params=tuple(sorted(time_varying_full.items())),
     )
 
 
@@ -2723,7 +2883,7 @@ def _build_transition_equations(
     return equations
 
 
-def normalize_transitions_rhs(
+def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
     spec: Mapping[str, Any],
 ) -> NormalizedRhs:
     """Normalize a transition-based RHS specification (diagram/hazard semantics).
@@ -2762,9 +2922,9 @@ def normalize_transitions_rhs(
         "kernels": meta_parts[2],
         "operators": meta_parts[3],
     }
-    meta.update(
-        {k: spec[k] for k in ("sources", "couplings", "constraints") if k in spec}
-    )
+    meta.update({
+        k: spec[k] for k in ("sources", "couplings", "constraints") if k in spec
+    })
 
     chain_block = spec.get("chain")
     if chain_block:
@@ -2808,6 +2968,37 @@ def normalize_transitions_rhs(
         name_blocklist=name_blocklist,
         axis_lookup=axis_lookup_dict,
     )
+    _reject_legacy_time_varying_field(spec)
+    time_axis_name = _resolve_time_axis_name(spec)
+    shaped_params, time_varying_full = _partition_time_varying_shaped(
+        shaped_params,
+        time_axis_name=time_axis_name,
+        axis_lookup=axis_lookup_dict,
+    )
+    if time_varying_full:
+        if isinstance(meta_parts[0], dict):
+            _strip_time_axis_in_mapping(
+                meta_parts[0],
+                tv_full_axes=time_varying_full,
+                time_axis_name=time_axis_name,
+            )
+        for tr in transitions_raw:
+            if not isinstance(tr, _MappingABC):
+                continue
+            r = tr.get("rate")
+            if isinstance(r, str):
+                tr["rate"] = _strip_time_axis_in_expr(  # type: ignore[index]
+                    r,
+                    tv_full_axes=time_varying_full,
+                    time_axis_name=time_axis_name,
+                )
+            n = tr.get("name")
+            if isinstance(n, str):
+                tr["name"] = _strip_time_axis_in_expr(  # type: ignore[index]
+                    n,
+                    tv_full_axes=time_varying_full,
+                    time_axis_name=time_axis_name,
+                )
 
     aliases, alias_template_map = _expand_alias_templates(
         meta_parts[0],
@@ -2860,8 +3051,11 @@ def normalize_transitions_rhs(
     )
 
     meta["shaped_params"] = tuple(sorted(shaped_params.items()))
+    meta["time_axis"] = time_axis_name
+    meta["time_varying_params"] = tuple(sorted(time_varying_full.items()))
 
     shaped_set = set(shaped_params)
+    time_varying_set = set(time_varying_full)
     return NormalizedRhs(
         kind="transitions",
         state_names=tuple(state_expanded),
@@ -2870,7 +3064,10 @@ def normalize_transitions_rhs(
         param_names=_sorted_unique(
             sym
             for sym in all_syms
-            if sym not in state_set and sym not in aliases and sym not in shaped_set
+            if sym not in state_set
+            and sym not in aliases
+            and sym not in shaped_set
+            and sym not in time_varying_set
         ),
         all_symbols=frozenset(all_syms | set(aliases.keys())),
         meta={**meta, "transitions": transitions_expanded},
@@ -2881,4 +3078,5 @@ def normalize_transitions_rhs(
             state_expanded=state_expanded,
         ),
         shaped_params=tuple(sorted(shaped_params.items())),
+        time_varying_params=tuple(sorted(time_varying_full.items())),
     )

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -15,12 +15,13 @@ types and functions are re-exported from ``specs.py`` for backward compat.
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping as _MappingABC
 from dataclasses import dataclass
 from itertools import product
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
 
 from op_system._axes import (
     _compute_axis_deltas,
@@ -897,20 +898,129 @@ def _expand_alias_templates(
     return aliases_out, alias_template_map
 
 
+_INITIAL_STATE_SHAPED_KEY = "shaped"
+_INITIAL_STATE_SHAPED_AXES_KEY = "axes"
+_INITIAL_STATE_SHAPED_ALLOWED_KEYS = frozenset(
+    (_INITIAL_STATE_SHAPED_KEY, _INITIAL_STATE_SHAPED_AXES_KEY)
+)
+
+
+def _normalize_shaped_initial_state_value(
+    raw_val: Mapping[str, Any],
+    *,
+    raw_key: str,
+    axis_lookup: dict[str, list[str]],
+) -> tuple[str, tuple[str, ...]]:
+    """Validate a shaped-initial-state value mapping.
+
+    A shaped IC entry looks like::
+
+        X[age, vax, loc, imm]:
+          shaped: x_init
+          axes: [age, vax, loc, imm]
+
+    The ``shaped`` field names a single parameter that is shaped over
+    ``axes``; downstream provider/engine code is responsible for emitting
+    one ParameterRequest per ``(name, axes)`` pair and indexing per cell
+    by the assignment of the LHS wildcards.
+
+    Returns:
+        ``(name, axes_tuple)`` where ``axes_tuple`` preserves the user's
+        declared axis order (no implicit reordering — engine plugins may
+        choose to transpose the resolved value into the LHS order).
+
+    Raises:
+        InvalidRhsSpecError: If validation fails.
+    """
+    extra_keys = set(raw_val.keys()) - _INITIAL_STATE_SHAPED_ALLOWED_KEYS
+    if extra_keys:
+        raise InvalidRhsSpecError(
+            detail=(
+                f"initial_state[{raw_key!r}] shaped entry has unknown "
+                f"keys {sorted(extra_keys)!r}; allowed keys are "
+                f"{sorted(_INITIAL_STATE_SHAPED_ALLOWED_KEYS)!r}"
+            ),
+        )
+    name_obj = raw_val.get(_INITIAL_STATE_SHAPED_KEY)
+    if not isinstance(name_obj, str) or not name_obj.strip():
+        raise InvalidRhsSpecError(
+            detail=(
+                f"initial_state[{raw_key!r}] shaped entry must set "
+                f"{_INITIAL_STATE_SHAPED_KEY!r} to a non-empty string"
+            ),
+        )
+    name = name_obj.strip()
+    if not name.isidentifier():
+        raise InvalidRhsSpecError(
+            detail=(
+                f"initial_state[{raw_key!r}] shaped name {name!r} is not "
+                "a valid identifier"
+            ),
+        )
+    axes_obj = raw_val.get(_INITIAL_STATE_SHAPED_AXES_KEY)
+    if not isinstance(axes_obj, (list, tuple)) or not axes_obj:
+        raise InvalidRhsSpecError(
+            detail=(
+                f"initial_state[{raw_key!r}] shaped entry must set "
+                f"{_INITIAL_STATE_SHAPED_AXES_KEY!r} to a non-empty list "
+                "of axis names"
+            ),
+        )
+    axes_list: list[str] = []
+    seen: set[str] = set()
+    for ax in axes_obj:
+        if not isinstance(ax, str) or not ax.strip():
+            raise InvalidRhsSpecError(
+                detail=(
+                    f"initial_state[{raw_key!r}] shaped axes must be non-empty strings"
+                ),
+            )
+        ax_s = ax.strip()
+        if ax_s in seen:
+            raise InvalidRhsSpecError(
+                detail=(
+                    f"initial_state[{raw_key!r}] shaped axes contain duplicate {ax_s!r}"
+                ),
+            )
+        if ax_s not in axis_lookup:
+            raise InvalidRhsSpecError(
+                detail=(
+                    f"initial_state[{raw_key!r}] shaped axis {ax_s!r} not "
+                    "defined in spec axes"
+                ),
+            )
+        seen.add(ax_s)
+        axes_list.append(ax_s)
+    return name, tuple(axes_list)
+
+
 def _expand_initial_state_templates(
-    initial_state_raw: Mapping[str, str] | None,
+    initial_state_raw: Mapping[str, Any] | None,
     *,
     axes: list[dict[str, Any]],
     template_map: Mapping[str, list[tuple[str, dict[str, str]]]],
-) -> dict[str, str] | None:
-    """Expand a templated initial_state mapping into concrete state→param pairs.
+) -> dict[str, Any] | None:
+    """Expand a templated initial_state mapping into concrete state→entry pairs.
 
     Supports wildcard selectors (``X[age, vax]``), pinned selectors
-    (``X[age, vax, imm=X0]``), and bare state names.
+    (``X[age, vax, imm=X0]``), and bare state names on the key side.
+
+    Each value is one of:
+
+    * A non-empty string — the legacy *scalar* form.  Per-cell template
+      substitution (``S0[vax]`` → ``S0__vax_v1``) still applies, so the
+      expanded entry is a single parameter name string.
+    * A mapping with keys ``shaped`` (parameter identifier) and ``axes``
+      (list of axis names) — the new *shaped* form.  Every expanded state
+      cell is stored as a dict ``{"shaped": name, "axes": (...,),
+      "coords": {axis: coord, ...}}`` where ``coords`` selects which cell
+      of the shaped parameter fills this state.  All shaped axes must be
+      LHS wildcards (or pinned coords) so that every expansion has a
+      coordinate for each axis.
 
     Returns:
-        Expanded ``dict[str, str]`` mapping, or ``None`` if *initial_state_raw*
-        is ``None``.
+        Expanded ``dict[str, str | dict[str, Any]]`` mapping, or ``None``
+        if *initial_state_raw* is ``None``.
 
     Raises:
         InvalidRhsSpecError: If validation fails.
@@ -919,10 +1029,40 @@ def _expand_initial_state_templates(
         return None
 
     axis_lookup = build_axis_lookup(axes)
-    result: dict[str, str] = {}
+    result: dict[str, Any] = {}
     expanded_keys: list[str] = []
 
     for raw_key, raw_val in initial_state_raw.items():
+        if isinstance(raw_val, _MappingABC):
+            shaped_name, shaped_axes = _normalize_shaped_initial_state_value(
+                raw_val,
+                raw_key=raw_key,
+                axis_lookup=axis_lookup,
+            )
+            results = expand_selector(
+                raw_key,
+                axis_lookup=axis_lookup,
+                context=f"initial_state key {raw_key!r}",
+            )
+            for expanded_key, assignment in results:
+                missing = [ax for ax in shaped_axes if ax not in assignment]
+                if missing:
+                    raise InvalidRhsSpecError(
+                        detail=(
+                            f"initial_state[{raw_key!r}] shaped axes "
+                            f"{missing!r} are not bound by the LHS "
+                            "selector (each shaped axis must appear as a "
+                            "wildcard or pinned coord on the key)"
+                        ),
+                    )
+                expanded_keys.append(expanded_key)
+                result[expanded_key] = {
+                    "shaped": shaped_name,
+                    "axes": shaped_axes,
+                    "coords": {ax: assignment[ax] for ax in shaped_axes},
+                }
+            continue
+
         val_s = str(raw_val).strip()
         if not val_s:
             raise InvalidRhsSpecError(
@@ -951,7 +1091,7 @@ def _expand_initial_state_templates(
 
 def _maybe_attach_initial_state(
     meta: dict[str, Any],
-    initial_state_raw: Mapping[str, str] | None,
+    initial_state_raw: Mapping[str, Any] | None,
     *,
     axes: list[dict[str, Any]],
     template_map: Mapping[str, list[tuple[str, dict[str, str]]]],
@@ -1355,7 +1495,12 @@ def _select_apply_along_kernel(
     )
 
 
-def _substitute_apply_along_brackets(expr: str, bound: Mapping[str, str]) -> str:
+def _substitute_apply_along_brackets(
+    expr: str,
+    bound: Mapping[str, str],
+    *,
+    axis_order: Sequence[str] = (),
+) -> str:
     """Rewrite ``name[ax=c, ...]`` to ``name__ax_<c>__...`` for bound axes.
 
     For each ``name[...]`` subexpression, axis assignments whose axis is in
@@ -1364,11 +1509,70 @@ def _substitute_apply_along_brackets(expr: str, bound: Mapping[str, str]) -> str
     stay inside the brackets.  The bracket itself is dropped if every
     assignment is consumed.
 
+    When ``axis_order`` is provided (the canonical ordering taken from the
+    spec's ``axes:`` list), any pre-existing ``__<axis>_<coord>`` suffix on
+    ``name`` is parsed off, merged with the newly-consumed pairs, and the
+    combined suffix is re-emitted in canonical order.  This makes nested
+    ``apply_along`` calls (where the inner pass appends a partial suffix and
+    the outer pass appends more) yield the same canonical state name as a
+    direct expansion, e.g. ``X__age_..__vax_..__loc_..__imm_..`` rather than
+    the binding-order accident ``X__imm_..__age_..__vax_..__loc_..``.
+
     Returns:
         Expression string with bound bracket assignments folded into
         ``__axis_coord`` suffixes.
     """
     pat = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\[([^\[\]]*)\]")
+    priority = {ax: i for i, ax in enumerate(axis_order)}
+
+    def _split_suffix(name: str) -> tuple[str, list[tuple[str, str]]]:
+        """Strip trailing ``__<axis>_<coord>`` tokens recognised by axis_order.
+
+        Walks ``__``-separated segments from the right, consuming each one
+        whose ``<axis>_`` prefix matches a known axis.  Stops at the first
+        non-matching segment; everything to its left is treated as the base
+        name.  Returns ``(base, [(axis, coord), ...])`` where the suffix
+        pairs are in left-to-right (original) order.
+        """
+        if not priority:
+            return name, []
+        parts = name.split("__")
+        if len(parts) <= 1:
+            return name, []
+        suffix_pairs: list[tuple[str, str]] = []
+        cut = len(parts)
+        for i in range(len(parts) - 1, 0, -1):
+            tok = parts[i]
+            # Longest matching axis name keeps the parse unambiguous when
+            # axis names share a prefix.
+            best: str | None = None
+            for ax in priority:
+                if tok.startswith(f"{ax}_") and len(tok) > len(ax) + 1:
+                    if best is None or len(ax) > len(best):
+                        best = ax
+            if best is None:
+                break
+            coord = tok[len(best) + 1 :]
+            suffix_pairs.append((best, coord))
+            cut = i
+        if not suffix_pairs:
+            return name, []
+        suffix_pairs.reverse()
+        base = "__".join(parts[:cut])
+        return base, suffix_pairs
+
+    def _emit_suffix(pairs: list[tuple[str, str]]) -> str:
+        if not priority:
+            return "".join(f"__{ax}_{_sanitize_fragment(c)}" for ax, c in pairs)
+        # Sort by canonical priority; pairs whose axis is unknown to priority
+        # (shouldn't occur for well-formed specs) preserve their original
+        # order at the end.
+        known = sorted(
+            (p for p in pairs if p[0] in priority),
+            key=lambda p: priority[p[0]],
+        )
+        unknown = [p for p in pairs if p[0] not in priority]
+        return "".join(f"__{ax}_{_sanitize_fragment(c)}" for ax, c in known + unknown)
 
     def _sub(match: re.Match[str]) -> str:
         name = match.group(1)
@@ -1387,12 +1591,11 @@ def _substitute_apply_along_brackets(expr: str, bound: Mapping[str, str]) -> str
             remaining.append(entry)
         if not consumed:
             return match.group(0)
-        suffix = "".join(
-            f"__{ax}_{_sanitize_fragment(coord)}" for ax, coord in consumed
-        )
+        base, existing = _split_suffix(name)
+        suffix = _emit_suffix(existing + consumed)
         if remaining:
-            return f"{name}{suffix}[{', '.join(remaining)}]"
-        return f"{name}{suffix}"
+            return f"{base}{suffix}[{', '.join(remaining)}]"
+        return f"{base}{suffix}"
 
     return pat.sub(_sub, expr)
 
@@ -1599,6 +1802,7 @@ def _expand_apply_along(expr: str, *, axes: list[dict[str, Any]]) -> str:  # noq
         Expression string with ``apply_along`` calls fully expanded.
     """
     axis_lookup = {str(ax.get("name")): ax for ax in axes if ax.get("name")}
+    axis_order = tuple(str(ax["name"]) for ax in axes if ax.get("name"))
     out = expr
     while True:
         span = _find_call_span(out, "apply_along")
@@ -1630,7 +1834,9 @@ def _expand_apply_along(expr: str, *, axes: list[dict[str, Any]]) -> str:  # noq
             ):
                 replaced = re.sub(rf"\b{re.escape(var_name)}\b", coord, replaced)
                 bound[ax_name] = coord
-            replaced = _substitute_apply_along_brackets(replaced, bound)
+            replaced = _substitute_apply_along_brackets(
+                replaced, bound, axis_order=axis_order
+            )
             if kernel == "integrate":
                 weight = "*".join(str(w) for _, w in combo)
                 terms.append(f"({weight})*({replaced})")
@@ -1988,11 +2194,13 @@ def _apply_transition_chains(
 
         if entry_cfg is not None:
             entry_from, entry_rate = entry_cfg
-            transitions_raw.append({
-                "from": entry_from,
-                "to": stage_names[0],
-                "rate": entry_rate,
-            })
+            transitions_raw.append(
+                {
+                    "from": entry_from,
+                    "to": stage_names[0],
+                    "rate": entry_rate,
+                }
+            )
 
         transitions_raw.extend(
             {
@@ -2005,11 +2213,13 @@ def _apply_transition_chains(
 
         if exit_cfg is not None:
             sink_s, sink_rate = exit_cfg
-            transitions_raw.append({
-                "from": stage_names[-1],
-                "to": sink_s,
-                "rate": sink_rate or forward_rates[-1],
-            })
+            transitions_raw.append(
+                {
+                    "from": stage_names[-1],
+                    "to": sink_s,
+                    "rate": sink_rate or forward_rates[-1],
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -2432,9 +2642,9 @@ def normalize_transitions_rhs(
         "kernels": meta_parts[2],
         "operators": meta_parts[3],
     }
-    meta.update({
-        k: spec[k] for k in ("sources", "couplings", "constraints") if k in spec
-    })
+    meta.update(
+        {k: spec[k] for k in ("sources", "couplings", "constraints") if k in spec}
+    )
 
     chain_block = spec.get("chain")
     if chain_block:

--- a/src/op_system/_templates.py
+++ b/src/op_system/_templates.py
@@ -348,18 +348,30 @@ def _build_chain_stage_names(cname: str, *, length: int) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-def _extract_placeholders_from_expr(expr: str) -> set[str]:
+def _extract_placeholders_from_expr(
+    expr: str,
+    *,
+    shaped_param_names: set[str] | None = None,
+) -> set[str]:
     """
     Extract wildcard placeholder axis names from ``[...]`` tokens in an expression.
 
     Only bare axis names (not ``axis=coord`` pins) are treated as placeholders.
+    When ``shaped_param_names`` is provided, ``[...]`` tokens whose base name
+    is a registered shaped parameter are skipped — such references are
+    rewritten to literal-index subscripts and must not trigger axis
+    expansion at the call site.
 
     Returns:
         Set of placeholder names referenced inside bracket templates.
     """
     placeholders: set[str] = set()
-    for match in _PLACEHOLDER_RE.finditer(expr):
-        inner = match.group(1)
+    skip = shaped_param_names or set()
+    for match in _INLINE_TEMPLATE_RE.finditer(expr):
+        base = match.group(1)
+        if base in skip:
+            continue
+        inner = match.group(2)
         for part in inner.split(","):
             part_s = part.strip()
             if part_s and "=" not in part_s:
@@ -401,6 +413,8 @@ def _apply_template_substitutions(
     *,
     assignment: Mapping[str, str],
     template_map: Mapping[str, list[tuple[str, dict[str, str]]]],
+    shaped_params: Mapping[str, tuple[str, ...]] | None = None,
+    axis_lookup: Mapping[str, list[str]] | None = None,
 ) -> str:
     """Replace template references in ``expr_s`` using a concrete assignment.
 
@@ -408,14 +422,25 @@ def _apply_template_substitutions(
     and inline placeholder syntax like ``theta[age,pop]`` when the
     placeholders are covered by ``assignment``.
 
+    When ``shaped_params`` and ``axis_lookup`` are provided, references to
+    a registered shaped parameter (e.g. ``theta[imm]`` for a parameter
+    declared shaped over ``("imm",)``) are rewritten as literal-index
+    subscripts (``theta[5]``) into the shaped buffer instead of being
+    expanded to per-coord scalar names.
+
     Returns:
         Expression string with template tokens replaced.
     """
     expr_out = expr_s
+    shaped = shaped_params or {}
 
-    # Explicit template keys from the template map.
+    # Explicit template keys from the template map. Skip any whose base
+    # collides with a registered shaped parameter — those are rewritten by
+    # the inline replacer below.
     for template_key in template_map:
         base, tokens = parse_selector(template_key)
+        if base in shaped:
+            continue
         wildcards = [t for t in tokens if isinstance(t, WildcardToken)]
         if not wildcards or any(wt.axis not in assignment for wt in wildcards):
             continue
@@ -431,6 +456,18 @@ def _apply_template_substitutions(
         phs = [p.strip() for p in inner.split(",") if p.strip() and "=" not in p]
         if not phs or any(ph not in assignment for ph in phs):
             return match.group(0)
+        if inner_base in shaped:
+            registered = shaped[inner_base]
+            if tuple(phs) != registered:
+                # Different ordering or axes — leave for downstream to flag.
+                return match.group(0)
+            if axis_lookup is None:
+                return match.group(0)
+            try:
+                idxs = [axis_lookup[ax].index(assignment[ax]) for ax in registered]
+            except (KeyError, ValueError):
+                return match.group(0)
+            return f"{inner_base}[{', '.join(str(i) for i in idxs)}]"
         return _render_template_name(inner_base, phs, assignment)
 
     return _INLINE_TEMPLATE_RE.sub(_inline_replacer, expr_out)

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -227,33 +227,31 @@ _ALLOWED_NODES: tuple[type[ast.AST], ...] = (
 )
 
 _ALLOWED_CALL_ROOTS: tuple[str, ...] = ("np",)
-_ALLOWED_CALL_FUNCS: frozenset[str] = frozenset(
-    {
-        # NumPy scalar math; keep small initially.
-        "abs",
-        "exp",
-        "expm1",
-        "log",
-        "log1p",
-        "log2",
-        "log10",
-        "sqrt",
-        "maximum",
-        "minimum",
-        "clip",
-        "where",
-        # Trig and hyperbolic.
-        "sin",
-        "cos",
-        "tan",
-        "sinh",
-        "cosh",
-        "tanh",
-        # Geometry-ish.
-        "hypot",
-        "arctan2",
-    }
-)
+_ALLOWED_CALL_FUNCS: frozenset[str] = frozenset({
+    # NumPy scalar math; keep small initially.
+    "abs",
+    "exp",
+    "expm1",
+    "log",
+    "log1p",
+    "log2",
+    "log10",
+    "sqrt",
+    "maximum",
+    "minimum",
+    "clip",
+    "where",
+    # Trig and hyperbolic.
+    "sin",
+    "cos",
+    "tan",
+    "sinh",
+    "cosh",
+    "tanh",
+    # Geometry-ish.
+    "hypot",
+    "arctan2",
+})
 
 _ALLOWED_HELPER_FUNCS: frozenset[str] = frozenset({"sum_state", "sum_prefix"})
 
@@ -524,6 +522,121 @@ def _make_eval_fn(  # noqa: C901
 # -----------------------------------------------------------------------------
 
 
+def _interp_along_axis(
+    t: object, ts: object, grid: object, *, axis: int, xp: object
+) -> object:
+    """Linearly interpolate ``grid`` along axis ``axis`` at scalar ``t``.
+
+    For a 1-D ``grid`` of shape ``(N,)`` returns a scalar; for an N-D
+    ``grid`` whose ``axis``-th dimension has length ``N`` returns an array
+    with that dimension removed.  Boundary behaviour is constant
+    extrapolation (clamp to the nearest end-point), matching
+    :func:`numpy.interp`.
+
+    Args:
+        t: Scalar evaluation time.
+        ts: 1-D monotonically non-decreasing array of grid times of length N.
+        grid: Array whose ``axis``-th dimension indexes ``ts``.
+        axis: Position of the time axis within ``grid``'s shape.
+        xp: Array backend namespace (numpy or jax.numpy).
+
+    Returns:
+        Interpolated value with ``grid``'s shape minus the ``axis`` slot.
+    """
+    backend = cast("Any", xp)
+    ts_arr = backend.asarray(ts)
+    grid_arr = backend.asarray(grid)
+    if axis != 0:
+        grid_arr = backend.moveaxis(grid_arr, axis, 0)
+    n = ts_arr.shape[0]
+    t_val = backend.asarray(t)
+    raw_idx = backend.searchsorted(ts_arr, t_val, side="right")
+    idx_right = backend.clip(raw_idx, 1, n - 1)
+    idx_left = idx_right - 1
+    t_left = ts_arr[idx_left]
+    t_right = ts_arr[idx_right]
+    span = t_right - t_left
+    raw_w = (t_val - t_left) / backend.where(
+        span == 0, backend.asarray(1.0, dtype=span.dtype), span
+    )
+    w = backend.clip(raw_w, 0.0, 1.0)
+    g_left = grid_arr[idx_left]
+    g_right = grid_arr[idx_right]
+    if g_left.ndim > 0:
+        w = backend.reshape(w, (1,) * g_left.ndim)
+    return (1.0 - w) * g_left + w * g_right
+
+
+def _wrap_eval_fn_for_time_varying(
+    eval_fn: EvalFn,
+    *,
+    time_varying_params: tuple[tuple[str, tuple[str, ...]], ...],
+    time_axis_name: str,
+    axes_meta: tuple[Mapping[str, Any], ...],
+    xp: object,
+) -> EvalFn:
+    """Wrap ``eval_fn`` so each time-varying name is interpolated at runtime.
+
+    For each ``(name, full_axes)`` in ``time_varying_params`` the wrapper
+    expects a single kwarg ``name`` whose shape matches ``full_axes``.  At
+    every call the wrapper interpolates that array along the time-axis
+    position using the time axis's declared coordinates as the grid, and
+    re-injects the reduced-shape result under ``name`` before delegating to
+    ``eval_fn``.
+
+    Args:
+        eval_fn: The unwrapped evaluator returned by the vectorized or
+            scalar compile path.
+        time_varying_params: Pairs ``(name, full_axes)`` declared
+            time-varying by the spec.  Each ``full_axes`` tuple must
+            contain ``time_axis_name``.
+        time_axis_name: The configured time-axis name (default ``"time"``).
+        axes_meta: Normalized axes records (each a mapping with ``name``
+            and ``coords``).  Used to look up the time-axis ``coords``
+            array baked into the wrapper closure as the interpolation grid.
+        xp: Array backend namespace, threaded through to
+            :func:`_interp_along_axis`.
+
+    Returns:
+        A new `EvalFn` with the same shape contract as ``eval_fn``.
+    """
+    if not time_varying_params:
+        return eval_fn
+    backend = cast("Any", xp)
+    ts_lookup = {
+        ax["name"]: backend.asarray(ax["coords"], dtype=backend.float64)
+        for ax in axes_meta
+        if ax.get("name") == time_axis_name
+    }
+    if time_axis_name not in ts_lookup:
+        _raise_parameter_error(
+            detail=(
+                f"time-varying parameters declared but the configured time "
+                f"axis {time_axis_name!r} is missing from the spec axes."
+            )
+        )
+    ts = ts_lookup[time_axis_name]
+    plan = tuple(
+        (name, full_axes.index(time_axis_name))
+        for name, full_axes in time_varying_params
+    )
+
+    def wrapped(t: object, y: object, **params: object) -> Float64Array:
+        for name, axis_pos in plan:
+            if name not in params:
+                _raise_parameter_error(
+                    detail=(
+                        f"time-varying parameter {name!r} requires the bare "
+                        f"{name!r} kwarg at call time."
+                    )
+                )
+            grid = params.pop(name)
+            params[name] = _interp_along_axis(t, ts, grid, axis=axis_pos, xp=xp)
+        return eval_fn(t, y, **params)
+
+    return wrapped
+
+
 def compile_rhs(rhs: NormalizedRhs, *, xp: object) -> CompiledRhs:
     """Compile a normalized RHS into a runnable evaluation function.
 
@@ -560,9 +673,17 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object) -> CompiledRhs:
             xp=xp,
         )
 
+    eval_fn = _wrap_eval_fn_for_time_varying(
+        eval_fn,
+        time_varying_params=rhs.time_varying_params,
+        time_axis_name=str(rhs.meta.get("time_axis", "time")),
+        axes_meta=tuple(rhs.meta.get("axes") or ()),
+        xp=xp,
+    )
+
     return CompiledRhs(
         state_names=rhs.state_names,
-        param_names=rhs.param_names,
+        param_names=tuple(rhs.param_names),
         eval_fn=eval_fn,
         meta=rhs.meta,
     )

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -218,34 +218,42 @@ _ALLOWED_NODES: tuple[type[ast.AST], ...] = (
     ast.Or,
     ast.BoolOp,
     ast.IfExp,
+    # Subscripts are needed for shaped-parameter buffer access (``theta[5]``)
+    # and for ``np.array``-style index expressions emitted by template
+    # substitution.
+    ast.Subscript,
+    ast.Index,
+    ast.Tuple,
 )
 
 _ALLOWED_CALL_ROOTS: tuple[str, ...] = ("np",)
-_ALLOWED_CALL_FUNCS: frozenset[str] = frozenset({
-    # NumPy scalar math; keep small initially.
-    "abs",
-    "exp",
-    "expm1",
-    "log",
-    "log1p",
-    "log2",
-    "log10",
-    "sqrt",
-    "maximum",
-    "minimum",
-    "clip",
-    "where",
-    # Trig and hyperbolic.
-    "sin",
-    "cos",
-    "tan",
-    "sinh",
-    "cosh",
-    "tanh",
-    # Geometry-ish.
-    "hypot",
-    "arctan2",
-})
+_ALLOWED_CALL_FUNCS: frozenset[str] = frozenset(
+    {
+        # NumPy scalar math; keep small initially.
+        "abs",
+        "exp",
+        "expm1",
+        "log",
+        "log1p",
+        "log2",
+        "log10",
+        "sqrt",
+        "maximum",
+        "minimum",
+        "clip",
+        "where",
+        # Trig and hyperbolic.
+        "sin",
+        "cos",
+        "tan",
+        "sinh",
+        "cosh",
+        "tanh",
+        # Geometry-ish.
+        "hypot",
+        "arctan2",
+    }
+)
 
 _ALLOWED_HELPER_FUNCS: frozenset[str] = frozenset({"sum_state", "sum_prefix"})
 

--- a/tests/op_system/test_op_system_apply_along.py
+++ b/tests/op_system/test_op_system_apply_along.py
@@ -16,7 +16,6 @@ derived from the axis ``deltas``).  These tests cover:
 from __future__ import annotations
 
 import pytest
-
 from op_system.specs import normalize_expr_rhs
 
 
@@ -211,7 +210,13 @@ def test_apply_along_inside_arithmetic_expression() -> None:
 
 
 def test_apply_along_nested_inside_apply_along() -> None:
-    """Nested apply_along calls should expand correctly to a flat product."""
+    """Nested apply_along calls should expand to canonical-order state names.
+
+    Even though the inner ``apply_along`` binds ``vax`` first and the outer
+    binds ``age``, the resulting bracket-collapsed names must follow the
+    canonical axis order taken from the spec's ``axes:`` list, so they
+    match what ``state: ["I[age, vax]"]`` produces directly.
+    """
     spec = {
         "kind": "expr",
         "axes": [
@@ -226,11 +231,40 @@ def test_apply_along_nested_inside_apply_along() -> None:
     }
     out = normalize_expr_rhs(spec)
     eq_n = out.equations[-1]
-    # Nested expansion consumes the inner-bound axis first, so suffix order
-    # follows binding order (vax then age) rather than bracket order.
     for a in ("y", "o"):
         for v in ("u", "v"):
-            assert f"I__vax_{v}__age_{a}" in eq_n
+            assert f"I__age_{a}__vax_{v}" in eq_n
+            # The reversed (binding-order) form should not appear.
+            assert f"I__vax_{v}__age_{a}" not in eq_n
+
+
+def test_apply_along_nested_three_axes_canonical_order() -> None:
+    """Triple-nested apply_along should still produce canonical-order names."""
+    spec = {
+        "kind": "expr",
+        "axes": [
+            {"name": "age", "coords": ["y", "o"]},
+            {"name": "vax", "coords": ["u", "v"]},
+            {"name": "imm", "type": "ordinal", "coords": ["x0", "x1"]},
+        ],
+        "state": ["X[age, vax, imm]", "N"],
+        "equations": {
+            "X[age, vax, imm]": "0.0",
+            # Inner-most binds imm, middle binds vax, outer binds age — the
+            # exact pathological pattern that triggered the SMH R19 KeyError.
+            "N": (
+                "apply_along(age=a, "
+                "apply_along(vax=b, "
+                "apply_along(imm=k, X[age=a, vax=b, imm=k])))"
+            ),
+        },
+    }
+    out = normalize_expr_rhs(spec)
+    eq_n = out.equations[-1]
+    for a in ("y", "o"):
+        for v in ("u", "v"):
+            for k in ("x0", "x1"):
+                assert f"X__age_{a}__vax_{v}__imm_{k}" in eq_n
 
 
 def test_apply_along_categorical_filter_subsets_coords() -> None:

--- a/tests/op_system/test_op_system_apply_along.py
+++ b/tests/op_system/test_op_system_apply_along.py
@@ -16,6 +16,7 @@ derived from the axis ``deltas``).  These tests cover:
 from __future__ import annotations
 
 import pytest
+
 from op_system.specs import normalize_expr_rhs
 
 

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -12,8 +12,11 @@ from __future__ import annotations
 
 import re
 
+import numpy as np
 import pytest
+from op_system import compile_rhs
 from op_system._constraints import _ConstraintRule, _normalize_constraints
+from op_system._errors import InvalidRhsSpecError
 from op_system.specs import (
     NormalizedRhs,
     StateTemplate,
@@ -179,14 +182,118 @@ def test_alias_and_param_templates_expand_over_axes() -> None:
     assert any("beta__age_y" in eq for eq in out.equations)
     assert any("beta__age_o" in eq for eq in out.equations)
 
-    expected_params = {
-        "b0",
-        "gamma",
-        "k_base",
-        "offset__age_y",
-        "offset__age_o",
-    }
+    # ``offset[age]`` is now a shaped parameter (not per-coord scalars and
+    # not included in ``param_names`` — those list scalar params only).
+    expected_params = {"b0", "gamma", "k_base"}
     assert set(out.param_names) == expected_params
+    assert dict(out.shaped_params) == {"offset": ("age",)}
+
+
+def test_shaped_param_single_axis_rewrites_to_literal_subscript() -> None:
+    """A bare ``theta[ax]`` ref becomes a literal ``theta[idx]`` subscript."""
+    spec = {
+        "kind": "expr",
+        "axes": [{"name": "imm", "coords": ["x0", "x1", "x2"]}],
+        "state": ["S[imm]"],
+        "equations": {"S[imm]": "-theta[imm] * S[imm]"},
+    }
+    out = normalize_expr_rhs(spec)
+    assert dict(out.shaped_params) == {"theta": ("imm",)}
+    assert out.equations == (
+        "-theta[0] * S__imm_x0",
+        "-theta[1] * S__imm_x1",
+        "-theta[2] * S__imm_x2",
+    )
+    # ``theta`` must not appear in the per-coord scalar param list.
+    assert "theta" not in out.param_names
+
+
+def test_shaped_param_multi_axis_rewrites_in_axis_order() -> None:
+    """Multi-axis shaped params emit indices in the registered axis order."""
+    spec = {
+        "kind": "expr",
+        "axes": [
+            {"name": "age", "coords": ["y", "o"]},
+            {"name": "vax", "coords": ["u", "v"]},
+        ],
+        "state": ["S[age, vax]"],
+        "equations": {"S[age, vax]": "-phi[age, vax] * S[age, vax]"},
+    }
+    out = normalize_expr_rhs(spec)
+    assert dict(out.shaped_params) == {"phi": ("age", "vax")}
+    assert "-phi[0, 0] * S__age_y__vax_u" in out.equations
+    assert "-phi[1, 1] * S__age_o__vax_v" in out.equations
+
+
+def test_shaped_param_inconsistent_axes_rejected() -> None:
+    """Inconsistent shaped-param axes across references must error."""
+    spec = {
+        "kind": "expr",
+        "axes": [
+            {"name": "age", "coords": ["y", "o"]},
+            {"name": "vax", "coords": ["u", "v"]},
+        ],
+        "state": ["S[age, vax]"],
+        "equations": {
+            "S[age, vax]": "-phi[age, vax] * S[age, vax] + phi[vax, age]",
+        },
+    }
+    with pytest.raises(InvalidRhsSpecError, match="inconsistent axes"):
+        normalize_expr_rhs(spec)
+
+
+def test_shaped_param_in_alias_body_propagates() -> None:
+    """Shaped-param subscripts in alias bodies survive to expanded equations."""
+    spec = {
+        "kind": "expr",
+        "axes": [{"name": "imm", "coords": ["x0", "x1"]}],
+        "state": ["S[imm]"],
+        "aliases": {"k[imm]": "kappa[imm] * 2"},
+        "equations": {"S[imm]": "-k[imm] * S[imm]"},
+    }
+    out = normalize_expr_rhs(spec)
+    assert dict(out.shaped_params) == {"kappa": ("imm",)}
+    assert out.aliases == {
+        "k__imm_x0": "kappa[0] * 2",
+        "k__imm_x1": "kappa[1] * 2",
+    }
+
+
+def test_shaped_param_in_transitions_rate() -> None:
+    """Shaped params work the same way inside ``transitions``-kind specs."""
+    spec = {
+        "kind": "transitions",
+        "axes": [{"name": "imm", "coords": ["x0", "x1", "x2"]}],
+        "state": ["S[imm]", "I[imm]"],
+        "transitions": [
+            {"from": "S[imm]", "to": "I[imm]", "rate": "theta[imm] * I[imm]"},
+        ],
+    }
+    out = normalize_rhs(spec)
+    assert dict(out.shaped_params) == {"theta": ("imm",)}
+    expanded = out.meta["transitions"]
+    rates = sorted(tr["rate"] for tr in expanded)
+    assert rates == [
+        "theta[0] * I__imm_x0",
+        "theta[1] * I__imm_x1",
+        "theta[2] * I__imm_x2",
+    ]
+
+
+def test_shaped_param_eval_end_to_end_scalar_backend() -> None:
+    """Compile + eval an RHS that uses a shaped parameter end-to-end."""
+    spec = {
+        "kind": "expr",
+        "axes": [{"name": "imm", "coords": ["x0", "x1", "x2"]}],
+        "state": ["S[imm]"],
+        "equations": {"S[imm]": "-theta[imm] * S[imm]"},
+    }
+    rhs = normalize_rhs(spec)
+    assert "theta" not in rhs.param_names
+    c = compile_rhs(rhs, xp=np)
+    y = np.array([10.0, 20.0, 40.0])
+    out = c.eval_fn(0.0, y, theta=np.array([0.1, 0.2, 0.5]))
+    assert np.allclose(out, np.array([-1.0, -4.0, -20.0]))
 
 
 def test_apply_along_kernel_sum_rejects_continuous_axis() -> None:

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -14,6 +14,7 @@ import re
 
 import numpy as np
 import pytest
+
 from op_system import compile_rhs
 from op_system._constraints import _ConstraintRule, _normalize_constraints
 from op_system._errors import InvalidRhsSpecError
@@ -294,6 +295,154 @@ def test_shaped_param_eval_end_to_end_scalar_backend() -> None:
     y = np.array([10.0, 20.0, 40.0])
     out = c.eval_fn(0.0, y, theta=np.array([0.1, 0.2, 0.5]))
     assert np.allclose(out, np.array([-1.0, -4.0, -20.0]))
+
+
+def test_time_varying_scalar_records_meta_and_excludes_param() -> None:
+    """A param subscripted with the time axis becomes time-varying."""
+    spec = {
+        "kind": "expr",
+        "axes": [
+            {"name": "imm", "coords": ["x0", "x1"]},
+            {
+                "name": "time",
+                "type": "continuous",
+                "domain": {"lb": 0.0, "ub": 2.0},
+                "size": 3,
+            },
+        ],
+        "state": ["S[imm]"],
+        "equations": {"S[imm]": "-beta[time] * S[imm]"},
+    }
+    rhs = normalize_rhs(spec)
+    assert rhs.time_varying_params == (("beta", ("time",)),)
+    assert rhs.meta["time_varying_params"] == (("beta", ("time",)),)
+    # Tv shaped names live in shaped_params with the time axis stripped.
+    assert dict(rhs.shaped_params) == {"beta": ()}
+    assert "beta" not in rhs.param_names
+    c = compile_rhs(rhs, xp=np)
+    # The compile contract is now a single bare-name kwarg per tv param.
+    assert "beta_grid" not in c.param_names
+    assert "beta_ts" not in c.param_names
+
+
+def test_time_varying_scalar_eval_interpolates() -> None:
+    """Compile + eval interpolates a time-varying scalar at run time."""
+    spec = {
+        "kind": "expr",
+        "axes": [
+            {"name": "imm", "coords": ["x0", "x1"]},
+            {
+                "name": "time",
+                "type": "continuous",
+                "domain": {"lb": 0.0, "ub": 2.0},
+                "size": 3,
+            },
+        ],
+        "state": ["S[imm]"],
+        "equations": {"S[imm]": "-beta[time] * S[imm]"},
+    }
+    c = compile_rhs(normalize_rhs(spec), xp=np)
+    grid = np.array([0.1, 0.3, 0.5])  # values at time=[0, 1, 2]
+    y = np.array([10.0, 20.0])
+    # At t=0.5 -> beta = 0.2
+    out = c.eval_fn(0.5, y, beta=grid)
+    assert np.allclose(out, np.array([-2.0, -4.0]))
+
+
+def test_time_varying_shaped_eval_interpolates_per_axis() -> None:
+    """A time-varying shaped param interpolates per axis cell at run time."""
+    spec = {
+        "kind": "expr",
+        "axes": [
+            {"name": "age", "coords": ["young", "old"]},
+            {
+                "name": "time",
+                "type": "continuous",
+                "domain": {"lb": 0.0, "ub": 1.0},
+                "size": 2,
+            },
+        ],
+        "state": ["S[age]"],
+        "equations": {"S[age]": "-nu[time, age] * S[age]"},
+    }
+    rhs = normalize_rhs(spec)
+    assert rhs.time_varying_params == (("nu", ("time", "age")),)
+    # The reduced shape (axes minus time) is what shaped_params records.
+    assert dict(rhs.shaped_params) == {"nu": ("age",)}
+    c = compile_rhs(rhs, xp=np)
+    grid = np.array([[0.1, 0.3], [0.5, 0.7]])  # shape (n_time=2, n_age=2)
+    y = np.array([10.0, 20.0])
+    # At t=0.5 -> nu = (0.3, 0.5)
+    out = c.eval_fn(0.5, y, nu=grid)
+    assert np.allclose(out, np.array([-3.0, -10.0]))
+
+
+def test_time_varying_axis_can_be_trailing() -> None:
+    """The time axis can appear in any position of a tv param's shape."""
+    spec = {
+        "kind": "expr",
+        "axes": [
+            {"name": "age", "coords": ["young", "old"]},
+            {
+                "name": "time",
+                "type": "continuous",
+                "domain": {"lb": 0.0, "ub": 1.0},
+                "size": 2,
+            },
+        ],
+        "state": ["S[age]"],
+        "equations": {"S[age]": "-nu[age, time] * S[age]"},
+    }
+    rhs = normalize_rhs(spec)
+    assert rhs.time_varying_params == (("nu", ("age", "time")),)
+    c = compile_rhs(rhs, xp=np)
+    grid = np.array([[0.1, 0.5], [0.3, 0.7]])  # shape (n_age=2, n_time=2)
+    y = np.array([10.0, 20.0])
+    # At t=0.5 -> nu interp along trailing axis = (0.3, 0.5).
+    out = c.eval_fn(0.5, y, nu=grid)
+    assert np.allclose(out, np.array([-3.0, -10.0]))
+
+
+def test_legacy_time_varying_field_rejected() -> None:
+    """The legacy ``time_varying`` field is rejected with a migration hint."""
+    spec = {
+        "kind": "expr",
+        "axes": [{"name": "imm", "coords": ["x0"]}],
+        "state": ["S[imm]"],
+        "equations": {"S[imm]": "-beta * S[imm]"},
+        "time_varying": ["beta"],
+    }
+    with pytest.raises(InvalidRhsSpecError, match=r"time_varying.*has been removed"):
+        normalize_rhs(spec)
+
+
+def test_time_varying_in_transitions_kind() -> None:
+    """The implicit time-axis subscript also works for the transitions kind."""
+    spec = {
+        "kind": "transitions",
+        "axes": [
+            {"name": "imm", "coords": ["x0", "x1"]},
+            {
+                "name": "time",
+                "type": "continuous",
+                "domain": {"lb": 0.0, "ub": 1.0},
+                "size": 2,
+            },
+        ],
+        "state": ["S[imm]", "I[imm]"],
+        "transitions": [
+            {"from": "S[imm]", "to": "I[imm]", "rate": "beta[time]"},
+        ],
+    }
+    rhs = normalize_rhs(spec)
+    assert rhs.time_varying_params == (("beta", ("time",)),)
+    c = compile_rhs(rhs, xp=np)
+    grid = np.array([0.0, 1.0])  # values at time=[0, 1]
+    # State order is (S[x0], S[x1], I[x0], I[x1]).
+    y = np.array([10.0, 5.0, 0.0, 0.0])
+    out = c.eval_fn(0.5, y, beta=grid)
+    # beta=0.5; flow=beta*source -> dS=[-5,-2.5], dI=[5,2.5].
+    assert np.allclose(out, np.array([-5.0, -2.5, 5.0, 2.5]))
 
 
 def test_apply_along_kernel_sum_rejects_continuous_axis() -> None:
@@ -1421,7 +1570,7 @@ def test_initial_state_pinned_key_invalid_coord_rejected() -> None:
 # -- shaped initial_state values -----------------------------------------------
 
 
-def _shaped_ic_axes_spec() -> dict:
+def _shaped_ic_axes_spec() -> dict[str, object]:
     return {
         "kind": "transitions",
         "axes": [
@@ -1500,11 +1649,12 @@ def test_initial_state_shaped_axis_not_bound_by_lhs_rejected() -> None:
         # path; expand_selector will reject the LHS first if X requires vax.)
         "X[age,imm]": {"shaped": "x_init", "axes": ["age", "vax", "imm"]},
     }
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"shaped"):
         normalize_transitions_rhs(spec)
 
 
 def test_initial_state_shaped_unknown_axis_rejected() -> None:
+    """A shaped IC entry naming an axis absent from the spec is rejected."""
     spec = _shaped_ic_axes_spec()
     spec["initial_state"] = {
         "X[age,vax,imm]": {"shaped": "x_init", "axes": ["age", "bogus"]},
@@ -1514,6 +1664,7 @@ def test_initial_state_shaped_unknown_axis_rejected() -> None:
 
 
 def test_initial_state_shaped_missing_name_rejected() -> None:
+    """A shaped IC entry without a ``shaped`` key is rejected."""
     spec = _shaped_ic_axes_spec()
     spec["initial_state"] = {
         "X[age,vax,imm]": {"axes": ["age", "vax", "imm"]},
@@ -1523,6 +1674,7 @@ def test_initial_state_shaped_missing_name_rejected() -> None:
 
 
 def test_initial_state_shaped_unknown_key_rejected() -> None:
+    """A shaped IC entry carrying an unknown key is rejected."""
     spec = _shaped_ic_axes_spec()
     spec["initial_state"] = {
         "X[age,vax,imm]": {

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import re
 
 import pytest
-
 from op_system._constraints import _ConstraintRule, _normalize_constraints
 from op_system.specs import (
     NormalizedRhs,
@@ -1310,6 +1309,146 @@ def test_initial_state_pinned_key_invalid_coord_rejected() -> None:
     }
     with pytest.raises(ValueError, match=r"pinned coord"):
         normalize_transitions_rhs(spec)
+
+
+# -- shaped initial_state values -----------------------------------------------
+
+
+def _shaped_ic_axes_spec() -> dict:
+    return {
+        "kind": "transitions",
+        "axes": [
+            {"name": "age", "coords": ["y", "o"]},
+            {"name": "vax", "coords": ["u", "v"]},
+            {"name": "imm", "coords": ["X0", "X1"]},
+        ],
+        "state": ["X[age,vax,imm]"],
+        "transitions": [
+            {"from": "X[age,vax,imm]", "to": "X[age,vax,imm]", "rate": "alpha"},
+        ],
+    }
+
+
+def test_initial_state_shaped_full_wildcards() -> None:
+    """Shaped IC over all-wildcard LHS records (name, axes, coords) per cell."""
+    spec = _shaped_ic_axes_spec()
+    spec["initial_state"] = {
+        "X[age,vax,imm]": {"shaped": "x_init", "axes": ["age", "vax", "imm"]},
+    }
+    out = normalize_transitions_rhs(spec)
+    ic = out.meta["initial_state"]
+    # 2 * 2 * 2 = 8 cells.
+    assert len(ic) == 8
+    entry = ic["X__age_y__vax_u__imm_X0"]
+    assert entry == {
+        "shaped": "x_init",
+        "axes": ("age", "vax", "imm"),
+        "coords": {"age": "y", "vax": "u", "imm": "X0"},
+    }
+    # Distinct cells get distinct coord assignments but share name + axes.
+    other = ic["X__age_o__vax_v__imm_X1"]
+    assert other["shaped"] == "x_init"
+    assert other["axes"] == ("age", "vax", "imm")
+    assert other["coords"] == {"age": "o", "vax": "v", "imm": "X1"}
+
+
+def test_initial_state_shaped_partial_with_pinned_axis() -> None:
+    """Shaped IC works when LHS pins one axis (covers a slice only)."""
+    spec = _shaped_ic_axes_spec()
+    spec["initial_state"] = {
+        "X[age,vax=u,imm]": {"shaped": "x_unvax_init", "axes": ["age", "imm"]},
+        "X[age,vax=v,imm]": {"shaped": "x_vax_init", "axes": ["age", "imm"]},
+    }
+    out = normalize_transitions_rhs(spec)
+    ic = out.meta["initial_state"]
+    assert len(ic) == 8
+    unvax = ic["X__age_y__vax_u__imm_X0"]
+    assert unvax["shaped"] == "x_unvax_init"
+    assert unvax["axes"] == ("age", "imm")
+    assert unvax["coords"] == {"age": "y", "imm": "X0"}
+    vax = ic["X__age_o__vax_v__imm_X1"]
+    assert vax["shaped"] == "x_vax_init"
+    assert vax["coords"] == {"age": "o", "imm": "X1"}
+
+
+def test_initial_state_shaped_axis_order_independent_of_lhs() -> None:
+    """Shaped axes preserve the user's declared order, not the LHS order."""
+    spec = _shaped_ic_axes_spec()
+    spec["initial_state"] = {
+        "X[age,vax,imm]": {"shaped": "x_init", "axes": ["imm", "age", "vax"]},
+    }
+    out = normalize_transitions_rhs(spec)
+    ic = out.meta["initial_state"]
+    entry = ic["X__age_y__vax_u__imm_X0"]
+    assert entry["axes"] == ("imm", "age", "vax")
+    assert entry["coords"] == {"age": "y", "vax": "u", "imm": "X0"}
+
+
+def test_initial_state_shaped_axis_not_bound_by_lhs_rejected() -> None:
+    """Shaped axes must all be wildcards or pinned coords on the LHS."""
+    spec = _shaped_ic_axes_spec()
+    spec["initial_state"] = {
+        # LHS has no `vax` token at all (ill-formed selector for the X
+        # state, but exercised here only to confirm the missing-axis error
+        # path; expand_selector will reject the LHS first if X requires vax.)
+        "X[age,imm]": {"shaped": "x_init", "axes": ["age", "vax", "imm"]},
+    }
+    with pytest.raises(ValueError):
+        normalize_transitions_rhs(spec)
+
+
+def test_initial_state_shaped_unknown_axis_rejected() -> None:
+    spec = _shaped_ic_axes_spec()
+    spec["initial_state"] = {
+        "X[age,vax,imm]": {"shaped": "x_init", "axes": ["age", "bogus"]},
+    }
+    with pytest.raises(ValueError, match=r"shaped axis 'bogus' not defined"):
+        normalize_transitions_rhs(spec)
+
+
+def test_initial_state_shaped_missing_name_rejected() -> None:
+    spec = _shaped_ic_axes_spec()
+    spec["initial_state"] = {
+        "X[age,vax,imm]": {"axes": ["age", "vax", "imm"]},
+    }
+    with pytest.raises(ValueError, match=r"shaped"):
+        normalize_transitions_rhs(spec)
+
+
+def test_initial_state_shaped_unknown_key_rejected() -> None:
+    spec = _shaped_ic_axes_spec()
+    spec["initial_state"] = {
+        "X[age,vax,imm]": {
+            "shaped": "x_init",
+            "axes": ["age", "vax", "imm"],
+            "shape": [2, 2, 2],
+        },
+    }
+    with pytest.raises(ValueError, match=r"unknown"):
+        normalize_transitions_rhs(spec)
+
+
+def test_initial_state_shaped_and_scalar_mixed() -> None:
+    """A spec may freely mix scalar and shaped IC entries across compartments."""
+    spec = {
+        "kind": "transitions",
+        "axes": [
+            {"name": "age", "coords": ["y", "o"]},
+            {"name": "vax", "coords": ["u", "v"]},
+        ],
+        "state": ["S[age,vax]", "I[age,vax]"],
+        "transitions": [
+            {"from": "S[age,vax]", "to": "I[age,vax]", "rate": "alpha"},
+        ],
+        "initial_state": {
+            "S[age,vax]": {"shaped": "s_init", "axes": ["age", "vax"]},
+            "I[age,vax]": "i_init",
+        },
+    }
+    out = normalize_transitions_rhs(spec)
+    ic = out.meta["initial_state"]
+    assert ic["S__age_y__vax_u"]["shaped"] == "s_init"
+    assert ic["I__age_y__vax_u"] == "i_init"
 
 
 def test_transitions_pinned_from_endpoint_expands_correctly() -> None:

--- a/tests/op_system/test_op_system_vectorize.py
+++ b/tests/op_system/test_op_system_vectorize.py
@@ -11,7 +11,6 @@ Covers:
 from __future__ import annotations
 
 import numpy as np
-
 from op_system._vectorize import build_vector_plan
 from op_system.compile import _make_eval_fn, compile_rhs
 from op_system.specs import normalize_rhs
@@ -96,8 +95,7 @@ def test_vectorized_matches_scalar_templated_param() -> None:
     _eval_equal(
         _sir_templated_param_spec(),
         beta=0.4,
-        gamma__age_y=0.1,
-        gamma__age_o=0.2,
+        gamma=np.array([0.1, 0.2]),
     )
 
 

--- a/tests/op_system/test_op_system_vectorize.py
+++ b/tests/op_system/test_op_system_vectorize.py
@@ -11,6 +11,7 @@ Covers:
 from __future__ import annotations
 
 import numpy as np
+
 from op_system._vectorize import build_vector_plan
 from op_system.compile import _make_eval_fn, compile_rhs
 from op_system.specs import normalize_rhs
@@ -64,7 +65,7 @@ def _sir_templated_param_spec() -> dict[str, object]:
     }
 
 
-def _eval_equal(spec: dict[str, object], **call_params: float) -> None:
+def _eval_equal(spec: dict[str, object], **call_params: object) -> None:
     rhs = normalize_rhs(spec)
     # ``compile_rhs`` always attempts the vectorized path; bypass it via
     # ``_make_eval_fn`` to keep an independent scalar reference for this


### PR DESCRIPTION
This pull request introduces significant improvements to the handling of shaped and time-varying parameters in the op-system package, enhances template substitution logic, and adds robust test coverage for these changes. The changes ensure correct parameter requests for shaped and time-varying parameters, provide runtime interpolation for time-varying parameters, and guarantee canonical axis order in state naming—even in complex, nested scenarios.

**Parameter handling and runtime evaluation improvements:**

- The `requested_parameters` method in `OpSystemSystem` now correctly distinguishes between shaped and time-varying parameters, emitting a single `ParameterRequest` per time-varying parameter with its full axes, and handling initial state entries robustly with error checking for collisions and type mismatches. [[1]](diffhunk://#diff-88aacd0c414c630ca19a4a7c70d9b02f3196123051eb784dab60d0e4f5219bbcL169-L181) [[2]](diffhunk://#diff-88aacd0c414c630ca19a4a7c70d9b02f3196123051eb784dab60d0e4f5219bbcR209-R273)
- A new runtime wrapper (`_wrap_eval_fn_for_time_varying`) interpolates time-varying parameters along the configured time axis at evaluation time, ensuring correct values are supplied to the compiled RHS. [[1]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R525-R639) [[2]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R676-R686)

**Template substitution and axis labeling:**

- Template substitution functions now skip expansion for references to shaped parameters and instead generate literal-index subscripts, preventing erroneous axis expansion and supporting correct shaped buffer access. [[1]](diffhunk://#diff-cd4be4dd0851d6c271983264ebc4a2c1e6844b268c41d016c371e5f263e36f40L351-R374) [[2]](diffhunk://#diff-cd4be4dd0851d6c271983264ebc4a2c1e6844b268c41d016c371e5f263e36f40R416-R443) [[3]](diffhunk://#diff-cd4be4dd0851d6c271983264ebc4a2c1e6844b268c41d016c371e5f263e36f40R459-R470)
- The system now preserves user-declared coordinate labels (`axis_labels`) alongside numeric coordinates, aiding engine plugins in mapping shaped initial condition assignments.

**Testing and validation:**

- New and updated tests verify that time-varying parameters emit correct `ParameterRequest` objects with full axes, respect configurable time axis names, and confirm canonical axis ordering in nested `apply_along` scenarios. [[1]](diffhunk://#diff-d5e4ccdad1aa6db779c09df62a963453f8b9414a46e5642e54b2603f8552d2a1R544-R590) [[2]](diffhunk://#diff-3feb34c5664512949245f304cc8095ce1cb2705998b7098106defa72bb49b14bL214-R220) [[3]](diffhunk://#diff-3feb34c5664512949245f304cc8095ce1cb2705998b7098106defa72bb49b14bL229-R268)

**Other changes:**

- The list of allowed AST nodes in the compiler now explicitly includes subscript and tuple nodes, supporting shaped-parameter buffer access.
- The `provider-sync` justfile recipe now always reinstalls the `op-system` package during sync.

These changes collectively improve correctness, flexibility, and maintainability in parameter handling and code generation for the op-system package.