### PR TITLE
perf(#103): iterative Add-chain rewrite + uniform-weight collapse

### DIFF
--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -726,11 +726,19 @@ def _make_weighted_sum_call(
     weights_in_index_order: list[float],
     shape: tuple[int, ...],
 ) -> ast.expr:
-    """Build ``np.sum(np.asarray([...], dtype=np.float64).reshape(shape) * buf)``.
+    """Build ``np.sum(np.asarray([...]).reshape(shape) * buf)``.
 
     ``weights_in_index_order`` is the flat list of per-cell weights in C-order
     matching ``np.ndindex(*shape)``. For 1-D buffers the ``reshape`` is
     omitted.
+
+    The generated ``np.asarray`` call deliberately omits an explicit
+    ``dtype=`` so that the weights adopt the calling backend's native float
+    dtype: ``float64`` for plain numpy and the configured default for
+    ``jax.numpy`` (which is ``float32`` unless ``jax_enable_x64`` is set).
+    Forcing ``np.float64`` here previously triggered a noisy
+    ``Explicitly requested dtype float64 ... will be truncated to dtype
+    float32`` warning at every JIT trace under JAX float32 mode.
 
     Returns:
         The constructed ``ast.expr`` for the fused weighted reduction.
@@ -746,16 +754,7 @@ def _make_weighted_sum_call(
             ctx=ast.Load(),
         ),
         args=[weights_list],
-        keywords=[
-            ast.keyword(
-                arg="dtype",
-                value=ast.Attribute(
-                    value=ast.Name(id="np", ctx=ast.Load()),
-                    attr="float64",
-                    ctx=ast.Load(),
-                ),
-            ),
-        ],
+        keywords=[],
     )
     if len(shape) > 1:
         asarray = ast.Call(

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import ast
 import math
+import sys
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from itertools import combinations as _comb
@@ -822,10 +823,23 @@ def _distribute_const_over_add(tree: ast.Expression) -> ast.Expression:
     flattens these into a single Add chain of ``w * S_buf[...]`` terms that
     the collapser can fold into one fused reduction.
 
-    Operates bottom-up; iterates to fixed point on each rewrite point. Only
-    distributes when one side of the ``Mult`` is a numeric constant — never
-    distributes runtime-variable factors (which would change semantics for
-    backends with shaped operands).
+    Iterative implementation: the top-level Add/Sub chain is flattened into a
+    term list (via :func:`_flatten_addsub`, itself iterative) and each leaf
+    is rewritten in isolation. This avoids the per-node Python frame that an
+    ``ast.NodeTransformer.visit`` would consume on right- or left-nested
+    Add chains thousands of nodes deep (e.g. aggregator aliases that sum
+    every cell of a templated state). Within each leaf we use a recursive
+    visitor; leaf depth is bounded by expression complexity (typically <=5),
+    not by chain length, so it is safe.
+
+    Distribution at a leaf may itself produce a new Add/Sub chain (when the
+    rewritten leaf is ``c*a + c*b``). Such leaves are folded back into the
+    outer term list with appropriate sign propagation, and the pass iterates
+    to a fixed point.
+
+    Only distributes when one side of the ``Mult`` is a numeric constant -
+    never distributes runtime-variable factors (which would change semantics
+    for backends with shaped operands).
 
     Returns:
         A possibly-rewritten ``ast.Expression`` semantically equal to
@@ -867,9 +881,40 @@ def _distribute_const_over_add(tree: ast.Expression) -> ast.Expression:
             ]
             return _reassemble_addsub(new_terms)
 
+    def _is_addsub(n: ast.AST) -> bool:
+        return isinstance(n, ast.BinOp) and isinstance(n.op, (ast.Add, ast.Sub))
+
     transformer = _Distributor()
