### PR TITLE
fix(#113): consume LHS-template axes in apply_along bracket rewriter

### DIFF
--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -1902,6 +1902,20 @@ def _substitute_apply_along_brackets(  # noqa: C901, PLR0913, PLR0915
                 consumed.append((entry, bound[entry]))
                 resolved.append((entry, bound[entry], "bound"))
                 continue
+            if entry in lhs_assignment:
+                # Bare LHS-template axis appearing in a state/param subscript
+                # alongside ``=``-bound apply_along coords (e.g. the ``loc``
+                # in ``X[loc, age=ap, vax=v, imm=k]`` inside a
+                # ``foi[age, loc]`` alias body). Consume it from the row
+                # assignment so the cell name is emitted in canonical
+                # ``axis_order`` rather than left as a trailing
+                # ``[loc]`` placeholder that downstream string substitution
+                # would re-append in binding order, breaking the canonical
+                # state-cell encoding.
+                coord = lhs_assignment[entry]
+                consumed.append((entry, coord))
+                resolved.append((entry, coord, "lhs"))
+                continue
             resolved.append((entry, None, None))
             remaining.append(entry)
 

--- a/src/op_system/_templates.py
+++ b/src/op_system/_templates.py
@@ -453,7 +453,9 @@ def _apply_template_substitutions(
     def _inline_replacer(match: re.Match[str]) -> str:
         inner_base = match.group(1)
         inner = match.group(2)
-        phs = [p.strip() for p in inner.split(",") if p.strip() and "=" not in p]
+        raw_parts = [p.strip() for p in inner.split(",") if p.strip()]
+        phs = [p for p in raw_parts if "=" not in p]
+        bound_parts = [p for p in raw_parts if "=" in p]
         if not phs or any(ph not in assignment for ph in phs):
             return match.group(0)
         if inner_base in shaped:
@@ -468,6 +470,22 @@ def _apply_template_substitutions(
             except (KeyError, ValueError):
                 return match.group(0)
             return f"{inner_base}[{', '.join(str(i) for i in idxs)}]"
+        if bound_parts:
+            # Mixed mode: bare LHS-template placeholders alongside =-bound
+            # apply_along coords (e.g. ``X[loc, age=ap, vax=v, imm=k]`` inside
+            # a ``foi[age, loc]`` alias body). Collapsing to a per-cell name
+            # would discard the bound entries and break downstream
+            # vectorization. Instead, rewrite each bare placeholder as an
+            # ``axis=coord`` binding from the row assignment and preserve the
+            # already-bound parts verbatim, producing a literal-cell selector
+            # the regular apply_along/vectorize path resolves correctly.
+            new_parts: list[str] = []
+            for part in raw_parts:
+                if "=" in part:
+                    new_parts.append(part)
+                else:
+                    new_parts.append(f"{part}={assignment[part]}")
+            return f"{inner_base}[{', '.join(new_parts)}]"
         return _render_template_name(inner_base, phs, assignment)
 
     return _INLINE_TEMPLATE_RE.sub(_inline_replacer, expr_out)

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -393,6 +393,82 @@ def test_same_axis_twice_in_templated_alias_substituted_into_transition() -> Non
     assert leaked == [], leaked
 
 
+def test_lhs_template_axis_in_state_subscript_with_bound_apply_along() -> None:
+    """Regression for #113 — bare LHS-template axis mixed with bound coords.
+
+    A templated alias body (e.g. ``foi[age, loc]``) may reference state
+    cells whose subscript mixes a bare LHS-template placeholder (``loc``,
+    threaded from the alias row assignment) with ``=``-bound apply_along
+    coords (``age=ap``, ``vax=v``, ``imm=k``):
+
+        foi[age, loc]: "apply_along(vax=v,
+                          apply_along(imm=k, X[loc, age=ap, vax=v, imm=k]))"
+
+    Before the fix, ``_substitute_apply_along_brackets`` consumed only the
+    ``=``-bound entries and left ``loc`` as a trailing ``[loc]``
+    placeholder, producing an intermediate like
+    ``X__age_a0__vax_u__imm_x0[loc]``. Downstream string substitution then
+    appended ``__loc_AK`` in binding order, yielding
+    ``X__age_a0__vax_u__imm_x0__loc_AK`` — a name that does not match the
+    canonical state-template encoding ``X__age_a0__vax_u__loc_AK__imm_x0``
+    and therefore looks like a missing parameter to the simulator.
+
+    Expected: bare LHS-template axes are consumed from the row assignment
+    alongside the bound coords, and the final cell name is emitted in
+    canonical ``axis_order`` (matching the declared state template).
+    """
+    spec = {
+        "kind": "transitions",
+        "axes": [
+            {"name": "age", "coords": ["a0", "a1"]},
+            {"name": "vax", "coords": ["u", "v"]},
+            {"name": "loc", "coords": ["AK", "AL"]},
+            {"name": "imm", "type": "ordinal", "coords": ["x0", "x1"]},
+        ],
+        "state": [
+            "I[age, vax, loc]",
+            "X[age, vax, loc, imm]",
+            "E[age, vax, loc]",
+        ],
+        "aliases": {
+            "foi[age, loc]": (
+                "apply_along(age=ap, apply_along(vax=v,"
+                " I[loc, age=ap, vax=v]"
+                " + apply_along(imm=k, X[loc, age=ap, vax=v, imm=k])))"
+            ),
+        },
+        "transitions": [
+            {
+                "from": "X[age, vax, loc, imm]",
+                "to": "E[age, vax, loc]",
+                "rate": "foi[age, loc] * theta[imm]",
+            },
+        ],
+    }
+    rhs = normalize_transitions_rhs(spec)
+    state_set = set(rhs.state_names)
+    body = rhs.aliases["foi__age_a0__loc_AK"]
+    # Every X__/I__ reference inside the alias body must resolve to an
+    # existing canonical state cell (i.e. axis_order is preserved).
+    found_state_refs = [
+        m
+        for m in re.findall(r"[A-Za-z_][A-Za-z0-9_]*__[A-Za-z0-9_]+", body)
+        if m.split("__", 1)[0] in {"I", "X"}
+    ]
+    assert found_state_refs, "expected state references in alias body"
+    missing = [m for m in found_state_refs if m not in state_set]
+    assert missing == [], (
+        f"alias body references non-canonical cells: {missing[:3]}"
+    )
+    # No spurious params from the alias-body collapse path.
+    leaked = [
+        n
+        for n in rhs.param_names
+        if n.startswith("X__") or n.startswith("I__") or n.startswith("foi")
+    ]
+    assert leaked == [], leaked
+
+
 def test_alias_subscript_axis_token_does_not_leak_into_param_names() -> None:
     """Axis names that appear only as subscripts in aliases are not params.
 


### PR DESCRIPTION
Fixes #113. Part of #7 / #112.

## Problem

When a templated alias body (e.g. `foi[age, loc]`) references a state
cell whose subscript mixes a bare LHS-template placeholder with
`=`-bound apply_along coords:

```yaml
foi[age, loc]: "apply_along(age=ap, apply_along(vax=v,
                  apply_along(imm=k, X[loc, age=ap, vax=v, imm=k])))"
```

`_substitute_apply_along_brackets` in `_normalize.py` only consumed the
`=`-bound entries and left the bare `loc` axis as a trailing `[loc]`
placeholder. Downstream string substitution then appended `__loc_AK`
in binding order, producing a non-canonical name like
`X__age_a0__vax_u__imm_x0__loc_AK` that does not match the declared
state-template axis order
(`X__age_a0__vax_u__loc_AK__imm_x0`) and surfaced as:

```
KeyError: "Required parameter 'X__age_age0to17__vax_unvaccinated__imm_x0__loc_AK' was requested but not configured."
```

This blocked all four `SMH_R19_op_system_hier_*` configs in
COVID19_USA that use the per-loc force-of-infection alias form.

## Fix

In `_substitute_apply_along_brackets._sub`, consume bare axes from
`lhs_assignment` (in addition to the existing same-axis-twice path)
so the final cell is emitted in canonical `axis_order`.

Also hardens `_apply_template_substitutions._inline_replacer` to
detect the mixed-mode case (bare placeholders + `=`-bound parts) and
rewrite bare placeholders as `axis=coord` bindings rather than
collapsing to per-cell names — defense in depth for the same class of
leak (kept because there's no axis ordering protection in the inline
substitution path either).

## Verification

- 229/229 tests pass (228 pre-existing + 1 new regression).
- `SMH_R19_op_system_hier_bspline_joint.yml` dry-run: exit 0.
- Inspected resulting alias body: state references resolve to canonical
  cells (`X__age_age0to17__vax_unvaccinated__loc_AK__imm_x0`).

## Test added

`test_lhs_template_axis_in_state_subscript_with_bound_apply_along` in
`tests/op_system/test_op_system_specs.py` — minimal `transitions`
spec with a templated alias whose body mixes bare LHS-template axes
with bound apply_along coords; asserts every state reference in the
expanded alias body resolves to a declared canonical state cell and no
state-shaped names leak into `param_names`.

## Notes

This is a tactical fix for the immediate blocker. The deeper
fragility (two parallel string-substitution passes with subtly
different axis-handling semantics) is tracked under milestone #7
("Typed expression IR") and umbrella #112.
