### PR TITLE
Fix continuous-axis coord lookup KeyError in build_vector_plan (#97)

### DIFF
--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -972,7 +972,14 @@ def build_vector_plan(rhs: NormalizedRhs) -> _VectorPlan | None:  # noqa: C901, 
         coords = ax.get("coords")
         if not coords:
             return None
-        axes_pairs.append((ax["name"], list(coords)))
+        # Stringify coords to match the convention in
+        # ``_templates.build_axis_lookup`` (and therefore the per-cell
+        # ``coord_assignments`` carried by state templates).  For categorical
+        # axes coords are already strings; for continuous axes declared with
+        # explicit numeric coords (e.g. ``[0.0, 5.0, ...]``) the unconverted
+        # raw values would key ``axis_index`` by ``float`` while lookups use
+        # ``str(float)``, causing ``KeyError`` in ``_build_access_ast``.
+        axes_pairs.append((ax["name"], [str(c) for c in coords]))
     axis_index = {ax: {c: i for i, c in enumerate(coords)} for ax, coords in axes_pairs}
 
     state_buffers: list[_BufferTemplate] = []

--- a/tests/op_system/test_op_system_vectorize.py
+++ b/tests/op_system/test_op_system_vectorize.py
@@ -292,8 +292,10 @@ def test_shaped_param_subscript_partial_axes_eval_matches_scalar() -> None:
 
 
 def test_continuous_axis_with_pinned_selector_transition_compiles() -> None:
-    """Regression for #97: ``kind: transitions`` with a continuous axis and a
-    pinned-coord selector on a categorical axis must compile.
+    """Regression for #97: continuous axis with pinned-coord selector must compile.
+
+    ``kind: transitions`` with a continuous axis and a pinned-coord selector on
+    a categorical axis must compile.
 
     Previously, ``build_vector_plan`` keyed ``axis_index`` by the raw
     continuous-axis coords (e.g. ``float`` ``0.0``) while per-cell

--- a/tests/op_system/test_op_system_vectorize.py
+++ b/tests/op_system/test_op_system_vectorize.py
@@ -289,3 +289,29 @@ def test_shaped_param_subscript_partial_axes_eval_matches_scalar() -> None:
         },
     }
     _eval_equal(spec, beta=0.3, c=np.array([1.0, 0.5]), d=np.array([0.1, 0.2]))
+
+
+def test_continuous_axis_with_pinned_selector_transition_compiles() -> None:
+    """Regression for #97: ``kind: transitions`` with a continuous axis and a
+    pinned-coord selector on a categorical axis must compile.
+
+    Previously, ``build_vector_plan`` keyed ``axis_index`` by the raw
+    continuous-axis coords (e.g. ``float`` ``0.0``) while per-cell
+    ``coord_assignments`` stringified them (``'0.0'``), causing a
+    ``KeyError: '0.0'`` from ``_build_access_ast`` when a transition's
+    ``to:`` template needed a scalar lookup against the continuous axis.
+    """
+    spec: dict[str, object] = {
+        "kind": "transitions",
+        "axes": [
+            {"name": "age", "type": "continuous", "coords": [0.0, 5.0, 10.0]},
+            {"name": "imm", "coords": ["x0", "x10"]},
+        ],
+        "state": ["S[age]", "X[age, imm]"],
+        "transitions": [
+            {"from": "S[age]", "to": "X[age, imm=x10]", "rate": "0.1"},
+        ],
+    }
+    rhs = normalize_rhs(spec)
+    plan = build_vector_plan(rhs)
+    assert plan is not None


### PR DESCRIPTION
Closes #97.

`build_vector_plan` keyed `axis_index` by **raw** axis coords, while `build_axis_lookup` (and the rest of the normalization pipeline) carries coords as **strings**. For categorical axes both happen to be strings; for continuous axes declared with explicit numeric coords (e.g. `[0.0, 5.0, 10.0]`) `axis_index` ended up keyed by Python floats while per-cell `coord_assignments` stored `'0.0'` (string-of-float), producing `KeyError: '0.0'` from `_build_access_ast` whenever a transition needed a scalar (non-tied) lookup against the continuous axis -- in practice triggered by any `to:` template with a literal-coord selector on a different axis (e.g. `X[age, imm=x10]`).

## Changes

* `src/op_system/_vectorize.py`: stringify coords when building `axes_pairs` in `build_vector_plan`, matching the convention in `_templates.build_axis_lookup`.
* `tests/op_system/test_op_system_vectorize.py`: regression test `test_continuum_axis_with_pinned_selector_transition_compiles`.

## Validation

* New regression test passes.
* Full suite: `195 passed, 1 skipped`.
* End-to-end: the COVID19_USA continuum-age + risk-axis SMH R19 config (the original real-world repro) now gets past compile.