### PR TITLE
fix(#109): preserve same-axis-twice through templated alias expansion

### DIFF
--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -1094,12 +1094,24 @@ def _expand_alias_templates(
             raise InvalidRhsSpecError(
                 detail=f"aliases[{raw_name!r}] must be a non-empty string"
             )
-        expr_s = _expand_helpers(expr_s, axes=axes, shaped_params=shaped_params)
 
         if canonical_name in alias_template_map:
+            # Defer ``_expand_helpers`` until the per-row LHS assignment is
+            # known so that same-axis-twice references like
+            # ``K[age, age=ap]`` inside a templated alias (e.g. ``foi[age]``)
+            # resolve the bare LHS-free position from the row assignment
+            # rather than collapsing onto the bound ``apply_along`` coord.
+            # Mirrors the equations path in ``_resolve_template_equation``.
             for expanded_name, assignment in alias_template_map[canonical_name]:
-                substituted = _apply_template_substitutions(
+                expanded_expr = _expand_helpers(
                     expr_s,
+                    axes=axes,
+                    shaped_params=shaped_params,
+                    lhs_assignment=assignment,
+                    axis_coords=axis_lookup,
+                )
+                substituted = _apply_template_substitutions(
+                    expanded_expr,
                     assignment=assignment,
                     template_map=combined_template_map,
                     shaped_params=shaped_params,
@@ -1107,7 +1119,9 @@ def _expand_alias_templates(
                 )
                 aliases_out[expanded_name] = substituted
         else:
-            aliases_out[raw_name] = expr_s
+            aliases_out[raw_name] = _expand_helpers(
+                expr_s, axes=axes, shaped_params=shaped_params
+            )
 
     return aliases_out, alias_template_map
 

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -353,6 +353,46 @@ def test_same_axis_twice_apply_along_eval_end_to_end() -> None:
     assert np.allclose(out[3:], np.array([140.0, 320.0, 500.0]))
 
 
+def test_same_axis_twice_in_templated_alias_substituted_into_transition() -> None:
+    """Regression — same-axis-twice survives alias→transition substitution.
+
+    Mirrors `test_same_axis_twice_apply_along_per_row_contraction` but the
+    same-axis-twice contraction lives inside a *templated alias*
+    (``foi[age]``) that is referenced from a transition rate
+    (``foi[age] * theta[imm]``). Before the fix the alias's
+    ``apply_along`` was helper-expanded once *without* an LHS row binding,
+    which collapsed ``K[age, age=ap]`` onto the bound coord and leaked the
+    full Cartesian product of K cells (e.g. ``K__age_a0__age_a0``) into
+    ``param_names`` instead of preserving the per-row contraction.
+    """
+    spec = {
+        "kind": "transitions",
+        "axes": [
+            {"name": "age", "coords": ["a0", "a1", "a2"]},
+            {"name": "vax", "coords": ["u", "v"]},
+            {"name": "imm", "type": "ordinal", "coords": ["x0", "x1"]},
+        ],
+        "state": ["I[age, vax]", "X[age, vax, imm]", "E[age, vax]"],
+        "aliases": {
+            "foi[age]": (
+                "apply_along(age=ap, K[age, age=ap]"
+                " * apply_along(vax=v, I[age=ap, vax=v]))"
+            ),
+        },
+        "transitions": [
+            {
+                "from": "X[age, vax, imm]",
+                "to": "E[age, vax]",
+                "rate": "foi[age] * theta[imm]",
+            },
+        ],
+    }
+    rhs = normalize_transitions_rhs(spec)
+    assert dict(rhs.shaped_params) == {"K": ("age", "age"), "theta": ("imm",)}
+    leaked = [n for n in rhs.param_names if "K" in n or n.startswith("foi")]
+    assert leaked == [], leaked
+
+
 def test_alias_subscript_axis_token_does_not_leak_into_param_names() -> None:
     """Axis names that appear only as subscripts in aliases are not params.
 


### PR DESCRIPTION
Closes #109.

## What

`_expand_alias_templates` was calling `_expand_helpers` once on the alias body **before** the per-row template substitution loop. When the alias was a templated `foi[age]` referencing `K[age, age=ap]` inside an `apply_along`, the helper expansion had no LHS row binding available and the `_substitute_apply_along_brackets` fix from #108 fell back to per-cell mangling — leaking `K__age_a0__age_a0`, `K__age_a0__age_a1`, … into `NormalizedRhs.param_names`.

This PR moves the `_expand_helpers` call **inside** the per-row loop for templated aliases, passing `lhs_assignment=assignment` and `axis_coords=axis_lookup`, mirroring `_resolve_template_equation` (which #108 fixed for the equations path).

## Tests

- New regression: `test_same_axis_twice_in_templated_alias_substituted_into_transition` — templated `foi[age]` alias with `K[age, age=ap]` substituted into a transition rate; asserts `K` stays in `shaped_params` and no `K__`/`foi` per-cell scalars leak into `param_names`.
- Full suite: 213 passed (was 212; +1 new).

## Motivation

Unblocks the COVID19_USA SMH R19 op_system migration where the legacy global mass-action FOI is replaced with a POLYMOD-fitted age × age contact-kernel contraction.