### PR TITLE
perf(vectorize): fuse apply_along integration weights into single reduction

### DIFF
--- a/scripts/api-reference.py
+++ b/scripts/api-reference.py
@@ -6,7 +6,7 @@
 
 from pathlib import Path
 
-from ruamel.yaml import YAML  # type: ignore[import-not-found]
+from ruamel.yaml import YAML
 
 
 def get_module_name(file_path: Path, src_root: Path) -> str:

--- a/scripts/api-reference.py
+++ b/scripts/api-reference.py
@@ -6,7 +6,7 @@
 
 from pathlib import Path
 
-from ruamel.yaml import YAML
+from ruamel.yaml import YAML  # type: ignore[import-not-found, unused-ignore]
 
 
 def get_module_name(file_path: Path, src_root: Path) -> str:

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -939,7 +939,11 @@ def _collapse_full_buffer_sums(  # noqa: C901, PLR0915
                 )
             )
             if full_cover:
-                if all(w == 1.0 for _t, w in items):
+                # Exact equality with 1.0 is intentional: weights of exactly 1.0
+                # arise from bare buffer subscripts (no constant factor) or
+                # from explicit literal ``1.0`` in the source. Near-1.0 weights
+                # (e.g. trapezoidal endpoints) must take the weighted-sum path.
+                if all(w == 1.0 for _t, w in items):  # noqa: RUF069
                     collapsed.append((sign, _make_sum_call(name)))
                 else:
                     weight_map = dict(items)
@@ -972,7 +976,10 @@ def _collapse_full_buffer_sums(  # noqa: C901, PLR0915
                         ctx=ast.Load(),
                     )
                     leaf_expr: ast.expr
-                    if w == 1.0:
+                    # Same intent as above: only an exact 1.0 weight may be
+                    # dropped; any other value must be re-emitted as an
+                    # explicit ``Constant * Subscript`` factor.
+                    if w == 1.0:  # noqa: RUF069
                         leaf_expr = sub
                     else:
                         leaf_expr = ast.BinOp(

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -672,6 +672,114 @@ def _make_sum_call(buf_name: str) -> ast.expr:
     )
 
 
+def _extract_weighted_buf_subscript(
+    node: ast.expr,
+) -> tuple[float, str, tuple[int, ...]] | None:
+    """If ``node`` reduces to ``(prod-of-consts) * <name>_buf[<int_tuple>]``.
+
+    Walks an arbitrarily-nested ``Mult`` tree, accumulating numeric
+    ``Constant`` factors (with ``UnaryOp(USub|UAdd, Constant)`` allowed) and
+    matching exactly one buffer subscript leaf. Returns ``None`` if the leaf
+    isn't of this shape or contains non-constant non-buffer factors.
+
+    Returns:
+        ``(weight, buffer_name, index_tuple)`` on match, else ``None``.
+    """
+    weight = 1.0
+    buf_match: tuple[str, tuple[int, ...]] | None = None
+    stack: list[ast.expr] = [node]
+    while stack:
+        n = stack.pop()
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Mult):
+            stack.extend((n.left, n.right))
+            continue
+        if isinstance(n, ast.UnaryOp) and isinstance(n.op, ast.UAdd):
+            stack.append(n.operand)
+            continue
+        if isinstance(n, ast.UnaryOp) and isinstance(n.op, ast.USub):
+            inner = n.operand
+            if isinstance(inner, ast.Constant) and isinstance(
+                inner.value, (int, float)
+            ):
+                weight *= -float(inner.value)
+                continue
+            return None
+        if isinstance(n, ast.Constant) and isinstance(n.value, (int, float)):
+            weight *= float(n.value)
+            continue
+        cls = _classify_buf_subscript(n)
+        if cls is None or buf_match is not None:
+            return None
+        buf_match = cls
+    if buf_match is None:
+        return None
+    name, idx = buf_match
+    return weight, name, idx
+
+
+def _make_weighted_sum_call(
+    buf_name: str,
+    weights_in_index_order: list[float],
+    shape: tuple[int, ...],
+) -> ast.expr:
+    """Build ``np.sum(np.asarray([...], dtype=np.float64).reshape(shape) * buf)``.
+
+    ``weights_in_index_order`` is the flat list of per-cell weights in C-order
+    matching ``np.ndindex(*shape)``. For 1-D buffers the ``reshape`` is
+    omitted.
+
+    Returns:
+        The constructed ``ast.expr`` for the fused weighted reduction.
+    """
+    weights_list = ast.List(
+        elts=[ast.Constant(value=float(w)) for w in weights_in_index_order],
+        ctx=ast.Load(),
+    )
+    asarray: ast.expr = ast.Call(
+        func=ast.Attribute(
+            value=ast.Name(id="np", ctx=ast.Load()),
+            attr="asarray",
+            ctx=ast.Load(),
+        ),
+        args=[weights_list],
+        keywords=[
+            ast.keyword(
+                arg="dtype",
+                value=ast.Attribute(
+                    value=ast.Name(id="np", ctx=ast.Load()),
+                    attr="float64",
+                    ctx=ast.Load(),
+                ),
+            ),
+        ],
+    )
+    if len(shape) > 1:
+        asarray = ast.Call(
+            func=ast.Attribute(value=asarray, attr="reshape", ctx=ast.Load()),
+            args=[
+                ast.Tuple(
+                    elts=[ast.Constant(value=int(s)) for s in shape],
+                    ctx=ast.Load(),
+                ),
+            ],
+            keywords=[],
+        )
+    product = ast.BinOp(
+        left=asarray,
+        op=ast.Mult(),
+        right=ast.Name(id=buf_name, ctx=ast.Load()),
+    )
+    return ast.Call(
+        func=ast.Attribute(
+            value=ast.Name(id="np", ctx=ast.Load()),
+            attr="sum",
+            ctx=ast.Load(),
+        ),
+        args=[product],
+        keywords=[],
+    )
+
+
 def _reassemble_addsub(terms: list[tuple[int, ast.expr]]) -> ast.expr:
     if not terms:
         return ast.Constant(value=0.0)