-    new_body = cast("ast.expr", transformer.visit(tree.body))
-    new_tree = ast.Expression(body=new_body)
+    body = tree.body
+    if _is_addsub(body):
+        # Iteratively flatten the (possibly enormous) outer chain and rewrite
+        # each leaf in isolation. Loop to a fixed point so distribution that
+        # produces new sub-chains gets refolded into the outer chain.
+        max_passes = 64  # safety bound; convergence is typically immediate
+        for _ in range(max_passes):
+            terms = _flatten_addsub(body)
+            new_terms: list[tuple[int, ast.expr]] = []
+            any_changed = False
+            for sign, leaf in terms:
+                # ``leaf`` is by construction not an Add/Sub root; depth is
+                # bounded by leaf complexity, so the recursive visit is safe.
+                rewritten = cast("ast.expr", transformer.visit(leaf))
+                if _is_addsub(rewritten):
+                    sub_terms = _flatten_addsub(rewritten)
+                    for ssign, sleaf in sub_terms:
+                        new_terms.append((sign * ssign, sleaf))
+                    any_changed = True
+                else:
+                    if rewritten is not leaf:
+                        any_changed = True
+                    new_terms.append((sign, rewritten))
+            body = _reassemble_addsub(new_terms)
+            if not any_changed:
+                break
+    else:
+        # No top-level chain: the body itself is shallow enough to recurse.
+        body = cast("ast.expr", transformer.visit(body))
+    new_tree = ast.Expression(body=body)
     ast.fix_missing_locations(new_tree)
     return new_tree
 
@@ -942,12 +987,42 @@ def _collapse_full_buffer_sums(  # noqa: C901, PLR0915
                 )
             )
             if full_cover:
-                # Exact equality with 1.0 is intentional: weights of exactly 1.0
-                # arise from bare buffer subscripts (no constant factor) or
-                # from explicit literal ``1.0`` in the source. Near-1.0 weights
-                # (e.g. trapezoidal endpoints) must take the weighted-sum path.
-                if all(w == 1.0 for _t, w in items):  # noqa: RUF069
+                # Three emission cases for a full-cover Add chain over ``buf``:
+                #
+                # 1. All weights exactly 1.0 (bare buffer subscripts) ->
+                #    ``np.sum(buf)``.
+                # 2. All weights equal to some constant ``c != 1.0`` (typical
+                #    when ``_distribute_const_over_add`` pushed an outer
+                #    constant factor like ``dt`` over a ``kernel=sum``
+                #    apply_along chain) -> ``c * np.sum(buf)``. Without this
+                #    branch we would emit ``np.sum(np.asarray([c,...]) * buf)``
+                #    with an inlined uniform weight array of length
+                #    ``prod(shape)``, which on large network/categorical
+                #    models bloats the JAX trace and balloons XLA compile
+                #    time (see op_system#103).
+                # 3. Heterogeneous weights (true ``kernel=integrate`` with
+                #    trapezoidal endpoints, or any non-uniform weight set)
+                #    -> ``np.sum(weights_arr * buf)`` via the fused-reduce
+                #    helper.
+                #
+                # Exact float equality is intentional: weights here come
+                # either from explicit literal coefficients in the source
+                # or from constant factors propagated by
+                # ``_distribute_const_over_add``. Near-1.0 weights from
+                # trapezoidal kernels (e.g. ``0.5``) take the weighted-sum
+                # path in case 3.
+                ws = [w for _t, w in items]
+                if all(w == 1.0 for w in ws):  # noqa: RUF069
                     collapsed.append((sign, _make_sum_call(name)))
