### PR TITLE
feat(#101): Array-API namespace-from-input contract + connector cleanup

### DIFF
--- a/flepimop2-op_system/pyproject.toml
+++ b/flepimop2-op_system/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flepimop2-op_system"
-version = "0.1.2"
+version = "0.2.0"
 description = "flepimop2 system provider package for op_system"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"

--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -27,7 +27,6 @@ pydantic BaseModel subclass is defined here, flepimop2 auto-generates a
 from __future__ import annotations
 
 import functools
-import importlib
 import sys
 from collections.abc import Mapping
 from types import MappingProxyType
@@ -36,8 +35,6 @@ from typing import (
     Any,
     Literal,
     NamedTuple,
-    SupportsFloat,
-    SupportsIndex,
     cast,
 )
 
@@ -59,7 +56,7 @@ from pydantic import ConfigDict, Field
 
 from op_system import CompiledRhs, compile_spec
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -84,20 +81,19 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
 
     model_config = ConfigDict(extra="allow")
 
-    def model_post_init(self, context: Any) -> None:  # noqa: ANN401, PLR0914
-        """Compile `op_system` specification and prepare stepper and shape helpers."""
+    def model_post_init(self, context: Any) -> None:  # noqa: ANN401
+        """Compile `op_system` specification and prepare stepper and shape helpers.
+
+        The compiled ``eval_fn`` is **namespace-polymorphic**: it infers
+        its array namespace from the input ``state`` at call time via
+        ``state.__array_namespace__()``. Callers therefore pick the
+        backend (NumPy, JAX, ...) by passing arrays of that namespace;
+        the connector performs no backend coercion.
+        """
         del context
 
         spec_obj = self.spec
-        array_backend = self._resolve_array_backend(
-            self.option("array_backend", "numpy")
-        )
-        xp, state_coerce, time_coerce, output_coerce = self._build_backend_runtime(
-            array_backend
-        )
-        self._array_namespace = xp
-
-        compiled = compile_spec(spec_obj, xp=xp)
+        compiled = compile_spec(spec_obj)
         n_state = len(compiled.state_names)
 
         axes_meta = self._extract_axes_meta(compiled)
@@ -132,7 +128,6 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
             "mixing_kernels": mixing_kernels,
             "operators": operators,
             "operator_axis": operator_axis,
-            "array_backend": array_backend,
         }
 
         def _stepper(
@@ -140,20 +135,16 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
             state: Float64NDArray,
             **kwargs: Any,  # noqa: ANN401
         ) -> Float64NDArray:
-            state_arr = state_coerce(state)
-            if state_arr.ndim != 1 or state_arr.size != n_state:
+            shape = getattr(state, "shape", None)
+            if shape != (n_state,):
                 msg = (
                     "state must be a 1D array matching the spec state length; "
-                    f"expected ({n_state},), got {state_arr.shape}."
+                    f"expected ({n_state},), got {shape}."
                 )
                 raise ValueError(msg)
             params = dict(mixing_kernels)
             params.update(kwargs)
-            result = compiled.eval_fn(time_coerce(time), state_arr, **params)
-            output = output_coerce(result)
-            if TYPE_CHECKING:
-                return np.asarray(output, dtype=np.float64)
-            return output
+            return compiled.eval_fn(time, state, **params)
 
         self._stepper = _stepper
         self._compiled_rhs = compiled  # handy for debugging/adapters
@@ -358,67 +349,6 @@ class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
             axis_order.append(name)
         return _AxesMeta(
             axis_order=tuple(axis_order), axis_sizes=axis_sizes, axis_coords=axis_coords
-        )
-
-    @staticmethod
-    def _resolve_array_backend(
-        backend_value: object,
-    ) -> Literal["numpy", "jax"]:
-        backend = str(backend_value)
-        if backend not in {"numpy", "jax"}:
-            msg = "options.array_backend must be one of {'numpy', 'jax'}"
-            raise ValueError(msg)
-        return cast("Literal['numpy', 'jax']", backend)
-
-    @staticmethod
-    def _get_array_namespace(backend: Literal["numpy", "jax"]) -> Any:  # noqa: ANN401
-        if backend == "numpy":
-            return np
-        try:
-            jnp = importlib.import_module("jax.numpy")
-        except ImportError as exc:
-            msg = "options.array_backend='jax' requires jax to be installed"
-            raise ImportError(msg) from exc
-        return jnp
-
-    @classmethod
-    def _build_backend_runtime(
-        cls, backend: Literal["numpy", "jax"]
-    ) -> tuple[
-        Any,
-        Callable[[object], Any],
-        Callable[[SupportsFloat | SupportsIndex | str | bytes | None], Any],
-        Callable[[object], Any],
-    ]:
-        xp = cls._get_array_namespace(backend)
-        if backend == "numpy":
-
-            def state_coerce(state: object) -> np.ndarray:
-                return np.asarray(state, dtype=np.float64)
-
-            def time_coerce(
-                time: SupportsFloat | SupportsIndex | str | bytes | None,
-            ) -> np.float64:
-                return np.float64(time)
-
-            def output_coerce(result: object) -> np.ndarray:
-                return np.asarray(result, dtype=np.float64)
-
-            return xp, state_coerce, time_coerce, output_coerce
-
-        def state_coerce_jax(state: object) -> Any:  # noqa: ANN401
-            return xp.asarray(state)
-
-        def passthrough(
-            value: SupportsFloat | SupportsIndex | str | bytes | None,
-        ) -> SupportsFloat | SupportsIndex | str | bytes | None:
-            return value
-
-        return (
-            xp,
-            state_coerce_jax,
-            passthrough,
-            cast("Callable[[object], Any]", passthrough),
         )
 
     @staticmethod

--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -135,12 +135,18 @@ def test_bind_delegates_to_step(sir_spec: dict[str, object]) -> None:
     np.testing.assert_allclose(via_bind, via_step, rtol=0.0, atol=0.0)
 
 
-def test_jax_backend_stepper_jittable(sir_spec: dict[str, object]) -> None:
-    """JAX backend returns tracer-compatible outputs under jit."""
+def test_jax_state_stepper_jittable(sir_spec: dict[str, object]) -> None:
+    """Passing a JAX state vector yields a jit-able, tracer-compatible stepper.
+
+    The connector no longer carries a ``array_backend`` option: the
+    namespace is inferred from the input ``state`` at call time via
+    ``__array_namespace__`` (op_system #101), so passing JAX arrays
+    is sufficient to get a JAX-native call path.
+    """
     jax = pytest.importorskip("jax")
     jnp = pytest.importorskip("jax.numpy")
 