@@ -683,6 +791,86 @@ def _reassemble_addsub(terms: list[tuple[int, ast.expr]]) -> ast.expr:
     return out
 
 
+def _is_constant_expr(node: ast.expr) -> bool:
+    """Return ``True`` if ``node`` evaluates to a numeric constant.
+
+    Recognises numeric ``Constant`` literals, unary +/- on such literals, and
+    ``Mult``/``Div`` of constant subexpressions. Used by the constant-over-Add
+    distributor to decide whether ``c * (a + b)`` may be flattened to
+    ``c*a + c*b``.
+    """
+    if isinstance(node, ast.Constant):
+        return isinstance(node.value, (int, float))
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+        return _is_constant_expr(node.operand)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, (ast.Mult, ast.Div)):
+        return _is_constant_expr(node.left) and _is_constant_expr(node.right)
+    return False
+
+
+def _distribute_const_over_add(tree: ast.Expression) -> ast.Expression:
+    """Rewrite ``c * (a + b)`` as ``c*a + c*b`` (and the symmetric form).
+
+    A pre-pass for the buffer-sum collapser: the normalize-time expansion of
+    nested ``apply_along`` calls produces structures like
+    ``w_age_i * (S_buf[i,0] + S_buf[i,1] + ...)`` where the weight is gated
+    behind a parenthesized inner sum, hiding the per-cell weighted leaves
+    from the leaf-classifier. Distributing constant factors over Add chains
+    flattens these into a single Add chain of ``w * S_buf[...]`` terms that
+    the collapser can fold into one fused reduction.
+
+    Operates bottom-up; iterates to fixed point on each rewrite point. Only
+    distributes when one side of the ``Mult`` is a numeric constant — never
+    distributes runtime-variable factors (which would change semantics for
+    backends with shaped operands).
+
+    Returns:
+        A possibly-rewritten ``ast.Expression`` semantically equal to
+        ``tree`` with constant-multipliers pushed inside Add/Sub chains.
+    """
+
+    class _Distributor(ast.NodeTransformer):
+        def visit_BinOp(self, node: ast.BinOp) -> ast.AST:
+            # Recurse first so inner distributions surface upward.
+            self.generic_visit(node)
+            if not isinstance(node.op, ast.Mult):
+                return node
+            # Identify the (constant, addsub) sides; either ordering is fine.
+            const_side: ast.expr | None = None
+            chain_side: ast.expr | None = None
+            if (
+                _is_constant_expr(node.left)
+                and isinstance(node.right, ast.BinOp)
+                and isinstance(node.right.op, (ast.Add, ast.Sub))
+            ):
+                const_side = node.left
+                chain_side = node.right
+            elif (
+                _is_constant_expr(node.right)
+                and isinstance(node.left, ast.BinOp)
+                and isinstance(node.left.op, (ast.Add, ast.Sub))
+            ):
+                const_side = node.right
+                chain_side = node.left
+            if const_side is None or chain_side is None:
+                return node
+            terms = _flatten_addsub(chain_side)
+            new_terms: list[tuple[int, ast.expr]] = [
+                (
+                    sign,
+                    ast.BinOp(left=const_side, op=ast.Mult(), right=leaf),
+                )
+                for sign, leaf in terms
+            ]
+            return _reassemble_addsub(new_terms)
+
+    transformer = _Distributor()
+    new_body = cast("ast.expr", transformer.visit(tree.body))
+    new_tree = ast.Expression(body=new_body)
+    ast.fix_missing_locations(new_tree)
+    return new_tree
+
+
 def _collapse_full_buffer_sums(  # noqa: C901, PLR0915
     tree: ast.Expression, buf_shapes: Mapping[str, tuple[int, ...]]
 ) -> ast.Expression:
@@ -691,39 +879,57 @@ def _collapse_full_buffer_sums(  # noqa: C901, PLR0915
     Operates iteratively to avoid blowing Python's recursion limit on the
     very long Add chains produced by aggregator aliases (e.g. an alias that
     sums every cell of a templated state). Within each Add/Sub chain found in
-    the tree, pure ``<name>_buf[<int_tuple>]`` terms are grouped by
+    the tree, leaves of the form ``<name>_buf[<int_tuple>]`` (or that pattern
+    multiplied by a product of constant numeric factors) are grouped by
     ``(name, sign)``; if the set of indices for a group exhausts the full
     Cartesian product of the buffer's shape, those terms are collapsed into a
-    single ``np.sum(buf)`` call. Other terms in the chain are left untouched.
+    single fused reduction. Bare-subscript groups become ``np.sum(buf)``;
+    weighted groups become ``np.sum(weights * buf)`` where ``weights`` is a
+    constant array shaped to ``buf``. This collapses the long weighted-sum
+    expansion of ``apply_along(..., kernel=integrate)`` into a single fused
+    multiply+reduce. Other terms in the chain are left untouched.
 
     Returns:
         A possibly-rewritten ``ast.Expression`` equivalent to ``tree`` but
         with full-buffer sums collapsed where detected.
     """
 
-    def collapse_chain(node: ast.expr) -> ast.expr:
+    def collapse_chain(node: ast.expr) -> ast.expr:  # noqa: C901, PLR0912, PLR0914, PLR0915
         terms = _flatten_addsub(node)
-        groups: dict[tuple[str, int], list[tuple[int, ...]]] = {}
+        # group key (buf_name, sign) -> list of (idx_tuple, weight); weight is
+        # 1.0 when the leaf was a bare buffer subscript, otherwise the product
+        # of constant factors multiplying the subscript.
+        groups: dict[tuple[str, int], list[tuple[tuple[int, ...], float]]] = {}
         other: list[tuple[int, ast.expr]] = []
         order: list[tuple[str, int]] = []
         for sign, leaf in terms:
+            name: str
+            idx: tuple[int, ...]
+            weight: float
             cls = _classify_buf_subscript(leaf)
-            if cls is None or cls[0] not in buf_shapes:
-                other.append((sign, leaf))
-                continue
-            key = (cls[0], sign)
+            if cls is not None and cls[0] in buf_shapes:
+                name, idx = cls
+                weight = 1.0
+            else:
+                wcls = _extract_weighted_buf_subscript(leaf)
+                if wcls is None or wcls[1] not in buf_shapes:
+                    other.append((sign, leaf))
+                    continue
+                weight, name, idx = wcls
+            key = (name, sign)
             if key not in groups:
                 groups[key] = []
                 order.append(key)
-            groups[key].append(cls[1])
+            groups[key].append((idx, weight))
         collapsed: list[tuple[int, ast.expr]] = list(other)
         changed = False
         for key in order:
             name, sign = key
-            idxs = groups[key]
+            items = groups[key]
+            idxs = [t for t, _w in items]
             shape = buf_shapes[name]
             expected = math.prod(shape) if shape else 1
-            if (
+            full_cover = (
                 len(idxs) == expected
                 and len(set(idxs)) == expected
                 and all(
@@ -731,11 +937,27 @@ def _collapse_full_buffer_sums(  # noqa: C901, PLR0915
                     and all(0 <= ti < si for ti, si in zip(t, shape, strict=True))
                     for t in idxs
                 )
-            ):
-                collapsed.append((sign, _make_sum_call(name)))
+            )
+            if full_cover:
+                if all(w == 1.0 for _t, w in items):
+                    collapsed.append((sign, _make_sum_call(name)))
+                else:
+                    weight_map = dict(items)
+                    flat_weights = (
+                        [
+                            weight_map[tuple(int(i) for i in t)]
+                            for t in np.ndindex(*shape)
+                        ]
+                        if shape
+                        else [weight_map[()]]
+                    )
+                    collapsed.append((
+                        sign,
+                        _make_weighted_sum_call(name, flat_weights, shape),
+                    ))
                 changed = True
             else:
-                for t in idxs:
+                for t, w in items:
                     slice_node: ast.expr
                     if len(t) == 1:
                         slice_node = ast.Constant(value=t[0])
@@ -744,14 +966,21 @@ def _collapse_full_buffer_sums(  # noqa: C901, PLR0915
                             elts=[ast.Constant(value=v) for v in t],
                             ctx=ast.Load(),
                         )
-                    collapsed.append((
-                        sign,
-                        ast.Subscript(
-                            value=ast.Name(id=name, ctx=ast.Load()),
-                            slice=slice_node,
-                            ctx=ast.Load(),
-                        ),
-                    ))
+                    sub = ast.Subscript(
+                        value=ast.Name(id=name, ctx=ast.Load()),
+                        slice=slice_node,
+                        ctx=ast.Load(),
+                    )
+                    leaf_expr: ast.expr
+                    if w == 1.0:
+                        leaf_expr = sub
+                    else:
+                        leaf_expr = ast.BinOp(
+                            left=ast.Constant(value=float(w)),
+                            op=ast.Mult(),
+                            right=sub,
+                        )
+                    collapsed.append((sign, leaf_expr))
         if not changed:
             return node
         return _reassemble_addsub(collapsed)
@@ -1092,6 +1321,7 @@ def build_vector_plan(rhs: NormalizedRhs) -> _VectorPlan | None:  # noqa: C901, 
                     axis_index=axis_index,
                     shaped_param_axes=shaped_param_axes,
                 )
+            tree = _distribute_const_over_add(tree)
             tree = _collapse_full_buffer_sums(tree, buf_shapes)
             code = compile(tree, filename="<op_system_vec>", mode="eval")
         except (ValueError, RuntimeError, TypeError, SyntaxError):

--- a/tests/op_system/test_op_system_vectorize.py
+++ b/tests/op_system/test_op_system_vectorize.py
@@ -10,6 +10,8 @@ Covers:
 
 from __future__ import annotations
 
+import dis
+
 import numpy as np
 
 from op_system._vectorize import build_vector_plan
@@ -317,3 +319,92 @@ def test_continuous_axis_with_pinned_selector_transition_compiles() -> None:
     rhs = normalize_rhs(spec)
     plan = build_vector_plan(rhs)
     assert plan is not None
+
+
+# ---------------------------------------------------------------------------
+# Weighted-sum collapse: fused multiply+reduce for ``apply_along(integrate)``
+# ---------------------------------------------------------------------------
+
+
+def _continuum_integrate_spec() -> dict[str, object]:
+    """Templated SIR with an alias that ``apply_along``-integrates over age.
+
+    The continuous-age axis is integrated via trapezoidal weights inside an
+    alias scalar. Post-normalize this is a long Add chain of
+    ``<weight_const> * <S>_buf[<age_idx>, <loc_idx>]`` terms covering every
+    cell of ``S``; the weighted-sum collapser must fold it into a single
+    fused ``np.sum(weights * S_buf)`` call.
+
+    Returns:
+        A spec dict suitable for passing to ``normalize_rhs``.
+    """
+    return {
+        "kind": "expr",
+        "axes": [
+            {"name": "age", "type": "continuous", "coords": [0.0, 1.0, 3.0, 4.0]},
+            {"name": "loc", "coords": ["a", "b"]},
+        ],
+        "state": ["S[age, loc]", "I[age, loc]"],
+        "params": ["beta", "gamma"],
+        "aliases": {
+            # Integrate S over age, sum over loc → scalar.
+            "S_total": (
+                "apply_along(age=a, "
+                "apply_along(loc=l, S[age=a, loc=l], kernel=sum), "
+                "kernel=integrate)"
+            ),
+        },
+        "equations": {
+            "S[age, loc]": "-beta * S[age, loc] * S_total",
+            "I[age, loc]": ("beta * S[age, loc] * S_total - gamma * I[age, loc]"),
+        },
+    }
+
+
+def test_weighted_apply_along_collapses_to_fused_reduction() -> None:
+    """``apply_along(integrate)`` should fuse weights into one reduction.
+
+    The ``S_total`` alias expands to a long chain of
+    ``w_age[i] * S_buf[i, j]`` terms covering every cell of ``S_buf``. The
+    weighted-sum collapser must rewrite this into a single
+    ``np.sum(<weights> * S_buf)`` fused multiply+reduce (no broadcast
+    intermediate, no per-cell load chain).
+    """
+    rhs = normalize_rhs(_continuum_integrate_spec())
+    plan = build_vector_plan(rhs)
+    assert plan is not None
+    alias_codes = {base: code for base, code, _shape in plan.alias_codes}
+    assert "S_total" in alias_codes
+    code = alias_codes["S_total"]
+    assert "S_buf" in code.co_names
+    # Structural assertions: post-collapse the alias must reference its
+    # buffer at most once and reference both ``asarray`` and ``sum`` (a
+    # single fused multiply-reduce). The un-collapsed form would reference
+    # ``S_buf`` once per cell and never call ``asarray``/``sum``.
+    s_buf_loads = sum(
+        1
+        for instr in dis.get_instructions(code)
+        if instr.opname.startswith("LOAD_") and instr.argval == "S_buf"
+    )
+    assert s_buf_loads == 1, (
+        f"expected a single fused S_buf load after collapse, got {s_buf_loads}"
+    )
+    assert "asarray" in code.co_names
+    assert "sum" in code.co_names
+
+    # The collapser must emit at least one numeric weight constant. Python
+    # may fold a list of numeric literals into a tuple constant, so search
+    # both flat and nested constants.
+    def _has_float(obj: object) -> bool:
+        if isinstance(obj, float):
+            return True
+        if isinstance(obj, (list, tuple, set, frozenset)):
+            return any(_has_float(x) for x in obj)
+        return False
+
+    assert any(_has_float(c) for c in code.co_consts)
+
+
+def test_weighted_apply_along_eval_matches_scalar() -> None:
+    """Numerical equivalence between fused-reduce and scalar eval paths."""
+    _eval_equal(_continuum_integrate_spec(), beta=0.3, gamma=0.1)


### PR DESCRIPTION
Closes #99.

## Problem

When the alias for an `apply_along(..., kernel=integrate)` call expands at normalize time, the result is a long Add chain of `(weight * buf[idx])` terms covering every cell of the integrated buffer. Previously the vectorized compile path only collapsed *unweighted* full-buffer sums into `np.sum(buf)`, so the weighted variant emitted by the integrate kernel ran as a Python-level Add chain with one multiply per cell — defeating the point of vectorization for the most common SMH continuum-axis use case.

## Solution

Two new passes added to the alias compilation pipeline in `_vectorize.py`:

1. **`_distribute_const_over_add`** — pre-pass that rewrites `c * (a + b)` → `c*a + c*b` when one side is a numeric constant. Flattens the nested `apply_along` expansion (`w_i * (S_buf[i,0] + S_buf[i,1] + ...)`) into a single weighted-leaf Add chain that the collapser can fold.

2. **Extended `_collapse_full_buffer_sums`** — now recognises leaves of the form `<const>*<buf>[<int_tuple>]` via a new `_extract_weighted_buf_subscript` helper, groups them by `(buf, sign)`, and when the captured indices cover every cell of the buffer, emits a single fused

   ```python
   np.sum(np.asarray([w0, ..., wN], dtype=np.float64).reshape(buf.shape) * buf)
   ```

   Bare-subscript groups (weights all 1.0) still collapse to the cheaper `np.sum(buf)`.

This puts the fusion at the right architectural layer — the vectorize pass is where shaped buffers and AST-level pattern recognition exist. The normalize-time string expansion is unchanged (it's still per-cell scalars feeding both the scalar fallback and the vectorized rewriter).

## Tests

- `test_weighted_apply_along_collapses_to_fused_reduction` — structural assertion that post-collapse the alias loads `S_buf` exactly once, references both `asarray` and `sum`, and embeds numeric weight constants.
- `test_weighted_apply_along_eval_matches_scalar` — numerical equivalence between the fused-reduce vectorized path and the scalar reference path on a nested `apply_along(integrate(sum))` alias.

## Validation

- 212 root tests pass (210 prior + 2 new).
- 40 provider tests pass.
- ruff + mypy clean.
- The `docs` step fails locally with a pre-existing missing `mkdocs-material` env issue, also broken on `main` — unrelated.

## Misc

Drops a now-unused `# type: ignore[import-not-found]` on the `ruamel.yaml` import in `scripts/api-reference.py` (mypy `unused-ignore`).