+                elif all(w == ws[0] for w in ws):  # noqa: RUF069
+                    collapsed.append((
+                        sign,
+                        ast.BinOp(
+                            left=ast.Constant(value=float(ws[0])),
+                            op=ast.Mult(),
+                            right=_make_sum_call(name),
+                        ),
+                    ))
                 else:
                     weight_map = dict(items)
                     flat_weights = (
@@ -1194,6 +1269,44 @@ def build_vector_plan(rhs: NormalizedRhs) -> _VectorPlan | None:  # noqa: C901, 
         signal that the spec is unsupported and the caller should fall back
         to the scalar engine.
     """
+    # Several internal passes still rely on recursive AST walks (notably
+    # ``_NameRewriter`` and CPython's ``ast.fix_missing_locations`` /
+    # ``compile``). On models whose normalize-time expansion produces long
+    # ``apply_along(kernel=sum)`` Add chains - e.g. aggregator aliases that
+    # sum every cell of a templated state - those walks consume one Python
+    # frame per chain node and blow the default 1000-frame recursion limit,
+    # silently dropping the model to the scalar fallback. Bump the limit
+    # for the duration of this call sized to a safe upper bound on the
+    # longest alias-or-equation expression. This is a temporary safety net
+    # while the recursive passes are migrated to iterative term-list form
+    # (op_system#103); it does not eliminate the underlying C-stack ceiling
+    # (~10-20k frames on typical builds), so it cannot rescue extreme
+    # workloads (e.g. continuum models with >50k-cell aggregators) - those
+    # require the structured-IR refactor tracked separately.
+    longest_expr = 0
+    for s in rhs.equations:
+        if isinstance(s, str) and len(s) > longest_expr:
+            longest_expr = len(s)
+    for s in rhs.aliases.values():
+        if isinstance(s, str) and len(s) > longest_expr:
+            longest_expr = len(s)
+    # Heuristic: each Add term in the expanded form is on the order of 8-16
+    # characters ("S__loc_l0001 + "), and the recursive walk depth roughly
+    # tracks term count plus a small constant for surrounding nodes.
+    needed = max(2000, longest_expr // 4 + 1000)
+    saved_limit = sys.getrecursionlimit()
+    if needed > saved_limit:
+        sys.setrecursionlimit(needed)
+    try:
+        return _build_vector_plan_inner(rhs)
+    finally:
+        sys.setrecursionlimit(saved_limit)
+
+
+def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
+    rhs: NormalizedRhs,
+) -> _VectorPlan | None:
+    """Vectorized-plan construction body (see ``build_vector_plan``)."""
     if not rhs.state_templates:
         return None
     # Require all states to be wildcard templates (have axes).

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -881,42 +881,61 @@ def _distribute_const_over_add(tree: ast.Expression) -> ast.Expression:
             ]
             return _reassemble_addsub(new_terms)
 
-    def _is_addsub(n: ast.AST) -> bool:
-        return isinstance(n, ast.BinOp) and isinstance(n.op, (ast.Add, ast.Sub))
-
     transformer = _Distributor()
     body = tree.body
-    if _is_addsub(body):
-        # Iteratively flatten the (possibly enormous) outer chain and rewrite
-        # each leaf in isolation. Loop to a fixed point so distribution that
-        # produces new sub-chains gets refolded into the outer chain.
-        max_passes = 64  # safety bound; convergence is typically immediate
-        for _ in range(max_passes):
-            terms = _flatten_addsub(body)
-            new_terms: list[tuple[int, ast.expr]] = []
-            any_changed = False
-            for sign, leaf in terms:
-                # ``leaf`` is by construction not an Add/Sub root; depth is
-                # bounded by leaf complexity, so the recursive visit is safe.
-                rewritten = cast("ast.expr", transformer.visit(leaf))
-                if _is_addsub(rewritten):
-                    sub_terms = _flatten_addsub(rewritten)
-                    for ssign, sleaf in sub_terms:
-                        new_terms.append((sign * ssign, sleaf))
-                    any_changed = True
-                else:
-                    if rewritten is not leaf:
-                        any_changed = True
-                    new_terms.append((sign, rewritten))
-            body = _reassemble_addsub(new_terms)
-            if not any_changed:
-                break
+    if _is_addsub_binop(body):
+        body = _distribute_addsub_chain(body, transformer)
     else:
         # No top-level chain: the body itself is shallow enough to recurse.
         body = cast("ast.expr", transformer.visit(body))
     new_tree = ast.Expression(body=body)
     ast.fix_missing_locations(new_tree)
     return new_tree
+
+
+def _is_addsub_binop(n: ast.AST) -> bool:
+    """Return True iff ``n`` is an ``ast.BinOp`` with an Add/Sub operator."""
+    return isinstance(n, ast.BinOp) and isinstance(n.op, (ast.Add, ast.Sub))
+
+
+def _distribute_addsub_chain(
+    body: ast.expr, transformer: ast.NodeTransformer
+) -> ast.expr:
+    """Iteratively flatten an Add/Sub chain and rewrite each leaf in place.
+
+    Loops to a fixed point so that distribution which produces new sub-chains
+    (``c*(a+b) -> c*a + c*b``) is refolded into the outer chain. Each leaf is
+    visited via ``transformer`` independently; leaf depth is bounded by leaf
+    complexity (typically <=5), not by chain length, so the recursive visit
+    is safe even when the outer chain has thousands of terms.
+
+    Args:
+        body: A top-level Add/Sub binop to distribute over.
+        transformer: An ``ast.NodeTransformer`` (typically ``_Distributor``)
+            that rewrites a single leaf expression.
+
+    Returns:
+        A possibly-rewritten ``ast.expr`` semantically equal to ``body``.
+    """
+    max_passes = 64  # safety bound; convergence is typically immediate
+    for _ in range(max_passes):
+        terms = _flatten_addsub(body)
+        new_terms: list[tuple[int, ast.expr]] = []
+        any_changed = False
+        for sign, leaf in terms:
+            rewritten = cast("ast.expr", transformer.visit(leaf))
+            if _is_addsub_binop(rewritten):
+                for ssign, sleaf in _flatten_addsub(rewritten):
+                    new_terms.append((sign * ssign, sleaf))
+                any_changed = True
+            else:
+                if rewritten is not leaf:
+                    any_changed = True
+                new_terms.append((sign, rewritten))
+        body = _reassemble_addsub(new_terms)
+        if not any_changed:
+            break
+    return body
 
 
 def _collapse_full_buffer_sums(  # noqa: C901, PLR0915
@@ -1014,7 +1033,7 @@ def _collapse_full_buffer_sums(  # noqa: C901, PLR0915
                 ws = [w for _t, w in items]
                 if all(w == 1.0 for w in ws):  # noqa: RUF069
                     collapsed.append((sign, _make_sum_call(name)))
-                elif all(w == ws[0] for w in ws):  # noqa: RUF069
+                elif all(w == ws[0] for w in ws):
                     collapsed.append((
                         sign,
                         ast.BinOp(
@@ -1261,7 +1280,7 @@ def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR
 # ---------------------------------------------------------------------------
 
 
-def build_vector_plan(rhs: NormalizedRhs) -> _VectorPlan | None:  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
+def build_vector_plan(rhs: NormalizedRhs) -> _VectorPlan | None:
     """Try to build a vectorized plan for ``rhs``.
 
     Returns:
@@ -1306,7 +1325,13 @@ def build_vector_plan(rhs: NormalizedRhs) -> _VectorPlan | None:  # noqa: C901, 
 def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
     rhs: NormalizedRhs,
 ) -> _VectorPlan | None:
-    """Vectorized-plan construction body (see ``build_vector_plan``)."""
+    """Vectorized-plan construction body (see ``build_vector_plan``).
+
+    Returns:
+        A ``_VectorPlan`` describing the vectorized layout, or ``None`` to
+        signal that the spec is unsupported and the caller should fall back
+        to the scalar engine.
+    """
     if not rhs.state_templates:
         return None
     # Require all states to be wildcard templates (have axes).

--- a/tests/op_system/test_op_system_vectorize.py
+++ b/tests/op_system/test_op_system_vectorize.py
@@ -407,3 +407,168 @@ def test_weighted_apply_along_collapses_to_fused_reduction() -> None:
 def test_weighted_apply_along_eval_matches_scalar() -> None:
     """Numerical equivalence between fused-reduce and scalar eval paths."""
     _eval_equal(_continuum_integrate_spec(), beta=0.3, gamma=0.1)
+
+
+# ---------------------------------------------------------------------------
+# Uniform-weight collapse (op_system#103 regression guard)
+#
+# When ``_distribute_const_over_add`` pushes an outer constant factor over a
+# ``kernel=sum`` apply_along chain, every leaf in the resulting Add chain
+# carries the same weight ``c``. The collapser must emit
+# ``c * np.sum(buf)`` rather than ``np.sum(np.asarray([c, ..., c]) * buf)``;
+# the inlined uniform array form bloats the JAX trace and balloons XLA
+# compile time on large network/categorical models (see issue #103).
+# ---------------------------------------------------------------------------
+
+
+def _network_outer_const_spec() -> dict[str, object]:
+    """Categorical SIR whose alias has a constant factor outside ``kernel=sum``.
+
+    The ``S_scaled`` alias multiplies a numeric constant by a full-axis
+    ``apply_along(kernel=sum)`` over a templated state. Post-normalize this
+    expands to ``0.25 * (S__age_y__loc_a + S__age_y__loc_b + ...)``; after
+    ``_distribute_const_over_add`` the chain becomes
+    ``0.25*S_buf[0,0] + 0.25*S_buf[0,1] + ...`` — a uniform-weight chain
+    that the collapser must fold back to ``0.25 * np.sum(S_buf)``.
+
+    Returns:
+        A spec dict suitable for passing to ``normalize_rhs``.
+    """
+    return {
+        "kind": "expr",
+        "axes": [
+            {"name": "age", "coords": ["y", "o"]},
+            {"name": "loc", "coords": ["a", "b"]},
+        ],
+        "state": ["S[age, loc]", "I[age, loc]"],
+        "params": ["beta", "gamma"],
+        "aliases": {
+            "S_scaled": (
+                "0.25 * apply_along(age=a, "
+                "apply_along(loc=l, S[age=a, loc=l], kernel=sum), "
+                "kernel=sum)"
+            ),
+        },
+        "equations": {
+            "S[age, loc]": "-beta * S[age, loc] * S_scaled",
+            "I[age, loc]": ("beta * S[age, loc] * S_scaled - gamma * I[age, loc]"),
+        },
+    }
+
+
+def test_uniform_weight_chain_collapses_without_inlined_array() -> None:
+    """Uniform-weight full-cover chain must emit ``c*np.sum(buf)``.
+
+    Regression test for op_system#103: the previous emission used
+    ``np.sum(np.asarray([c, c, ..., c]).reshape(shape) * buf)``, embedding
+    an inlined Python literal of length ``prod(shape)`` in every alias
+    that had any outer constant factor multiplying a ``kernel=sum``
+    apply_along. On large network configs this produced multi-minute XLA
+    compiles. The fix must (a) keep ``S_buf`` referenced once, (b) keep
+    ``sum`` referenced, and (c) NOT emit ``asarray`` for this case.
+    """
+    rhs = normalize_rhs(_network_outer_const_spec())
+    plan = build_vector_plan(rhs)
+    assert plan is not None
+    alias_codes = {base: code for base, code, _shape in plan.alias_codes}
+    assert "S_scaled" in alias_codes
+    code = alias_codes["S_scaled"]
+    s_buf_loads = sum(
+        1
+        for instr in dis.get_instructions(code)
+        if instr.opname.startswith("LOAD_") and instr.argval == "S_buf"
+    )
+    assert s_buf_loads == 1, (
+        f"expected a single fused S_buf load after collapse, got {s_buf_loads}"
+    )
+    assert "sum" in code.co_names, (
+        "uniform-weight chain should collapse to a single np.sum call"
+    )
+    assert "asarray" not in code.co_names, (
+        "uniform-weight chain must NOT emit an inlined np.asarray weight "
+        "array (regression of op_system#103); expected c * np.sum(buf) form"
+    )
+    # The constant factor 0.25 must survive somewhere in co_consts.
+    assert any(
+        isinstance(c, float) and c == 0.25  # noqa: RUF069
+        for c in code.co_consts
+    ), f"expected 0.25 constant in co_consts, got {code.co_consts}"
+
+
+def test_uniform_weight_chain_eval_matches_scalar() -> None:
+    """Numerical equivalence on the uniform-weight collapse path."""
+    _eval_equal(_network_outer_const_spec(), beta=0.3, gamma=0.1)
+
+
+# ---------------------------------------------------------------------------
+# Recursion-safety on long Add chains (op_system#103 regression guard)
+#
+# Aggregator aliases that sum across a large templated state expand at
+# normalize time to a single Add chain with one term per cell. With the
+# previous recursive ``ast.NodeTransformer``-based ``_distribute_const_over_add``
+# pass, chains beyond Python's default ~1000-frame limit raised a silent
+# ``RecursionError`` that was swallowed by the blanket ``except`` in
+# ``build_vector_plan``, dropping the model to the scalar fallback (a 100x
+# slowdown on real workloads). The pass must now be iterative on the outer
+# chain and survive arbitrarily long aliases.
+# ---------------------------------------------------------------------------
+
+
+def _huge_chain_spec(n_loc: int) -> dict[str, object]:
+    """Categorical SIR with ``n_loc`` locations and a constant-scaled aggregator.
+
+    The ``S_scaled`` alias forces ``_distribute_const_over_add`` to walk a
+    chain of ``n_loc`` Add terms; the outer ``0.25`` factor must be pushed
+    inside before the collapser can fold the chain into ``c * np.sum(buf)``.
+
+    Args:
+        n_loc: Number of synthetic location coords (chain length).
+
+    Returns:
+        A spec dict suitable for passing to ``normalize_rhs``.
+    """
+    coords = [f"l{i:04d}" for i in range(n_loc)]
+    return {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": coords}],
+        "state": ["S[loc]", "I[loc]"],
+        "params": ["beta", "gamma"],
+        "aliases": {
+            "S_scaled": "0.25 * apply_along(loc=l, S[loc=l], kernel=sum)",
+        },
+        "equations": {
+            "S[loc]": "-beta * S[loc] * S_scaled",
+            "I[loc]": "beta * S[loc] * S_scaled - gamma * I[loc]",
+        },
+    }
+
+
+def test_long_add_chain_does_not_raise_recursionerror() -> None:
+    """Chains far beyond ``sys.getrecursionlimit()`` must vectorize cleanly.
+
+    Regression guard for op_system#103: the previous recursive pass blew the
+    Python C-stack on any aggregator alias whose expanded Add chain exceeded
+    the default 1000-frame recursion limit. Picks ``n_loc`` well above any
+    plausible default limit so that a recursive implementation would fail
+    even if the user has bumped ``setrecursionlimit`` modestly.
+    """
+    rhs = normalize_rhs(_huge_chain_spec(n_loc=2500))
+    plan = build_vector_plan(rhs)
+    assert plan is not None, (
+        "build_vector_plan returned None on a long-chain alias - "
+        "_distribute_const_over_add likely raised RecursionError that "
+        "was swallowed by the blanket except in build_vector_plan"
+    )
+    alias_codes = {base: code for base, code, _shape in plan.alias_codes}
+    assert "S_scaled" in alias_codes
+    code = alias_codes["S_scaled"]
+    # Must still collapse to the fused np.sum(buf) form, not unroll 2500 loads.
+    s_buf_loads = sum(
+        1
+        for instr in dis.get_instructions(code)
+        if instr.opname.startswith("LOAD_") and instr.argval == "S_buf"
+    )
+    assert s_buf_loads == 1, (
+        f"long chain should still collapse to a single S_buf load, "
+        f"got {s_buf_loads}"
+    )