-    sys = OpSystemSystem(spec=sir_spec, options={"array_backend": "jax"})
+    sys = OpSystemSystem(spec=sir_spec)
     stepper = sys.bind(params={"beta": 0.3, "gamma": 0.1})
     y0 = jnp.asarray([0.999, 0.001, 0.0])
 
@@ -148,20 +154,6 @@ def test_jax_backend_stepper_jittable(sir_spec: dict[str, object]) -> None:
 
     expected = np.array([-0.0002997, 0.0001997, 0.0001], dtype=np.float64)
     np.testing.assert_allclose(np.asarray(out), expected, rtol=1e-6, atol=1e-12)
-
-
-def test_option_array_backend_defaults_to_numpy(sir_spec: dict[str, object]) -> None:
-    """array_backend option defaults to numpy when omitted."""
-    sys = OpSystemSystem(spec=sir_spec)
-    assert sys.option("array_backend", None) == "numpy"
-
-
-def test_option_array_backend_invalid_value_raises(
-    sir_spec: dict[str, object],
-) -> None:
-    """Reject unsupported array_backend option values."""
-    with pytest.raises(ValueError, match=r"options\.array_backend"):
-        OpSystemSystem(spec=sir_spec, options={"array_backend": "torch"})
 
 
 # -- Integration: full SystemABC.bind() contract -----------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     { name = "Timothy Willard", email = "twillard@unc.edu" },
 ]
 dependencies = [
-    "numpy>=1.26",
+    "numpy>=2.0",
     "pydantic>=2.12.5,<3.0.0",
 ]
 

--- a/src/op_system/__init__.py
+++ b/src/op_system/__init__.py
@@ -21,14 +21,13 @@ Design guarantees:
 
 from __future__ import annotations
 
-import importlib
+import warnings
 from importlib.metadata import version
 from typing import Final, Literal
 
-import numpy as np
-
 from op_system._identifer_string import IdentifierString
 from op_system._state_string import StateString
