### PR TITLE
fix(normalize): exclude axis names, template bases, and builtins from `param_names`

### DIFF
--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -2799,6 +2799,8 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:  # noqa: C901,
 
     shaped_set = set(shaped_params)
     time_varying_set = set(time_varying_full)
+    axis_name_set = set(axis_lookup_dict)
+    template_base_set = {parse_selector(k)[0] for k in template_map_all}
     return NormalizedRhs(
         kind="expr",
         state_names=tuple(state_expanded),
@@ -2811,6 +2813,9 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:  # noqa: C901,
             and sym not in aliases
             and sym not in shaped_set
             and sym not in time_varying_set
+            and sym not in axis_name_set
+            and sym not in template_base_set
+            and sym not in _SHAPED_PARAM_BUILTIN_NAMES
         ),
         all_symbols=frozenset(all_syms | set(aliases.keys())),
         meta=meta,
@@ -3056,6 +3061,8 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
 
     shaped_set = set(shaped_params)
     time_varying_set = set(time_varying_full)
+    axis_name_set = set(axis_lookup_dict)
+    template_base_set = {parse_selector(k)[0] for k in template_map_all}
     return NormalizedRhs(
         kind="transitions",
         state_names=tuple(state_expanded),
@@ -3068,6 +3075,9 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
             and sym not in aliases
             and sym not in shaped_set
             and sym not in time_varying_set
+            and sym not in axis_name_set
+            and sym not in template_base_set
+            and sym not in _SHAPED_PARAM_BUILTIN_NAMES
         ),
         all_symbols=frozenset(all_syms | set(aliases.keys())),
         meta={**meta, "transitions": transitions_expanded},

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -297,6 +297,88 @@ def test_shaped_param_eval_end_to_end_scalar_backend() -> None:
     assert np.allclose(out, np.array([-1.0, -4.0, -20.0]))
 
 
+def test_alias_subscript_axis_token_does_not_leak_into_param_names() -> None:
+    """Axis names that appear only as subscripts in aliases are not params.
+
+    Regression for the case where a non-time axis token (e.g. ``loc``)
+    used in an alias like ``foi: r0_loc[loc] * ...`` was incorrectly
+    surfaced in ``NormalizedRhs.param_names`` because
+    ``_collect_alias_symbols`` walks every ``ast.Name`` (descending into
+    ``Subscript.slice``) and the previous filter only excluded the time
+    axis via ``time_varying_params``.
+    """
+    spec = {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": ["a", "b", "c"]}],
+        "state": ["S[loc]"],
+        "aliases": {"foi": "beta * r0_loc[loc]"},
+        "equations": {"S[loc]": "-foi * S[loc]"},
+    }
+    rhs = normalize_expr_rhs(spec)
+    assert "loc" not in rhs.param_names
+    assert dict(rhs.shaped_params) == {"r0_loc": ("loc",)}
+    assert set(rhs.param_names) == {"beta"}
+
+
+def test_transition_rate_axis_token_does_not_leak_into_param_names() -> None:
+    """Same regression as above but for the ``transitions`` rhs kind."""
+    spec = {
+        "kind": "transitions",
+        "axes": [{"name": "loc", "coords": ["a", "b"]}],
+        "state": ["S[loc]", "I[loc]"],
+        "transitions": [
+            {"from": "S[loc]", "to": "I[loc]", "rate": "beta * r0_loc[loc]"}
+        ],
+    }
+    rhs = normalize_transitions_rhs(spec)
+    assert "loc" not in rhs.param_names
+    assert dict(rhs.shaped_params) == {"r0_loc": ("loc",)}
+    assert set(rhs.param_names) == {"beta"}
+
+
+def test_unexpanded_alias_template_state_base_does_not_leak() -> None:
+    """A bare templated-state base in a non-templated alias is not a param.
+
+    ``_collect_alias_symbols`` walks every ``ast.Name`` and only the alias
+    *names* matching a template are expanded per coord by
+    ``_expand_alias_templates``.  An unexpanded alias like
+    ``foi: beta * sum_state(S[loc])`` therefore yields the bare
+    ``ast.Name('S')`` -- which previously fell through into ``param_names``
+    because the filter only excluded the post-expansion state names
+    (``S__loc_a`` etc.), not the template base.
+    """
+    spec = {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": ["a", "b"]}],
+        "state": ["S[loc]"],
+        "aliases": {"foi": "beta * sum_state(S[loc])"},
+        "equations": {"S[loc]": "-foi"},
+    }
+    rhs = normalize_expr_rhs(spec)
+    assert "S" not in rhs.param_names
+    assert "sum_state" not in rhs.param_names
+    assert set(rhs.param_names) == {"beta"}
+
+
+def test_unexpanded_alias_template_alias_base_does_not_leak() -> None:
+    """A bare templated-alias base in a non-templated alias is not a param."""
+    spec = {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": ["a", "b"]}],
+        "state": ["S[loc]"],
+        "aliases": {
+            "k[loc]": "k_base * mult[loc]",
+            "foi": "beta * sum_state(k[loc])",
+        },
+        "equations": {"S[loc]": "-foi"},
+    }
+    rhs = normalize_expr_rhs(spec)
+    assert "k" not in rhs.param_names
+    assert "sum_state" not in rhs.param_names
+    assert dict(rhs.shaped_params) == {"mult": ("loc",)}
+    assert set(rhs.param_names) == {"beta", "k_base"}
+
+
 def test_time_varying_scalar_records_meta_and_excludes_param() -> None:
     """A param subscripted with the time axis becomes time-varying."""
     spec = {


### PR DESCRIPTION
Closes #93.

## Summary

Three related leaks in the `param_names` filter where bare `ast.Name` tokens collected from unexpanded alias / equation expressions surfaced as 'requested' parameters in `flepimop2.Simulator.resolve_inputs()` (manifesting as `KeyError: \"Required parameter '...' was requested but not configured.\"`).

All three share one root cause: `_collect_alias_symbols` / `_gather_equations` walk every `ast.Name` from raw expression strings, but the post-collection `param_names` filter in both `normalize_expr_rhs` and `normalize_transitions_rhs` only excluded a partial set of legitimate non-param names.

### Fixes

1. **Declared axis names** used as subscript indices (e.g. the `loc` in `foi: r0_loc[loc] * ...`). The time axis was already exempt via `_partition_time_varying_shaped`; non-time axes now get the same exemption via `set(axis_lookup_dict)`.
2. **Templated state / alias *bases*** in non-templated alias expressions (e.g. the bare `S` from `foi: ... * S[loc]` where `S[loc]` is the template key — only the post-expansion names like `S__loc_a` were excluded before). Now `template_base_set = {parse_selector(k)[0] for k in template_map_all}` is also subtracted.
3. **Built-in helpers** (`np`, `t`, `sum_state`, `sum_prefix`). These were already excluded from shaped-param scanning via `_SHAPED_PARAM_BUILTIN_NAMES` but never from `param_names`. Now subtracted in both functions.

The three exemptions are symmetric across `normalize_expr_rhs` and `normalize_transitions_rhs`.