--- a/tests/op_system/test_op_system_vectorize.py
+++ b/tests/op_system/test_op_system_vectorize.py
@@ -569,6 +569,5 @@ def test_long_add_chain_does_not_raise_recursionerror() -> None:
         if instr.opname.startswith("LOAD_") and instr.argval == "S_buf"
     )
     assert s_buf_loads == 1, (
-        f"long chain should still collapse to a single S_buf load, "
-        f"got {s_buf_loads}"
+        f"long chain should still collapse to a single S_buf load, got {s_buf_loads}"
     )


### PR DESCRIPTION
perf(#103): iterative Add-chain rewrite + uniform-weight collapse

The vectorized compile path silently bailed on any model whose normalize-time
expansion produced an Add chain longer than Python's default recursion limit.
This dropped network and continuum models to the scalar fallback, causing
two regressions tracked in op_system#103:

1. Long-chain bail. Aggregator aliases that sum every cell of a templated
   state expand to a single ~N-term Add chain. Recursive AST visitors
   (`_NameRewriter`, `_distribute_const_over_add`, CPython's `compile` and
   `ast.fix_missing_locations`) consume one Python frame per chain node and
   raise RecursionError, which was swallowed by the blanket `except` in
   `build_vector_plan`. Result: silent fallback to scalar with ~100x
   slowdown.

2. Inlined uniform-weight array. When the distributor pushed an outer
   constant factor over a kernel=sum chain, the collapser emitted
   `np.sum(np.asarray([c, ..., c]).reshape(shape) * buf)` rather than
   `c * np.sum(buf)`. The inlined per-cell literal balloned XLA compile
   time on large categorical models.

Fixes:

- `_distribute_const_over_add` is now iterative on the outer Add chain,
  using the existing iterative `_flatten_addsub` / `_reassemble_addsub`
  primitives. Each leaf is rewritten in isolation; leaf depth is bounded
  by expression complexity, not by chain length. Loops to a fixed point
  so distribution that produces sub-chains gets refolded into the outer
  chain.
- `_collapse_full_buffer_sums` learned a uniform-weight branch that emits
  `c * np.sum(buf)` (or just `np.sum(buf)` when c == 1) instead of an
  inlined weight array.
- `build_vector_plan` installs a sized `sys.setrecursionlimit` guard for
  the duration of the call, scaled to the longest alias-or-equation
  expression. This is a temporary safety net for the remaining recursive
  passes (notably `_NameRewriter`); it does not eliminate the underlying
  C-stack ceiling and will be removed when those passes are migrated to
  iterative term-list form (planned as part of the structured-IR refactor).

Tests:

- Adds `test_long_add_chain_does_not_raise_recursionerror` (n_loc=2500,
  exceeds default 1000-frame limit).
- Adds `test_uniform_weight_chain_collapses_without_inlined_array` and
  `test_uniform_weight_chain_eval_matches_scalar`.
- All 211 existing op_system tests continue to pass.

Bench (COVID19_USA prior-predictive, JAX_PLATFORMS=cpu):
- Network model: 1.6s cold / 0.06s warm (was 383s cold / 1.7s warm post-#100).
- Hier configs (4x bspline/hsgp x joint/separable): ~1.5s cold / ~0.06s warm.
- Continuum (72k states): now succeeds at 2.4s cold / 0.5s warm (was hang).

Closes  #103.