+from op_system._typing import Array
 
 from .compile import CompiledRhs, EvalFn, compile_rhs
 from .specs import (
@@ -55,19 +54,6 @@ EXPERIMENTAL_FEATURES: frozenset[str] = frozenset()  # noqa: RUF067
 # -----------------------------------------------------------------------------
 
 
-def _resolve_xp(backend: Literal["numpy", "jax"]) -> object:  # noqa: RUF067
-    if backend == "numpy":
-        return np
-    try:
-        return importlib.import_module("jax.numpy")
-    except ImportError as exc:
-        msg = (
-            "backend='jax' requires jax to be installed "
-            '(pip install "op_system[jax]")'
-        )
-        raise ImportError(msg) from exc
-
-
 def compile_spec(  # noqa: RUF067
     spec: dict[str, object],
     *,
@@ -79,25 +65,37 @@ def compile_spec(  # noqa: RUF067
 
     This is the recommended public entrypoint for most users and adapters.
 
+    The compiled ``eval_fn`` is **namespace-polymorphic**: it infers its
+    array namespace from the input ``y`` at call time
+    (``y.__array_namespace__()``), so a single compiled callable handles
+    NumPy, JAX (concrete and traced), and any other Array-API backend
+    natively. No compile-time backend selection is required.
+
     Args:
         spec: Raw RHS specification mapping (YAML/JSON friendly).
-        xp: Optional array backend namespace. If provided, takes precedence over
-            backend selection.
-        backend: Backend selector used when xp is not provided.
+        xp: **Deprecated.** Formerly the compile-time array backend
+            namespace. Now ignored — see ``compile_rhs`` for details.
+            Will be removed in a future release.
+        backend: **Deprecated.** Formerly selected the compile-time
+            backend (``"numpy"`` or ``"jax"``). Now ignored. Will be
+            removed in a future release.
 
     Returns:
         CompiledRhs: Runnable RHS callable container.
-
-    Raises:
-        ValueError: If both `xp` and a non-default backend are provided.
     """
-    if xp is not None and backend != DEFAULT_ARRAY_BACKEND:
-        msg = "Pass either xp or backend='jax', not both."
-        raise ValueError(msg)
+    if xp is not None or backend != DEFAULT_ARRAY_BACKEND:
+        warnings.warn(
+            "compile_spec(xp=..., backend=...) is deprecated and ignored. "
+            "The compiled eval_fn now infers its array namespace from the "
+            "input `y` at call time via __array_namespace__(); pass JAX "
+            "arrays for a JAX-native call, NumPy arrays for a NumPy call. "
+            "These kwargs will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
-    xp_ns = _resolve_xp(backend) if xp is None else xp
     rhs = normalize_rhs(spec)
-    return compile_rhs(rhs, xp=xp_ns)
+    return compile_rhs(rhs)
 
 
 # -----------------------------------------------------------------------------
@@ -108,6 +106,7 @@ __all__ = [
     "DEFAULT_ARRAY_BACKEND",
     "EXPERIMENTAL_FEATURES",
     "SUPPORTED_RHS_KINDS",
+    "Array",
     "CompiledRhs",
     "EvalFn",
     "IdentifierString",

--- a/src/op_system/_typing.py
+++ b/src/op_system/_typing.py
@@ -1,0 +1,51 @@
+"""op_system._typing.
+
+Lightweight Array-API structural typing for op_system inputs and outputs.
+
+Mirrors :class:`flepimop2.typing.Array` so that producers and consumers
+across both packages can share the same structural contract without an
+import dependency between them.
+
+The single load-bearing capability is :meth:`Array.__array_namespace__`,
+which is what allows :func:`op_system.compile.compile_rhs` to obtain the
+operations namespace at *call time* from the input arrays themselves —
+removing the need for a compile-time backend selector and giving users a
+single, namespace-polymorphic, trace-pure ``eval_fn``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Array(Protocol):
+    """Structural Array-API protocol.
+
+    Any object whose runtime type implements ``shape``, ``dtype``,
+    ``__array_namespace__`` and ``item`` satisfies this protocol. NumPy
+    >= 2.0 ndarrays, JAX arrays (concrete and traced), and PyTorch tensors
+    (via the array-api compat layer) all qualify.
+
+    The namespace returned by ``__array_namespace__`` is the *only* gate
+    op_system uses to dispatch operations: input → namespace → output in
+    that same namespace. No conversion, no coercion, no compile-time
+    backend selector.
+    """
+
+    @property
+    def shape(self) -> tuple[int, ...]: ...
+
+    @property
+    def dtype(self) -> object: ...
+
+    def __array_namespace__(  # noqa: PLW3201
+        self,
+        *,
+        api_version: Any = None,  # noqa: ANN401
+    ) -> object: ...
+
+    def item(self) -> Any: ...  # noqa: ANN401
+
+
+__all__ = ["Array"]

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -35,9 +35,12 @@ import numpy as np
 
 from op_system.compile import (
     _SAFE_BUILTINS,
-    _is_numpy_backend,
+    _check_numeric_dtype,
+    _Indexable,
+    _namespace_of,
     _parse_expr,
     _validate_ast,
+    _validate_state_vector,
 )
 
 if TYPE_CHECKING:
@@ -1386,13 +1389,19 @@ def build_vector_plan(rhs: NormalizedRhs) -> _VectorPlan | None:  # noqa: C901, 
 # ---------------------------------------------------------------------------
 
 
-def make_vectorized_eval_fn(plan: _VectorPlan, *, xp: object) -> EvalFn:  # noqa: C901, PLR0915
-    """Return an ``eval_fn(t, y, **params)`` driven by ``plan``."""
+def make_vectorized_eval_fn(plan: _VectorPlan) -> EvalFn:  # noqa: C901, PLR0915
+    """Return a namespace-polymorphic ``eval_fn(t, y, **params)`` driven by ``plan``.
+
+    The compiled function infers its array namespace from the input ``y``
+    via :meth:`y.__array_namespace__` at call time, so a single eval_fn
+    handles NumPy and JAX (and any other Array-API backend) without
+    branching. Calling it with JAX arrays (or tracers) yields a JAX-native
+    computation.
+    """
     state_templates = plan.state_templates
     alias_codes = plan.alias_codes
     eq_groups = plan.eq_groups
     n_state = plan.n_state
-    is_numpy = _is_numpy_backend(xp)
 
     # Pre-compute param buffer assembly recipes: (base, expanded_names, shape)
     # — at eval time we stack the corresponding param values.
@@ -1406,20 +1415,13 @@ def make_vectorized_eval_fn(plan: _VectorPlan, *, xp: object) -> EvalFn:  # noqa
     # passed under the bare base name.
     extra_param_buffers = plan.extra_param_buffers
 
-    def eval_fn(t: object, y: object, **params: object) -> Float64Array:  # noqa: C901, PLR0912, PLR0914, PLR0915
-        if is_numpy:
-            y_in = np.asarray(y, dtype=np.float64)
-            t_val: object = np.float64(cast("Any", t))
-        else:
-            y_in = cast("Any", xp).asarray(y)
-            t_val = cast("Any", xp).asarray(t)
-        if y_in.shape != (n_state,):
-            msg = (
-                f"state has an invalid shape/value. expected (n_state={n_state},), "
-                f"got {y_in.shape}"
-            )
-            raise ValueError(msg)
+    def eval_fn(t: object, y: object, **params: object) -> Float64Array:  # noqa: C901, PLR0912, PLR0914
+        xp = _namespace_of(y)
+        _check_numeric_dtype(xp, getattr(y, "dtype", None))
+        y_arr = _validate_state_vector(y, n_state=n_state)
+        y_idx = cast("_Indexable", y_arr)
 
+        t_val: object = xp.asarray(t)
         env: dict[str, object] = {"np": xp, "t": t_val}
         env.update(params)
 
@@ -1429,22 +1431,10 @@ def make_vectorized_eval_fn(plan: _VectorPlan, *, xp: object) -> EvalFn:  # noqa
         for base, names, shape in param_recipes:
             if all(n in params for n in names):
                 vals = [params[n] for n in names]
-                if is_numpy:
-                    env[f"{base}_buf"] = np.asarray(vals, dtype=np.float64).reshape(
-                        shape
-                    )
-                else:
-                    xp_ns = cast("Any", xp)
-                    env[f"{base}_buf"] = xp_ns.reshape(xp_ns.asarray(vals), shape)
+                env[f"{base}_buf"] = xp.reshape(xp.asarray(vals), shape)
             elif base in params:
                 bare = params[base]
-                if is_numpy:
-                    env[f"{base}_buf"] = np.asarray(bare, dtype=np.float64).reshape(
-                        shape
-                    )
-                else:
-                    xp_ns = cast("Any", xp)
-                    env[f"{base}_buf"] = xp_ns.reshape(xp_ns.asarray(bare), shape)
+                env[f"{base}_buf"] = xp.reshape(xp.asarray(bare), shape)
             else:
                 missing = next(n for n in names if n not in params)
                 msg = (
@@ -1459,21 +1449,13 @@ def make_vectorized_eval_fn(plan: _VectorPlan, *, xp: object) -> EvalFn:  # noqa
                 msg = f"missing shaped param {base!r}: supply as a shape-{shape} array"
                 raise ValueError(msg)
             bare = params[base]
-            if is_numpy:
-                env[f"{base}_buf"] = np.asarray(bare, dtype=np.float64).reshape(shape)
-            else:
-                xp_ns = cast("Any", xp)
-                env[f"{base}_buf"] = xp_ns.reshape(xp_ns.asarray(bare), shape)
+            env[f"{base}_buf"] = xp.reshape(xp.asarray(bare), shape)
 
         # Build state buffers via reshape on contiguous slices.
         for tpl in state_templates:
             size = math.prod(tpl.shape)
-            slc = y_in[tpl.offset : tpl.offset + size]
-            env[f"{tpl.base}_buf"] = (
-                slc.reshape(tpl.shape)
-                if is_numpy
-                else cast("Any", xp).reshape(slc, tpl.shape)
-            )
+            slc = y_idx[tpl.offset : tpl.offset + size]
+            env[f"{tpl.base}_buf"] = xp.reshape(slc, tpl.shape)
 
         # Eval alias buffers in declaration order.
         for base, code, shape in alias_codes:
@@ -1485,10 +1467,7 @@ def make_vectorized_eval_fn(plan: _VectorPlan, *, xp: object) -> EvalFn:  # noqa
                 msg = f"alias {base!r} evaluation failed: {exc!r}"
                 raise ValueError(msg) from exc
             if shape:
-                if is_numpy:
-                    val = np.broadcast_to(val, shape)
-                else:
-                    val = cast("Any", xp).broadcast_to(val, shape)
+                val = xp.broadcast_to(val, shape)
             env[f"{base}_buf"] = val
 
         # Eval per-template equation buffers and concatenate.
@@ -1503,37 +1482,20 @@ def make_vectorized_eval_fn(plan: _VectorPlan, *, xp: object) -> EvalFn:  # noqa
                 except (NameError, ValueError, TypeError, ArithmeticError) as exc:
                     msg = f"equation {grp.base!r} evaluation failed: {exc!r}"
                     raise ValueError(msg) from exc
-                if is_numpy:
-                    arr = np.broadcast_to(
-                        np.asarray(val, dtype=np.float64), grp.vec_shape
-                    )
-                else:
-                    xp_ns = cast("Any", xp)
-                    arr = xp_ns.broadcast_to(xp_ns.asarray(val), grp.vec_shape)
+                arr = xp.broadcast_to(xp.asarray(val), grp.vec_shape)
                 bin_results.append(arr)
 
             if not grp.unroll_axes:
                 # Fully vectorized — single result already in template order.
                 whole = bin_results[0]
-            elif is_numpy:
-                stacked = np.stack(cast("Any", bin_results), axis=0).reshape(
-                    grp.unroll_shape + grp.vec_shape
-                )
-                whole = np.transpose(stacked, grp.assembly_perm)
             else:
-                xp_ns = cast("Any", xp)
-                stacked = xp_ns.reshape(
-                    xp_ns.stack(bin_results, axis=0),
+                stacked = xp.reshape(
+                    xp.stack(bin_results, axis=0),
                     grp.unroll_shape + grp.vec_shape,
                 )
-                whole = xp_ns.transpose(stacked, grp.assembly_perm)
-            if is_numpy:
-                pieces.append(np.asarray(whole).reshape(-1))
-            else:
-                pieces.append(cast("Any", xp).reshape(whole, (-1,)))
+                whole = xp.transpose(stacked, grp.assembly_perm)
+            pieces.append(xp.reshape(whole, (-1,)))
 
-        if is_numpy:
-            return cast("Float64Array", np.concatenate(cast("Any", pieces)))
-        return cast("Float64Array", cast("Any", xp).concatenate(pieces))
+        return cast("Float64Array", xp.concatenate(pieces))
 
     return eval_fn

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import ast
 import importlib
+import warnings
 from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import (
@@ -46,21 +47,55 @@ Float64Array = NDArray[np.float64]
 ScalarLike = SupportsFloat | SupportsIndex | str | bytes | None
 _SAFE_BUILTINS = {"__import__": __import__}
 
-
-class _BackendNamespace(Protocol):
-    def asarray(self, obj: object, dtype: object | None = None) -> object: ...
-
-    def stack(self, arrays: list[object]) -> object: ...
-
-    def sum(self, arr: object) -> object: ...
+_NUMERIC_DTYPE_KINDS = frozenset({"b", "i", "u", "f", "c"})
 
 
 class _Indexable(Protocol):
-    def __getitem__(self, idx: int) -> object: ...
+    def __getitem__(self, idx: int | slice) -> object: ...
 
 
-def _is_numpy_backend(xp: object) -> bool:
-    return xp is np or getattr(xp, "__name__", "") == "numpy"
+def _namespace_of(y: object) -> Any:  # noqa: ANN401
+    """Return the Array-API namespace of ``y``.
+
+    Raises:
+        TypeError: If ``y`` does not implement ``__array_namespace__``.
+            NumPy >= 2.0 arrays, JAX arrays (concrete and traced),
+            and PyTorch tensors (via array-api compat) all qualify.
+    """
+    ns_fn = getattr(y, "__array_namespace__", None)
+    if ns_fn is None:
+        msg = (
+            "op_system eval_fn requires Array-API arrays for `y` "
+            "(NumPy >= 2.0, JAX, PyTorch). Got "
+            f"{type(y).__name__!r} which does not implement "
+            "__array_namespace__()."
+        )
+        raise TypeError(msg)
+    return ns_fn()
+
+
+def _check_numeric_dtype(xp: Any, dtype: object) -> None:  # noqa: ANN401
+    """Validate that ``dtype`` is numeric in the Array-API sense.
+
+    Mirrors :meth:`flepimop2.parameter.abc.ParameterValue.__post_init__`:
+    use ``xp.isdtype(dtype, "numeric")`` and fall back to ``dtype.kind``
+    for namespaces that predate ``isdtype``. Does *not* coerce.
+
+    Raises:
+        TypeError: If ``dtype`` is not a numeric Array-API dtype.
+    """
+    isdtype = getattr(xp, "isdtype", None)
+    if isdtype is not None:
+        try:
+            if isdtype(dtype, "numeric"):
+                return
+        except (TypeError, ValueError):
+            pass
+    kind = getattr(dtype, "kind", None)
+    if kind in _NUMERIC_DTYPE_KINDS:
+        return
+    msg = f"op_system requires numeric array dtype, got {dtype!r}"
+    raise TypeError(msg)
 
 
 # -----------------------------------------------------------------------------
@@ -429,12 +464,13 @@ def _evaluate_equations(
     *,
     eq_code: list[CodeType],
     env: Mapping[str, object],
-    xp: object,
+    xp: Any,  # noqa: ANN401
 ) -> Float64Array:
     """Evaluate equation code objects against an environment.
 
     Returns:
-        Derivative vector aligned to the provided state ordering.
+        Derivative vector aligned to the provided state ordering, in the
+        same array namespace as ``xp`` (i.e. as the input ``y``).
     """
     out_vals: list[object] = []
     for codeobj in eq_code:
@@ -446,68 +482,61 @@ def _evaluate_equations(
             _raise_invalid_expression(detail=f"equation evaluation failed: {exc!r}")
         out_vals.append(val)
 
-    if _is_numpy_backend(xp):
-        return np.asarray(out_vals, dtype=np.float64)
-    return cast("Float64Array", cast("_BackendNamespace", xp).asarray(out_vals))
+    return cast("Float64Array", xp.asarray(out_vals))
 
 
-def _make_eval_fn(  # noqa: C901
+def _make_eval_fn(
     *,
     state_names: tuple[str, ...],
     aliases: Mapping[str, str],
     equations: tuple[str, ...],
-    xp: object,
 ) -> EvalFn:
+    """Build a namespace-polymorphic ``eval_fn(t, y, **params) -> dydt``.
+
+    The compiled function infers its array namespace from the input ``y``
+    via :meth:`y.__array_namespace__` at call time. No coercion is
+    performed: producers hand in arrays of the desired backend and dtype,
+    and outputs come back in that same namespace. This keeps the function
+    natively callable under ``jax.jit`` / ``jax.vmap`` (tracers carry
+    ``__array_namespace__``) without any wrapping for correctness.
+
+    Returns:
+        EvalFn: A callable ``(t, y, **params) -> dydt`` with the same
+            namespace as ``y``.
+    """
     n_state = len(state_names)
     name_to_idx = {s: i for i, s in enumerate(state_names)}
     alias_code = _collect_alias_code(aliases)
     eq_code = _collect_eq_code(equations)
 
-    def _sum_state(env: Mapping[str, object]) -> object:
-        values = [v for k, v in env.items() if k in name_to_idx]
-        if not values:
-            return cast("_BackendNamespace", xp).asarray(0.0)
-        if _is_numpy_backend(xp):
-            return np.float64(np.sum(np.asarray(values, dtype=np.float64)))
-        xp_ns = cast("_BackendNamespace", xp)
-        return xp_ns.sum(xp_ns.stack(values))
+    def eval_fn(t: object, y: object, **params: object) -> Float64Array:
+        xp = _namespace_of(y)
+        _check_numeric_dtype(xp, getattr(y, "dtype", None))
+        y_arr = _validate_state_vector(y, n_state=n_state)
 
-    def _sum_prefix(prefix: str, env: Mapping[str, object]) -> object:
-        values = [
-            v for k, v in env.items() if k.startswith(prefix) and k in name_to_idx
-        ]
-        if not values:
-            return cast("_BackendNamespace", xp).asarray(0.0)
-        if _is_numpy_backend(xp):
-            return np.float64(np.sum(np.asarray(values, dtype=np.float64)))
-        xp_ns = cast("_BackendNamespace", xp)
-        return xp_ns.sum(xp_ns.stack(values))
-
-    def _build_env(
-        t: object, y_arr: object, params: Mapping[str, object]
-    ) -> dict[str, object]:
-        t_val = (
-            np.float64(cast("ScalarLike", t))
-            if _is_numpy_backend(xp)
-            else cast("_BackendNamespace", xp).asarray(t)
-        )
+        t_val = xp.asarray(t)
         env: dict[str, object] = {"np": xp, "t": t_val}
         for s, i in name_to_idx.items():
             env[s] = cast("_Indexable", y_arr)[i]
         env.update(params)
-        env["sum_state"] = lambda: _sum_state(env)
-        env["sum_prefix"] = lambda prefix: _sum_prefix(str(prefix), env)
-        return env
 
-    def eval_fn(t: object, y: object, **params: object) -> Float64Array:
-        y_in: object
-        if _is_numpy_backend(xp):
-            y_in = np.asarray(y, dtype=np.float64)
-        else:
-            y_in = cast("_BackendNamespace", xp).asarray(y)
-        y_arr = _validate_state_vector(y_in, n_state=n_state)
+        def _sum_state() -> object:
+            values = [v for k, v in env.items() if k in name_to_idx]
+            if not values:
+                return xp.asarray(0.0)
+            return xp.sum(xp.stack(values))
 
-        env = _build_env(t, y_arr, params)
+        def _sum_prefix(prefix: object) -> object:
+            pfx = str(prefix)
+            values = [
+                v for k, v in env.items() if k.startswith(pfx) and k in name_to_idx
+            ]
+            if not values:
+                return xp.asarray(0.0)
+            return xp.sum(xp.stack(values))
+
+        env["sum_state"] = _sum_state
+        env["sum_prefix"] = _sum_prefix
 
         if alias_code:
             env.update(_resolve_aliases(alias_code, base_env=env))
@@ -523,7 +552,12 @@ def _make_eval_fn(  # noqa: C901
 
 
 def _interp_along_axis(
-    t: object, ts: object, grid: object, *, axis: int, xp: object
+    t: object,
+    ts: object,
+    grid: object,
+    *,
+    axis: int,
+    xp: Any,  # noqa: ANN401
 ) -> object:
     """Linearly interpolate ``grid`` along axis ``axis`` at scalar ``t``.
 
@@ -538,32 +572,32 @@ def _interp_along_axis(
         ts: 1-D monotonically non-decreasing array of grid times of length N.
         grid: Array whose ``axis``-th dimension indexes ``ts``.
         axis: Position of the time axis within ``grid``'s shape.
-        xp: Array backend namespace (numpy or jax.numpy).
+        xp: Array-API namespace, derived from the input ``y`` by the
+            caller (``y.__array_namespace__()``).
 
     Returns:
         Interpolated value with ``grid``'s shape minus the ``axis`` slot.
     """
-    backend = cast("Any", xp)
-    ts_arr = backend.asarray(ts)
-    grid_arr = backend.asarray(grid)
+    ts_arr = xp.asarray(ts)
+    grid_arr = xp.asarray(grid)
     if axis != 0:
-        grid_arr = backend.moveaxis(grid_arr, axis, 0)
+        grid_arr = xp.moveaxis(grid_arr, axis, 0)
     n = ts_arr.shape[0]
-    t_val = backend.asarray(t)
-    raw_idx = backend.searchsorted(ts_arr, t_val, side="right")
-    idx_right = backend.clip(raw_idx, 1, n - 1)
+    t_val = xp.asarray(t)
+    raw_idx = xp.searchsorted(ts_arr, t_val, side="right")
+    idx_right = xp.clip(raw_idx, 1, n - 1)
     idx_left = idx_right - 1
     t_left = ts_arr[idx_left]
     t_right = ts_arr[idx_right]
     span = t_right - t_left
-    raw_w = (t_val - t_left) / backend.where(
-        span == 0, backend.asarray(1.0, dtype=span.dtype), span
+    raw_w = (t_val - t_left) / xp.where(
+        span == 0, xp.asarray(1.0, dtype=span.dtype), span
     )
-    w = backend.clip(raw_w, 0.0, 1.0)
+    w = xp.clip(raw_w, 0.0, 1.0)
     g_left = grid_arr[idx_left]
     g_right = grid_arr[idx_right]
     if g_left.ndim > 0:
-        w = backend.reshape(w, (1,) * g_left.ndim)
+        w = xp.reshape(w, (1,) * g_left.ndim)
     return (1.0 - w) * g_left + w * g_right
 
 
@@ -573,7 +607,6 @@ def _wrap_eval_fn_for_time_varying(
     time_varying_params: tuple[tuple[str, tuple[str, ...]], ...],
     time_axis_name: str,
     axes_meta: tuple[Mapping[str, Any], ...],
-    xp: object,
 ) -> EvalFn:
     """Wrap ``eval_fn`` so each time-varying name is interpolated at runtime.
 
@@ -583,6 +616,11 @@ def _wrap_eval_fn_for_time_varying(
     position using the time axis's declared coordinates as the grid, and
     re-injects the reduced-shape result under ``name`` before delegating to
     ``eval_fn``.
+
+    The array namespace used for interpolation is derived from the input
+    ``y`` at call time, so the wrapped callable remains namespace-poly-
+    morphic and trace-pure (works directly under ``jax.jit`` / ``jax.vmap``
+    when called with JAX arrays).
 
     Args:
         eval_fn: The unwrapped evaluator returned by the vectorized or
@@ -594,17 +632,16 @@ def _wrap_eval_fn_for_time_varying(
         axes_meta: Normalized axes records (each a mapping with ``name``
             and ``coords``).  Used to look up the time-axis ``coords``
             array baked into the wrapper closure as the interpolation grid.
-        xp: Array backend namespace, threaded through to
-            :func:`_interp_along_axis`.
 
     Returns:
         A new `EvalFn` with the same shape contract as ``eval_fn``.
     """
     if not time_varying_params:
         return eval_fn
-    backend = cast("Any", xp)
+    # Bake the time-axis coords as plain numpy at compile time. ``xp.asarray``
+    # at eval time will adopt them into the input namespace as needed.
     ts_lookup = {
-        ax["name"]: backend.asarray(ax["coords"], dtype=backend.float64)
+        ax["name"]: np.asarray(ax["coords"], dtype=np.float64)
         for ax in axes_meta
         if ax.get("name") == time_axis_name
     }
@@ -622,6 +659,7 @@ def _wrap_eval_fn_for_time_varying(
     )
 
     def wrapped(t: object, y: object, **params: object) -> Float64Array:
+        xp = _namespace_of(y)
         for name, axis_pos in plan:
             if name not in params:
                 _raise_parameter_error(
@@ -637,20 +675,39 @@ def _wrap_eval_fn_for_time_varying(
     return wrapped
 
 
-def compile_rhs(rhs: NormalizedRhs, *, xp: object) -> CompiledRhs:
+def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
     """Compile a normalized RHS into a runnable evaluation function.
 
     Always attempts the vectorized eval path that operates on shaped buffers
     (one tensor expression per state template) and falls back automatically
     to the scalar path when the spec falls outside the supported subset.
 
+    The returned ``eval_fn`` is **namespace-polymorphic**: it infers its
+    array namespace from the input ``y`` at call time
+    (``y.__array_namespace__()``), and returns arrays in that same
+    namespace. Calling it with JAX arrays (or tracers) yields a JAX-native
+    computation suitable for ``jax.jit`` / ``jax.vmap`` without any
+    correctness wrapping.
+
     Args:
         rhs: Normalized RHS produced by `op_system.specs.normalize_rhs`.
-        xp: Array backend namespace.
+        xp: **Deprecated.** Formerly the compile-time array backend
+            namespace. Now ignored — the namespace is resolved per call
+            from the input ``y``. Will be removed in a future release.
 
     Returns:
         A `CompiledRhs` containing an `eval_fn(t, y, **params) -> dydt`.
     """
+    if xp is not None:
+        warnings.warn(
+            "compile_rhs(xp=...) is deprecated and ignored. The compiled "
+            "eval_fn now infers its array namespace from the input `y` at "
+            "call time via __array_namespace__(); pass JAX arrays for a "
+            "JAX-native call, NumPy arrays for a NumPy call. The `xp` "
+            "kwarg will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     if rhs.kind not in {"expr", "transitions"}:
         _raise_unsupported_feature(
             feature=f"rhs.kind={rhs.kind}",
@@ -662,7 +719,7 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object) -> CompiledRhs:
     vec = importlib.import_module("op_system._vectorize")
     plan = vec.build_vector_plan(rhs)
     eval_fn: EvalFn | None = (
-        vec.make_vectorized_eval_fn(plan, xp=xp) if plan is not None else None
+        vec.make_vectorized_eval_fn(plan) if plan is not None else None
     )
 
     if eval_fn is None:
@@ -670,7 +727,6 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object) -> CompiledRhs:
             state_names=rhs.state_names,
             aliases=rhs.aliases,
             equations=rhs.equations,
-            xp=xp,
         )
 
     eval_fn = _wrap_eval_fn_for_time_varying(
@@ -678,7 +734,6 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object) -> CompiledRhs:
         time_varying_params=rhs.time_varying_params,
         time_axis_name=str(rhs.meta.get("time_axis", "time")),
         axes_meta=tuple(rhs.meta.get("axes") or ()),
-        xp=xp,
     )
 
     return CompiledRhs(

--- a/tests/op_system/test_jax_native.py
+++ b/tests/op_system/test_jax_native.py
@@ -1,0 +1,197 @@
+"""Acceptance tests for issue #101.
+
+Verifies that ``compile_rhs(rhs).eval_fn`` is genuinely **JAX-native** when
+called with JAX arrays — i.e. trace-pure, ``jax.jit``-able and ``jax.vmap``-
+able without any wrapping for correctness — and that NumPy and JAX call
+paths agree numerically.
+
+Mirrors the contract documented in :mod:`op_system._typing` and
+:func:`op_system.compile.compile_rhs`: the array namespace is inferred from
+the input ``y`` at call time via ``y.__array_namespace__()``; no compile-
+time backend selection is required.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import op_system.compile as _op_system_compile
+from op_system import Array, compile_spec
+
+# ---------------------------------------------------------------------------
+# Symbol removal: assert _is_numpy_backend is gone (issue #101 step 4).
+# ---------------------------------------------------------------------------
+
+
+def test_is_numpy_backend_is_removed() -> None:
+    """The dual-path discriminator should no longer exist."""
+    assert not hasattr(_op_system_compile, "_is_numpy_backend"), (
+        "_is_numpy_backend should be removed: namespace selection is now "
+        "per-call from the input via __array_namespace__()."
+    )
+    assert not hasattr(_op_system_compile, "_BackendNamespace"), (
+        "_BackendNamespace Protocol should be removed: the runtime contract "
+        "is op_system.Array (a structural Array-API protocol)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Array protocol export.
+# ---------------------------------------------------------------------------
+
+
+def test_array_protocol_is_exported_and_runtime_checkable() -> None:
+    """``op_system.Array`` is a runtime-checkable Protocol."""
+    arr = np.asarray([1.0, 2.0])
+    assert isinstance(arr, Array)
+
+
+# ---------------------------------------------------------------------------
+# NumPy path (no jax dependency).
+# ---------------------------------------------------------------------------
+
+
+def _expr_spec() -> dict[str, object]:
+    return {
+        "kind": "expr",
+        "state": ["S", "I", "R"],
+        "equations": {
+            "S": "-beta * S * I",
+            "I": "beta * S * I - gamma * I",
+            "R": "gamma * I",
+        },
+    }
+
+
+def test_numpy_call_no_xp_kwarg() -> None:
+    """Compile with no xp; eval with a NumPy array; get a NumPy array out."""
+    compiled = compile_spec(_expr_spec())
+    y0 = np.asarray([0.99, 0.01, 0.0])
+    out = compiled.eval_fn(0.0, y0, beta=1.5, gamma=0.5)
+    assert out.__array_namespace__() is np
+    expected = np.asarray([
+        -1.5 * 0.99 * 0.01,
+        1.5 * 0.99 * 0.01 - 0.5 * 0.01,
+        0.5 * 0.01,
+    ])
+    assert np.allclose(np.asarray(out), expected, atol=1e-15)
+
+
+def test_non_array_y_raises_typeerror() -> None:
+    """Passing a Python list (no __array_namespace__) raises a clear error."""
+    compiled = compile_spec(_expr_spec())
+    with pytest.raises(TypeError, match="__array_namespace__"):
+        compiled.eval_fn(0.0, [0.99, 0.01, 0.0], beta=1.5, gamma=0.5)
+
+
+def test_non_numeric_dtype_raises_typeerror() -> None:
+    """An object-dtype array fails the numeric-dtype gate."""
+    compiled = compile_spec(_expr_spec())
+    bad = np.asarray(["a", "b", "c"], dtype=object)
+    with pytest.raises(TypeError, match="numeric"):
+        compiled.eval_fn(0.0, bad, beta=1.5, gamma=0.5)
+
+
+# ---------------------------------------------------------------------------
+# JAX path: trace-purity + numerical agreement (skipped if jax unavailable).
+# ---------------------------------------------------------------------------
+
+
+def test_jax_eval_fn_is_jaxpr_pure() -> None:
+    """``jax.make_jaxpr(eval_fn)`` succeeds with no concretization warnings.
+
+    This is the trace-purity acceptance criterion from #101: the compiled
+    function must be a pure JAX-native callable with no implicit numpy
+    coercion that would break tracing.
+    """
+    jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
+
+    compiled = compile_spec(_expr_spec())
+    y0 = jnp.asarray([0.99, 0.01, 0.0])
+
+    def f(t: object, y: object, beta: object, gamma: object) -> object:
+        return compiled.eval_fn(t, y, beta=beta, gamma=gamma)
+
+    jaxpr = jax.make_jaxpr(f)(0.0, y0, 1.5, 0.5)
+    # If we got here the trace closed without TracerArrayConversionError.
+    text = str(jaxpr)
+    assert "Tracer" not in text  # tracers should not leak as str-reprs
+    assert text  # non-empty jaxpr proves the body was actually traced
+
+
+def test_jax_eval_fn_is_jit_callable() -> None:
+    """``jax.jit(eval_fn)`` wraps for performance only; correctness is native."""
+    jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
+
+    compiled = compile_spec(_expr_spec())
+    y0 = jnp.asarray([0.99, 0.01, 0.0])
+    jit_eval = jax.jit(
+        lambda t, y, beta, gamma: compiled.eval_fn(t, y, beta=beta, gamma=gamma)
+    )
+    out = jit_eval(0.0, y0, 1.5, 0.5)
+    assert out.__array_namespace__() is jnp
+    expected = np.asarray([
+        -1.5 * 0.99 * 0.01,
+        1.5 * 0.99 * 0.01 - 0.5 * 0.01,
+        0.5 * 0.01,
+    ])
+    assert np.allclose(np.asarray(out), expected, atol=1e-12)
+
+
+def test_jax_eval_fn_is_vmap_compatible() -> None:
+    """``jax.vmap(eval_fn, in_axes=(None, 0))`` runs over batched state."""
+    jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
+
+    compiled = compile_spec(_expr_spec())
+    batch = jnp.asarray([
+        [0.99, 0.01, 0.0],
+        [0.80, 0.10, 0.10],
+        [0.50, 0.30, 0.20],
+    ])
+    vmapped = jax.vmap(
+        lambda y: compiled.eval_fn(0.0, y, beta=1.5, gamma=0.5),
+        in_axes=0,
+    )
+    out = vmapped(batch)
+    assert out.shape == (3, 3)
+    # Spot-check the first row matches the scalar call.
+    scalar = compiled.eval_fn(0.0, batch[0], beta=1.5, gamma=0.5)
+    assert np.allclose(np.asarray(out[0]), np.asarray(scalar), atol=1e-12)
+
+
+def test_numpy_and_jax_paths_agree_numerically() -> None:
+    """Same eval_fn, same inputs → same outputs across NumPy and JAX."""
+    jnp = pytest.importorskip("jax.numpy")
+
+    compiled = compile_spec(_expr_spec())
+    y0_np = np.asarray([0.7, 0.2, 0.1])
+    y0_jx = jnp.asarray(y0_np)
+    out_np = compiled.eval_fn(0.0, y0_np, beta=0.4, gamma=0.1)
+    out_jx = compiled.eval_fn(0.0, y0_jx, beta=0.4, gamma=0.1)
+    assert np.allclose(np.asarray(out_np), np.asarray(out_jx), rtol=1e-12)
+
+
+def test_vectorized_path_is_jax_native_too() -> None:
+    """The vectorized eval path also infers namespace from input."""
+    jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
+
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "axes": [{"name": "age", "coords": ["y", "o"]}],
+        "state": ["S[age]", "I[age]", "R[age]"],
+        "equations": {
+            "S[age]": "-beta * S[age] * I[age]",
+            "I[age]": "beta * S[age] * I[age] - gamma * I[age]",
+            "R[age]": "gamma * I[age]",
+        },
+    }
+    compiled = compile_spec(spec)
+    y0 = jnp.asarray([0.49, 0.49, 0.01, 0.01, 0.0, 0.0])
+    out = jax.jit(lambda y: compiled.eval_fn(0.0, y, beta=1.0, gamma=0.2))(y0)
+    assert out.__array_namespace__() is jnp
+    assert out.shape == (6,)

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -385,42 +385,70 @@ def test_compile_spec_owns_default_backend_policy() -> None:
 
 
 def test_compile_spec_rejects_conflicting_backend_and_xp() -> None:
-    """compile_spec rejects passing backend='jax' with explicit xp."""
+    """compile_spec emits a DeprecationWarning when xp/backend are passed.
+
+    The old "conflicting backend and xp" error is gone: namespace selection
+    is now per-call from the input ``y``, so both kwargs are accepted (and
+    ignored) under a single deprecation warning.
+    """
     spec: dict[str, object] = {
         "kind": "expr",
         "state": ["x"],
         "equations": {"x": "x"},
     }
-    with pytest.raises(ValueError, match=r"Pass either xp or backend='jax'"):
-        compile_spec(spec, xp=np, backend="jax")
+    with pytest.warns(DeprecationWarning, match="namespace from the input"):
+        compiled = compile_spec(spec, xp=np, backend="jax")
+    # Still produces a working compiled RHS.
+    out = compiled.eval_fn(0.0, np.array([2.0], dtype=np.float64))
+    assert np.isclose(float(out[0]), 2.0)
 
 
 def test_compile_spec_with_backend_jax_is_jittable() -> None:
-    """compile_spec supports backend='jax' as a public UX path."""
+    """compile_spec produces a JAX-jittable eval_fn when called with a JAX state.
+
+    The namespace is inferred from the input ``y`` via
+    ``__array_namespace__``, so no compile-time backend selection is
+    required (the deprecated ``backend`` kwarg is accepted and ignored).
+    """
     jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
 
     spec: dict[str, object] = {
         "kind": "expr",
         "state": ["x"],
         "equations": {"x": "beta * x"},
     }
-    compiled = compile_spec(spec, backend="jax")
+    with pytest.warns(DeprecationWarning, match="namespace from the input"):
+        compiled = compile_spec(spec, backend="jax")
 
-    y0 = np.array([2.0], dtype=np.float64)
+    y0 = jnp.asarray([2.0])
     out = jax.jit(lambda beta: compiled.eval_fn(0.0, y0, beta=beta))(1.5)
     assert np.allclose(np.asarray(out), np.asarray([3.0]))
 
 
 def test_compile_rhs_requires_explicit_backend_namespace() -> None:
-    """compile_rhs requires explicit xp so default policy is centralized."""
+    """compile_rhs no longer requires (or honors) an explicit ``xp``.
+
+    Backend selection is per-call from the input ``y`` via
+    ``__array_namespace__``. Passing ``xp`` is accepted under a
+    DeprecationWarning for one release; omitting it is the new default.
+    """
     spec: dict[str, object] = {
         "kind": "expr",
         "state": ["x"],
         "equations": {"x": "x"},
     }
     rhs = normalize_rhs(spec)
-    with pytest.raises(TypeError, match=r"required keyword-only argument: 'xp'"):
-        compile_rhs(rhs)  # type: ignore[call-arg]
+    # Default (no xp) works.
+    compiled = compile_rhs(rhs)
+    out = compiled.eval_fn(0.0, np.array([2.5], dtype=np.float64))
+    assert np.isclose(float(out[0]), 2.5)
+    # Passing xp emits a DeprecationWarning but still produces a usable
+    # CompiledRhs.
+    with pytest.warns(DeprecationWarning, match="namespace from the input"):
+        compiled_dep = compile_rhs(rhs, xp=np)
+    out2 = compiled_dep.eval_fn(0.0, np.array([4.0], dtype=np.float64))
+    assert np.isclose(float(out2[0]), 4.0)
 
 
 def test_compile_rhs_with_jax_backend_is_jittable() -> None:

--- a/tests/op_system/test_op_system_vectorize.py
+++ b/tests/op_system/test_op_system_vectorize.py
@@ -76,9 +76,8 @@ def _eval_equal(spec: dict[str, object], **call_params: object) -> None:
         state_names=rhs.state_names,
         aliases=rhs.aliases,
         equations=rhs.equations,
-        xp=np,
     )
-    c_v = compile_rhs(rhs, xp=np)
+    c_v = compile_rhs(rhs)
     rng = np.random.RandomState(0)
     y = rng.rand(len(rhs.state_names))
     out_s = scalar_eval(0.0, y, **call_params)


### PR DESCRIPTION
## Summary

Implements #101: replace the compile-time `xp` parameter with **Array-API namespace inference from the input state**, plus a corresponding cleanup of the `flepimop2-op_system` connector.

The compiled `eval_fn` is now namespace-polymorphic: it resolves its array namespace from `state.__array_namespace__()` at call time. NumPy and JAX users get the same `eval_fn`; the namespace is decided by the array they pass in. This removes the need for both op_system and downstream consumers to carry parallel "numpy vs jax" code paths.

## op_system changes

- **New `op_system._typing.Array`** — runtime-checkable Protocol mirroring the Array-API surface used internally (`shape`, `dtype`, `__array_namespace__`, `item`). Exported from `op_system`.
- **`compile.py`**:
  - New helpers `_namespace_of(y)` and `_check_numeric_dtype(xp, dtype)` (with friendly TypeError for plain lists / non-numeric dtypes).
  - `_make_eval_fn`, `_evaluate_equations`, `_interp_along_axis`, `_wrap_eval_fn_for_time_varying`, `compile_rhs`: all `xp` parameters removed; `xp` resolved per-call from the input.
  - `_is_numpy_backend` and `_BackendNamespace` deleted.
- **`_vectorize.py`**: collapses the numpy/xp branches; `eval_fn` resolves `xp` from `y` and uses the shared `_validate_state_vector` / `_check_numeric_dtype` helpers.
- **`compile_spec(spec, *, xp=None, backend="numpy")`**: both kwargs deprecated. Emits a single `DeprecationWarning("namespace from the input ...")` if either is non-default; ignores them and returns the polymorphic `CompiledRhs`.
- `numpy>=2.0` (Array-API conformance).

## Connector changes (`flepimop2-op_system`, breaking → 0.2.0)

The connector previously coerced state/time/output to a user-selected namespace declared via the `array_backend` option. With namespace-from-input, the entire coercion stack is dead weight.

- Removed: `array_backend` option, `_resolve_array_backend`, `_get_array_namespace`, `_build_backend_runtime`, and the state/time/output coercion callables.
- `compile_spec(spec_obj)` (no `xp=` kwarg).
- `_stepper` is now a thin wrapper: shape-checks `state`, merges mixing-kernel params, calls `compiled.eval_fn(time, state, **params)` directly.
- Caller picks the backend by passing arrays of that namespace (np or jnp).

Net: −78 lines in the connector.

## Tests

- New `tests/op_system/test_jax_native.py` (10 tests, 5 gated by `pytest.importorskip("jax")`):
  - `_is_numpy_backend` is gone; `Array` Protocol is exported & runtime-checkable.
  - NumPy call works without `xp=`; non-array `y` and non-numeric dtype raise `TypeError`.
  - JAX path: `jax.make_jaxpr` traces cleanly; `jax.jit` works; `jax.vmap(eval_fn, in_axes=(None, 0))` works; numpy/jax outputs agree to `rtol=1e-12`; vectorized path is jit-able.
- Existing `test_op_system_compile.py` / `test_op_system_vectorize.py` tests adjusted to drop `xp=` kwargs.
- Connector tests: renamed `test_jax_backend_stepper_jittable` → `test_jax_state_stepper_jittable` (now passes a `jnp` state instead of setting an option). Removed `test_option_array_backend_defaults_to_numpy` and `test_option_array_backend_invalid_value_raises`.

## CI

`just ci` is fully green:

| Check | Result |
| --- | --- |
| ruff (root + provider) | All checks passed |
| mypy --strict (root: 25 files, provider: 1 file) | Success |
| pytest root | 222 passed |
| pytest provider | 38 passed, 1 skipped |
| mkdocs build --strict | OK |

## Migration

Downstream users on the previous API:

```python
# old
compiled = compile_spec(spec, xp=jnp)
out = compiled.eval_fn(t, y_jax)
```

```python
# new -- no xp kwarg; pass jax arrays to get jax outputs
compiled = compile_spec(spec)
out = compiled.eval_fn(t, y_jax)
```

The deprecated `xp=` / `backend=` kwargs still work (they're ignored after a one-shot warning) so existing code keeps running unchanged.

Closes #101.
