### PR TITLE
feat(#112): typed expression IR foundation + ExpressionString

### DIFF
--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -33,13 +33,11 @@ from types import MappingProxyType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Literal,
     NamedTuple,
     cast,
 )
 
 import numpy as np
-from flepimop2.configuration import ModuleModel
 from flepimop2.parameter.abc import ModelStateSpecification, ParameterRequest
 from flepimop2.system.abc import SystemABC
 from flepimop2.typing import (
@@ -71,8 +69,7 @@ class _AxesMeta(NamedTuple):
     axis_coords: dict[str, np.ndarray]
 
 
-class OpSystemSystem(ModuleModel, SystemABC):  # noqa: D101
-    module: Literal["flepimop2.system.op_system"] = "flepimop2.system.op_system"
+class OpSystemSystem(SystemABC, module="flepimop2.system.op_system"):  # noqa: D101
     state_change: StateChangeEnum = StateChangeEnum.FLOW
 
     spec: dict[str, object] = Field(

--- a/src/op_system/__init__.py
+++ b/src/op_system/__init__.py
@@ -31,6 +31,7 @@ from op_system._typing import Array
 
 from .compile import CompiledRhs, EvalFn, compile_rhs
 from .specs import (
+    ExpressionString,
     NormalizedRhs,
     normalize_expr_rhs,
     normalize_rhs,
@@ -109,6 +110,7 @@ __all__ = [
     "Array",
     "CompiledRhs",
     "EvalFn",
+    "ExpressionString",
     "IdentifierString",
     "NormalizedRhs",
     "StateString",

--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -98,6 +98,22 @@ _CMP_OP_NAMES: dict[type[ast.cmpop], str] = {
     ast.GtE: ">=",
 }
 
+_BINARY_OPS: frozenset[str] = frozenset({
+    "+",
+    "-",
+    "*",
+    "/",
+    "%",
+    "==",
+    "!=",
+    "<",
+    "<=",
+    ">",
+    ">=",
+    "and",
+    "or",
+})
+
 
 def _invalid(*, detail: str) -> NoReturn:
     raise InvalidExpressionError(detail=detail)
@@ -310,6 +326,75 @@ def parse_expr_to_ir(expr: str, *, lower_helpers: bool = False) -> Expr:
     return ir
 
 
+def _unparse_axis_index(idx: AxisIndex) -> str:
+    if idx.placeholder is not None:
+        return f"${idx.placeholder}"
+    if idx.coord is not None:
+        return repr(idx.coord)
+    return idx.axis
+
+
+def _unparse_call_args(args: tuple[Expr, ...]) -> str:
+    parts: list[str] = []
+    for arg in args:
+        if isinstance(arg, Apply) and arg.op == "kwarg":
+            key_node, value_node = arg.args
+            if not isinstance(key_node, Literal) or not isinstance(
+                key_node.value, str
+            ):
+                _invalid(detail="malformed kwarg node in IR unparser")
+            parts.append(f"{key_node.value}={unparse_ir(value_node)}")
+        else:
+            parts.append(unparse_ir(arg))
+    return ", ".join(parts)
+
+
+def unparse_ir(expr: Expr) -> str:  # noqa: C901, PLR0911
+    """Render a typed IR expression back to its Python source string.
+
+    Args:
+        expr: Typed IR expression.
+
+    Returns:
+        Python expression source string equivalent to ``expr``.
+    """
+    if isinstance(expr, Literal):
+        return repr(expr.value)
+
+    if isinstance(expr, Sym):
+        return expr.name
+
+    if isinstance(expr, Subscript):
+        idx_str = ", ".join(_unparse_axis_index(i) for i in expr.indices)
+        return f"{expr.name}[{idx_str}]"
+
+    if isinstance(expr, Apply):
+        if expr.op == "neg" and len(expr.args) == 1:
+            return f"-({unparse_ir(expr.args[0])})"
+        if expr.op == "pos" and len(expr.args) == 1:
+            return f"+({unparse_ir(expr.args[0])})"
+        if expr.op == "pow" and len(expr.args) == 2:
+            left, right = expr.args
+            return f"({unparse_ir(left)}) ** ({unparse_ir(right)})"
+        if expr.op == "ifelse" and len(expr.args) == 3:
+            test, body, orelse = expr.args
+            return (
+                f"({unparse_ir(body)}) if ({unparse_ir(test)})"
+                f" else ({unparse_ir(orelse)})"
+            )
+        if expr.op in _BINARY_OPS and len(expr.args) >= 2:
+            sep = f" {expr.op} "
+            return "(" + sep.join(unparse_ir(a) for a in expr.args) + ")"
+        return f"{expr.op}({_unparse_call_args(expr.args)})"
+
+    if isinstance(expr, Reduce):
+        binding_str = ", ".join(f"{k}={v}" for k, v in expr.bindings)
+        suffix = f", {binding_str}" if binding_str else ""
+        return f"{expr.kind}({unparse_ir(expr.body)}{suffix})"
+
+    _invalid(detail=f"unsupported IR node in unparser: {type(expr).__name__}")
+
+
 __all__ = [
     "Apply",
     "AxisIndex",
@@ -321,4 +406,5 @@ __all__ = [
     "lower_helper_calls",
     "parse_expr_to_ir",
     "to_ir",
+    "unparse_ir",
 ]

--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -339,9 +339,7 @@ def _unparse_call_args(args: tuple[Expr, ...]) -> str:
     for arg in args:
         if isinstance(arg, Apply) and arg.op == "kwarg":
             key_node, value_node = arg.args
-            if not isinstance(key_node, Literal) or not isinstance(
-                key_node.value, str
-            ):
+            if not isinstance(key_node, Literal) or not isinstance(key_node.value, str):
                 _invalid(detail="malformed kwarg node in IR unparser")
             parts.append(f"{key_node.value}={unparse_ir(value_node)}")
         else:

--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -73,6 +73,12 @@ class Reduce:
 
 Expr = Literal | Sym | Subscript | Apply | Reduce
 
+_HELPER_REDUCE_OPS: frozenset[str] = frozenset({
+    "apply_along",
+    "sum_over",
+    "integrate_over",
+})
+
 
 _BIN_OP_NAMES: dict[type[ast.operator], str] = {
     ast.Add: "+",
@@ -95,6 +101,70 @@ _CMP_OP_NAMES: dict[type[ast.cmpop], str] = {
 
 def _invalid(*, detail: str) -> NoReturn:
     raise InvalidExpressionError(detail=detail)
+
+
+def _kwarg_name(arg: Expr) -> str:
+    if isinstance(arg, Literal) and isinstance(arg.value, str):
+        return arg.value
+    _invalid(detail="kwarg marker must use a string key")
+
+
+def _kwarg_value_as_binding(value: Expr, *, key: str) -> str:
+    if isinstance(value, Sym):
+        return value.name
+    if isinstance(value, Literal):
+        return str(value.value)
+    _invalid(detail=f"helper binding {key!r} must be a symbol or literal")
+
+
+def _lower_single_helper(node: Apply) -> Expr:
+    if node.op not in _HELPER_REDUCE_OPS:
+        return node
+
+    kw_nodes: list[Apply] = []
+    positional: list[Expr] = []
+    for arg in node.args:
+        if isinstance(arg, Apply) and arg.op == "kwarg":
+            kw_nodes.append(arg)
+        else:
+            positional.append(arg)
+
+    if len(positional) != 1:
+        _invalid(detail=f"{node.op} helper requires exactly one body expression")
+
+    bindings: list[tuple[str, str]] = []
+    for kw_node in kw_nodes:
+        if len(kw_node.args) != 2:
+            _invalid(detail="kwarg marker must contain (key, value)")
+        key = _kwarg_name(kw_node.args[0])
+        val = _kwarg_value_as_binding(kw_node.args[1], key=key)
+        bindings.append((key, val))
+
+    return Reduce(kind=node.op, bindings=tuple(bindings), body=positional[0])
+
+
+def lower_helper_calls(expr: Expr) -> Expr:
+    """Lower helper-call ``Apply`` nodes into structured ``Reduce`` nodes.
+
+    This is a no-runtime-impact scaffolding pass used by Option 1 migration.
+    It rewrites helper calls in typed IR only; compile/normalize still consume
+    string expressions today.
+
+    Returns:
+        Expression IR with helper calls lowered to ``Reduce`` nodes.
+    """
+    if isinstance(expr, Apply):
+        lowered_args = tuple(lower_helper_calls(arg) for arg in expr.args)
+        return _lower_single_helper(Apply(op=expr.op, args=lowered_args))
+
+    if isinstance(expr, Reduce):
+        return Reduce(
+            kind=expr.kind,
+            bindings=expr.bindings,
+            body=lower_helper_calls(expr.body),
+        )
+
+    return expr
 
 
 def _call_name(func: ast.AST) -> str:
@@ -193,9 +263,19 @@ def to_ir(node: ast.AST) -> Expr:  # noqa: C901, PLR0911, PLR0912
         )
 
     if isinstance(node, ast.Call):
+        call_args: list[Expr] = [to_ir(arg) for arg in node.args]
+        for kw in node.keywords:
+            if kw.arg is None:
+                _invalid(detail="kwargs unpacking is not supported in IR parser")
+            call_args.append(
+                Apply(
+                    op="kwarg",
+                    args=(Literal(value=kw.arg), to_ir(kw.value)),
+                )
+            )
         return Apply(
             op=_call_name(node.func),
-            args=tuple(to_ir(arg) for arg in node.args),
+            args=tuple(call_args),
         )
 
     if isinstance(node, ast.Subscript):
@@ -209,11 +289,12 @@ def to_ir(node: ast.AST) -> Expr:  # noqa: C901, PLR0911, PLR0912
     _invalid(detail=f"unsupported AST node in IR parser: {type(node).__name__}")
 
 
-def parse_expr_to_ir(expr: str) -> Expr:
+def parse_expr_to_ir(expr: str, *, lower_helpers: bool = False) -> Expr:
     """Parse an expression string and convert it to typed IR.
 
     Args:
         expr: Expression source string.
+        lower_helpers: When ``True``, lower helper-call nodes to ``Reduce``.
 
     Returns:
         Parsed IR tree.
@@ -223,7 +304,10 @@ def parse_expr_to_ir(expr: str) -> Expr:
         tree = ast.parse(expr, mode="eval")
     except SyntaxError as exc:
         _invalid(detail=f"invalid expression syntax: {exc.msg}")
-    return to_ir(tree)
+    ir = to_ir(tree)
+    if lower_helpers:
+        return lower_helper_calls(ir)
+    return ir
 
 
 __all__ = [
@@ -234,6 +318,7 @@ __all__ = [
     "Reduce",
     "Subscript",
     "Sym",
+    "lower_helper_calls",
     "parse_expr_to_ir",
     "to_ir",
 ]

--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -1,0 +1,239 @@
+"""Typed expression IR for op_system.
+
+This module introduces a small, immutable intermediate representation (IR)
+for expression terms. The initial scope is parse-only: convert Python AST
+expressions into typed IR nodes without changing compile/normalize behavior.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from typing import NoReturn
+
+from ._errors import InvalidExpressionError
+
+
+@dataclass(frozen=True, slots=True)
+class Literal:
+    """Literal scalar value in an expression."""
+
+    value: float | int | bool | str
+
+
+@dataclass(frozen=True, slots=True)
+class Sym:
+    """Bare identifier symbol (e.g. ``beta``, ``S``, ``np`` root names)."""
+
+    name: str
+
+
+@dataclass(frozen=True, slots=True)
+class AxisIndex:
+    """One subscript position for an indexed expression.
+
+    For the initial parse-only phase, ``axis`` stores the token text for
+    name-style indices (e.g. ``age`` in ``K[age, ap]``). Literal indices
+    (e.g. ``K[0]`` or ``K['x']``) are represented by ``coord``.
+    """
+
+    axis: str
+    coord: str | None = None
+    placeholder: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Subscript:
+    """Indexed reference (e.g. ``K[age, ap]``)."""
+
+    name: str
+    indices: tuple[AxisIndex, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class Apply:
+    """Generic operation/call node.
+
+    The ``op`` field stores either an operator token (e.g. ``+``, ``*``) or
+    function name (e.g. ``np.exp``, ``sum_state``).
+    """
+
+    op: str
+    args: tuple[Expr, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class Reduce:
+    """Reduction primitive placeholder for future helper-lowering passes."""
+
+    kind: str
+    bindings: tuple[tuple[str, str], ...]
+    body: Expr
+
+
+Expr = Literal | Sym | Subscript | Apply | Reduce
+
+
+_BIN_OP_NAMES: dict[type[ast.operator], str] = {
+    ast.Add: "+",
+    ast.Sub: "-",
+    ast.Mult: "*",
+    ast.Div: "/",
+    ast.Pow: "pow",
+    ast.Mod: "%",
+}
+
+_CMP_OP_NAMES: dict[type[ast.cmpop], str] = {
+    ast.Eq: "==",
+    ast.NotEq: "!=",
+    ast.Lt: "<",
+    ast.LtE: "<=",
+    ast.Gt: ">",
+    ast.GtE: ">=",
+}
+
+
+def _invalid(*, detail: str) -> NoReturn:
+    raise InvalidExpressionError(detail=detail)
+
+
+def _call_name(func: ast.AST) -> str:
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        parts: list[str] = [func.attr]
+        cur: ast.AST = func.value
+        while isinstance(cur, ast.Attribute):
+            parts.append(cur.attr)
+            cur = cur.value
+        if isinstance(cur, ast.Name):
+            parts.append(cur.id)
+            return ".".join(reversed(parts))
+    _invalid(detail="unsupported call target in IR parser")
+
+
+def _axis_index_from_expr(node: ast.expr) -> AxisIndex:
+    if isinstance(node, ast.Name):
+        if node.id.startswith("$"):
+            ph = node.id[1:]
+            return AxisIndex(axis=ph, placeholder=ph)
+        return AxisIndex(axis=node.id)
+    if isinstance(node, ast.Constant) and isinstance(
+        node.value, (str, int, float, bool)
+    ):
+        return AxisIndex(axis="", coord=str(node.value))
+    _invalid(detail=f"unsupported subscript index node: {type(node).__name__}")
+
+
+def _parse_subscript_indices(slc: ast.expr) -> tuple[AxisIndex, ...]:
+    if isinstance(slc, ast.Tuple):
+        return tuple(_axis_index_from_expr(elt) for elt in slc.elts)
+    return (_axis_index_from_expr(slc),)
+
+
+def to_ir(node: ast.AST) -> Expr:  # noqa: C901, PLR0911, PLR0912
+    """Convert a Python AST node (expression) into typed IR.
+
+    Args:
+        node: ``ast.Expression`` or ``ast.expr`` node.
+
+    Returns:
+        Parsed IR expression.
+
+    """
+    if isinstance(node, ast.Expression):
+        return to_ir(node.body)
+
+    if isinstance(node, ast.Name):
+        return Sym(name=node.id)
+
+    if isinstance(node, ast.Constant) and isinstance(
+        node.value, (str, int, float, bool)
+    ):
+        return Literal(value=node.value)
+
+    if isinstance(node, ast.BinOp):
+        op = _BIN_OP_NAMES.get(type(node.op))
+        if op is None:
+            _invalid(detail=f"unsupported binary operator: {type(node.op).__name__}")
+        return Apply(op=op, args=(to_ir(node.left), to_ir(node.right)))
+
+    if isinstance(node, ast.UnaryOp):
+        if isinstance(node.op, ast.USub):
+            return Apply(op="neg", args=(to_ir(node.operand),))
+        if isinstance(node.op, ast.UAdd):
+            return Apply(op="pos", args=(to_ir(node.operand),))
+        _invalid(detail=f"unsupported unary operator: {type(node.op).__name__}")
+
+    if isinstance(node, ast.BoolOp):
+        op = "and" if isinstance(node.op, ast.And) else "or"
+        return Apply(op=op, args=tuple(to_ir(v) for v in node.values))
+
+    if isinstance(node, ast.Compare):
+        if len(node.ops) != len(node.comparators):
+            _invalid(detail="malformed comparison node")
+        left = node.left
+        parts: list[Expr] = []
+        for op_node, right in zip(node.ops, node.comparators, strict=True):
+            op = _CMP_OP_NAMES.get(type(op_node))
+            if op is None:
+                _invalid(
+                    detail=f"unsupported comparison operator: {type(op_node).__name__}"
+                )
+            parts.append(Apply(op=op, args=(to_ir(left), to_ir(right))))
+            left = right
+        if len(parts) == 1:
+            return parts[0]
+        return Apply(op="and", args=tuple(parts))
+
+    if isinstance(node, ast.IfExp):
+        return Apply(
+            op="ifelse",
+            args=(to_ir(node.test), to_ir(node.body), to_ir(node.orelse)),
+        )
+
+    if isinstance(node, ast.Call):
+        return Apply(
+            op=_call_name(node.func),
+            args=tuple(to_ir(arg) for arg in node.args),
+        )
+
+    if isinstance(node, ast.Subscript):
+        if not isinstance(node.value, ast.Name):
+            _invalid(detail="subscript base must be a simple name")
+        return Subscript(
+            name=node.value.id,
+            indices=_parse_subscript_indices(node.slice),
+        )
+
+    _invalid(detail=f"unsupported AST node in IR parser: {type(node).__name__}")
+
+
+def parse_expr_to_ir(expr: str) -> Expr:
+    """Parse an expression string and convert it to typed IR.
+
+    Args:
+        expr: Expression source string.
+
+    Returns:
+        Parsed IR tree.
+
+    """
+    try:
+        tree = ast.parse(expr, mode="eval")
+    except SyntaxError as exc:
+        _invalid(detail=f"invalid expression syntax: {exc.msg}")
+    return to_ir(tree)
+
+
+__all__ = [
+    "Apply",
+    "AxisIndex",
+    "Expr",
+    "Literal",
+    "Reduce",
+    "Subscript",
+    "Sym",
+    "parse_expr_to_ir",
+    "to_ir",
+]

--- a/src/op_system/_symbols.py
+++ b/src/op_system/_symbols.py
@@ -6,8 +6,43 @@ AST-level symbol extraction utilities used by expression normalization.
 from __future__ import annotations
 
 import ast
+from dataclasses import dataclass, field
 
 from op_system._errors import InvalidExpressionError
+
+
+@dataclass(frozen=True, slots=True)
+class ExpressionString:
+    """Validated expression wrapper with cached AST and symbol names."""
+
+    source: str
+    ast: ast.AST = field(init=False, repr=False)
+    names: frozenset[str] = field(init=False)
+
+    def __post_init__(self) -> None:
+        try:
+            parsed = ast.parse(self.source, mode="eval")
+        except SyntaxError as exc:
+            raise InvalidExpressionError(
+                detail=f"invalid expression syntax: {exc.msg}"
+            ) from exc
+
+        found_names: set[str] = set()
+        for node in ast.walk(parsed):
+            if isinstance(node, ast.Name):
+                found_names.add(str(node.id))
+
+        object.__setattr__(self, "ast", parsed)
+        object.__setattr__(self, "names", frozenset(found_names))
+
+
+def parse_expression_string(expr: str) -> ExpressionString:
+    """Parse ``expr`` into an :class:`ExpressionString`.
+
+    Returns:
+        Validated expression wrapper with parsed AST and names.
+    """
+    return ExpressionString(expr)
 
 
 def _parse_expr(expr: str) -> ast.AST:
@@ -15,26 +50,29 @@ def _parse_expr(expr: str) -> ast.AST:
 
     Returns:
         The parsed AST node.
-
-    Raises:
-        InvalidExpressionError: If validation fails.
     """
-    try:
-        return ast.parse(expr, mode="eval")
-    except SyntaxError as exc:
-        raise InvalidExpressionError(
-            detail=f"invalid expression syntax: {exc.msg}"
-        ) from exc
+    return parse_expression_string(expr).ast
 
 
-def _collect_names(tree: ast.AST) -> set[str]:
+def _collect_names(tree: ast.AST | ExpressionString) -> set[str]:
     """Collect all Name identifiers referenced in an expression AST.
 
     Returns:
         Set of identifier names found in the expression.
     """
+    if isinstance(tree, ExpressionString):
+        return set(tree.names)
+
     names: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Name):
             names.add(str(node.id))
     return names
+
+
+__all__ = [
+    "ExpressionString",
+    "_collect_names",
+    "_parse_expr",
+    "parse_expression_string",
+]

--- a/src/op_system/_symbols.py
+++ b/src/op_system/_symbols.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from op_system._errors import InvalidExpressionError
-from op_system._ir import to_ir
+from op_system._ir import parse_expr_to_ir, to_ir
 
 if TYPE_CHECKING:
     from op_system._ir import Expr
@@ -47,6 +47,14 @@ class ExpressionString:
             Parsed typed IR tree.
         """
         return to_ir(self.ast)
+
+    def as_lowered_ir(self) -> Expr:
+        """Return helper-lowered typed IR for this expression.
+
+        Returns:
+            Typed IR tree with helper calls lowered to ``Reduce`` nodes.
+        """
+        return parse_expr_to_ir(self.source, lower_helpers=True)
 
 
 def parse_expression_string(expr: str) -> ExpressionString:

--- a/src/op_system/_symbols.py
+++ b/src/op_system/_symbols.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from op_system._errors import InvalidExpressionError
-from op_system._ir import parse_expr_to_ir
+from op_system._ir import to_ir
 
 if TYPE_CHECKING:
     from op_system._ir import Expr
@@ -46,7 +46,7 @@ class ExpressionString:
         Returns:
             Parsed typed IR tree.
         """
-        return parse_expr_to_ir(self.source)
+        return to_ir(self.ast)
 
 
 def parse_expression_string(expr: str) -> ExpressionString:

--- a/src/op_system/_symbols.py
+++ b/src/op_system/_symbols.py
@@ -7,8 +7,13 @@ from __future__ import annotations
 
 import ast
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from op_system._errors import InvalidExpressionError
+from op_system._ir import parse_expr_to_ir
+
+if TYPE_CHECKING:
+    from op_system._ir import Expr
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,6 +39,14 @@ class ExpressionString:
 
         object.__setattr__(self, "ast", parsed)
         object.__setattr__(self, "names", frozenset(found_names))
+
+    def as_ir(self) -> Expr:
+        """Return the typed IR representation for this expression.
+
+        Returns:
+            Parsed typed IR tree.
+        """
+        return parse_expr_to_ir(self.source)
 
 
 def parse_expression_string(expr: str) -> ExpressionString:

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -37,6 +37,9 @@ from typing import (
 import numpy as np
 from numpy.typing import NDArray
 
+from op_system._errors import InvalidExpressionError
+from op_system._symbols import parse_expression_string
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
     from types import CodeType
@@ -301,9 +304,10 @@ def _parse_expr(expr: str) -> ast.Expression:
         Parsed AST for the expression.
     """
     try:
-        return ast.parse(expr, mode="eval")
-    except SyntaxError as exc:  # pragma: no cover
-        _raise_invalid_expression(detail=f"invalid expression syntax: {exc.msg}")
+        parsed = parse_expression_string(expr).ast
+    except InvalidExpressionError as exc:
+        _raise_invalid_expression(detail=exc.detail)
+    return cast("ast.Expression", parsed)
 
 
 def _validate_call(func: ast.AST, *, expr: str) -> None:

--- a/src/op_system/specs.py
+++ b/src/op_system/specs.py
@@ -23,9 +23,11 @@ from op_system._normalize import (
     normalize_rhs,
     normalize_transitions_rhs,
 )
+from op_system._symbols import ExpressionString
 from op_system._templates import PinnedToken, SelectorToken, WildcardToken
 
 __all__ = [
+    "ExpressionString",
     "NormalizedRhs",
     "PinnedToken",
     "SelectorToken",

--- a/tests/op_system/test_op_system_expression_string.py
+++ b/tests/op_system/test_op_system_expression_string.py
@@ -7,7 +7,7 @@ import ast
 import pytest
 
 from op_system._errors import InvalidExpressionError
-from op_system._ir import Apply, Subscript
+from op_system._ir import Apply, Reduce, Subscript
 from op_system._symbols import (
     ExpressionString,
     _collect_names,
@@ -69,3 +69,13 @@ def test_expression_string_as_ir_subscript() -> None:
     ir = expr.as_ir()
     assert isinstance(ir, Subscript)
     assert ir.name == "K"
+
+
+def test_expression_string_as_lowered_ir_helpers() -> None:
+    """ExpressionString can project directly to helper-lowered IR."""
+    expr = ExpressionString("apply_along(I[age], age=ap)")
+
+    ir = expr.as_lowered_ir()
+    assert isinstance(ir, Reduce)
+    assert ir.kind == "apply_along"
+    assert ir.bindings == (("age", "ap"),)

--- a/tests/op_system/test_op_system_expression_string.py
+++ b/tests/op_system/test_op_system_expression_string.py
@@ -7,6 +7,7 @@ import ast
 import pytest
 
 from op_system._errors import InvalidExpressionError
+from op_system._ir import Apply, Subscript
 from op_system._symbols import (
     ExpressionString,
     _collect_names,
@@ -50,3 +51,21 @@ def test_expression_string_is_exported_from_specs() -> None:
     expr = ExpressionStringFromSpecs("r0 * I")
 
     assert expr.names == frozenset({"r0", "I"})
+
+
+def test_expression_string_as_ir_arithmetic() -> None:
+    """ExpressionString can project to the typed IR representation."""
+    expr = ExpressionString("beta * I")
+
+    ir = expr.as_ir()
+    assert isinstance(ir, Apply)
+    assert ir.op == "*"
+
+
+def test_expression_string_as_ir_subscript() -> None:
+    """IR projection preserves subscript structure for indexed expressions."""
+    expr = ExpressionString("K[age, ap]")
+
+    ir = expr.as_ir()
+    assert isinstance(ir, Subscript)
+    assert ir.name == "K"

--- a/tests/op_system/test_op_system_expression_string.py
+++ b/tests/op_system/test_op_system_expression_string.py
@@ -1,0 +1,52 @@
+"""Tests for ExpressionString parse wrapper (issue #22 groundwork)."""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from op_system._errors import InvalidExpressionError
+from op_system._symbols import (
+    ExpressionString,
+    _collect_names,
+    _parse_expr,
+    parse_expression_string,
+)
+from op_system.specs import ExpressionString as ExpressionStringFromSpecs
+
+
+def test_expression_string_exposes_ast_and_names() -> None:
+    """ExpressionString parses once and provides AST plus symbol set."""
+    expr = ExpressionString("beta * S * I / N - gamma * I")
+
+    assert isinstance(expr.ast, ast.AST)
+    assert expr.names == frozenset({"beta", "S", "I", "N", "gamma"})
+
+
+def test_expression_string_invalid_syntax_raises() -> None:
+    """Invalid syntax raises InvalidExpressionError."""
+    with pytest.raises(InvalidExpressionError, match="invalid expression syntax"):
+        ExpressionString("beta **")
+
+
+def test_collect_names_accepts_expression_string_wrapper() -> None:
+    """_collect_names supports ExpressionString without re-walking callers."""
+    expr = parse_expression_string("x + y + z")
+
+    assert _collect_names(expr) == {"x", "y", "z"}
+
+
+def test_parse_expr_backwards_compatible_with_ast() -> None:
+    """Legacy _parse_expr API still returns an AST object."""
+    tree = _parse_expr("a + b")
+
+    assert isinstance(tree, ast.AST)
+    assert _collect_names(tree) == {"a", "b"}
+
+
+def test_expression_string_is_exported_from_specs() -> None:
+    """ExpressionString is available from the public specs facade."""
+    expr = ExpressionStringFromSpecs("r0 * I")
+
+    assert expr.names == frozenset({"r0", "I"})

--- a/tests/op_system/test_op_system_ir.py
+++ b/tests/op_system/test_op_system_ir.py
@@ -1,0 +1,54 @@
+"""Tests for the typed expression IR parser foundation (issue #112)."""
+
+from __future__ import annotations
+
+import pytest
+
+from op_system._errors import InvalidExpressionError
+from op_system._ir import Apply, AxisIndex, Literal, Subscript, Sym, parse_expr_to_ir
+
+
+def test_parse_expr_to_ir_arithmetic_tree_shape() -> None:
+    """Arithmetic expressions parse into nested ``Apply`` IR nodes."""
+    expr = "beta * S * I / N - gamma * I"
+    ir = parse_expr_to_ir(expr)
+
+    assert isinstance(ir, Apply)
+    assert ir.op == "-"
+    left, right = ir.args
+    assert isinstance(left, Apply)
+    assert left.op == "/"
+    assert isinstance(right, Apply)
+    assert right.op == "*"
+
+
+def test_parse_expr_to_ir_subscript_with_symbolic_indices() -> None:
+    """Subscript expressions parse into ``Subscript`` and ``AxisIndex`` nodes."""
+    ir = parse_expr_to_ir("K[age, ap]")
+
+    assert isinstance(ir, Subscript)
+    assert ir.name == "K"
+    assert ir.indices == (AxisIndex(axis="age"), AxisIndex(axis="ap"))
+
+
+def test_parse_expr_to_ir_function_calls_and_literals() -> None:
+    """Calls and literals are represented as ``Apply``/``Literal`` nodes."""
+    ir = parse_expr_to_ir("np.maximum(x, 0.0)")
+
+    assert isinstance(ir, Apply)
+    assert ir.op == "np.maximum"
+    assert len(ir.args) == 2
+    assert isinstance(ir.args[0], Sym)
+    assert isinstance(ir.args[1], Literal)
+
+
+def test_parse_expr_to_ir_rejects_invalid_syntax() -> None:
+    """Invalid expression syntax raises ``InvalidExpressionError``."""
+    with pytest.raises(InvalidExpressionError, match="invalid expression syntax"):
+        parse_expr_to_ir("beta **")
+
+
+def test_parse_expr_to_ir_rejects_unsupported_nodes() -> None:
+    """Unsupported AST constructs raise ``InvalidExpressionError``."""
+    with pytest.raises(InvalidExpressionError, match="unsupported"):
+        parse_expr_to_ir("(lambda x: x)(1)")

--- a/tests/op_system/test_op_system_ir.py
+++ b/tests/op_system/test_op_system_ir.py
@@ -5,7 +5,16 @@ from __future__ import annotations
 import pytest
 
 from op_system._errors import InvalidExpressionError
-from op_system._ir import Apply, AxisIndex, Literal, Subscript, Sym, parse_expr_to_ir
+from op_system._ir import (
+    Apply,
+    AxisIndex,
+    Literal,
+    Reduce,
+    Subscript,
+    Sym,
+    lower_helper_calls,
+    parse_expr_to_ir,
+)
 
 
 def test_parse_expr_to_ir_arithmetic_tree_shape() -> None:
@@ -52,3 +61,34 @@ def test_parse_expr_to_ir_rejects_unsupported_nodes() -> None:
     """Unsupported AST constructs raise ``InvalidExpressionError``."""
     with pytest.raises(InvalidExpressionError, match="unsupported"):
         parse_expr_to_ir("(lambda x: x)(1)")
+
+
+def test_parse_expr_to_ir_captures_call_kwargs_as_ir_nodes() -> None:
+    """Call kwargs are preserved in IR for later lowering passes."""
+    ir = parse_expr_to_ir("apply_along(I[age], age=ap)")
+
+    assert isinstance(ir, Apply)
+    assert ir.op == "apply_along"
+    assert len(ir.args) == 2
+    assert isinstance(ir.args[0], Subscript)
+    assert isinstance(ir.args[1], Apply)
+    assert ir.args[1].op == "kwarg"
+
+
+def test_helper_lowering_rewrites_apply_along_to_reduce() -> None:
+    """Helper lowering converts apply_along call into a Reduce node."""
+    ir = parse_expr_to_ir("apply_along(I[age], age=ap)", lower_helpers=True)
+
+    assert isinstance(ir, Reduce)
+    assert ir.kind == "apply_along"
+    assert ir.bindings == (("age", "ap"),)
+    assert isinstance(ir.body, Subscript)
+
+
+def test_lower_helper_calls_preserves_non_helper_apply() -> None:
+    """Lowering leaves non-helper Apply nodes unchanged."""
+    ir = parse_expr_to_ir("np.maximum(x, 0.0)")
+    lowered = lower_helper_calls(ir)
+
+    assert isinstance(lowered, Apply)
+    assert lowered.op == "np.maximum"

--- a/tests/op_system/test_op_system_ir_unparse.py
+++ b/tests/op_system/test_op_system_ir_unparse.py
@@ -1,0 +1,36 @@
+"""Tests for IR unparser round-trip behavior (issue #112)."""
+
+from __future__ import annotations
+
+import pytest
+
+from op_system._ir import parse_expr_to_ir, unparse_ir
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "beta * S * I / N - gamma * I",
+        "np.maximum(x, 0.0)",
+        "K[age, ap]",
+        "x + y * z",
+        "a ** 2",
+        "-(x + 1)",
+    ],
+)
+def test_unparse_ir_round_trip_value_equivalence(expr: str) -> None:
+    """Round-tripping IR through unparser yields semantically equivalent source."""
+    ir1 = parse_expr_to_ir(expr)
+    rendered = unparse_ir(ir1)
+    ir2 = parse_expr_to_ir(rendered)
+
+    assert ir1 == ir2
+
+
+def test_unparse_ir_renders_helper_reduce_node() -> None:
+    """Unparser renders Reduce nodes back into helper call form."""
+    ir = parse_expr_to_ir("apply_along(I[age], age=ap)", lower_helpers=True)
+
+    rendered = unparse_ir(ir)
+    assert rendered.startswith("apply_along(")
+    assert "age=ap" in rendered


### PR DESCRIPTION
# Typed expression IR foundation (#112)

Incremental, non-runtime-impact scaffolding toward the typed expression IR migration tracked in #112. No existing semantics change; everything new is additive and covered by tests.

## Summary

- New `op_system._ir` module with a typed expression IR:
  - `Literal`, `Sym`, `AxisIndex`, `Subscript`, `Apply`, `Reduce` (frozen dataclasses).
  - `to_ir(node)` — convert a parsed `ast.Expression` to IR (BinOp, UnaryOp, BoolOp, Compare, IfExp, Call, Subscript, Name, Constant).
  - `parse_expr_to_ir(expr, *, lower_helpers=False)` — parse-and-convert convenience.
  - `lower_helper_calls(expr)` — lowers `apply_along` / `sum_over` / `integrate_over` calls into `Reduce` nodes, capturing axis bindings.
  - `unparse_ir(expr)` — round-trip IR back to expression source.
- New `ExpressionString` value type (frozen, slotted) in `op_system._symbols`:
  - Lazily exposes cached `ast` and `names` after validation.
  - `as_ir()` uses the cached AST; `as_lowered_ir()` runs helper-lowering.
  - Re-exported from `op_system.specs` and the package root.
- Internal call sites in `compile.py` and `_normalize.py` routed through `parse_expression_string(...)` so we parse once and reuse the cached AST.
- Tests:
  - `tests/op_system/test_op_system_ir.py` — IR shape, helper lowering, kwarg capture, error paths.
  - `tests/op_system/test_op_system_expression_string.py` — wrapper behavior, backward compat, IR bridge.
  - `tests/op_system/test_op_system_ir_unparse.py` — IR → source round-trip.

## Validation

- `just lint-root` — clean
- `just mypy-root` — clean (29 source files)
- `just test-root` — 251 passed

## Issue references

Tracking: #112
Related groundwork: #22, #30

This PR does **not** close any issue: #112 is the multi-stage tracking issue, #22 still requires a Pydantic-typed replacement at the existing `specs.py` site, and #30 still needs closure-cleanup / pickling work. Subsequent PRs will land those slices.
