### PR TITLE
feat(#112): IR axis resolution + traversal/substitution helpers

### DIFF
--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, NoReturn
 from ._errors import InvalidExpressionError
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Mapping
 
 
 @dataclass(frozen=True, slots=True)
@@ -457,6 +457,93 @@ def iter_subscripts(expr: Expr) -> Iterator[Subscript]:
         yield from iter_subscripts(expr.body)
 
 
+def walk(expr: Expr) -> Iterator[Expr]:
+    """Yield every IR node reachable from ``expr`` in pre-order.
+
+    Args:
+        expr: Root IR expression.
+
+    Yields:
+        ``expr`` itself first, followed by every child node.
+    """
+    yield expr
+    if isinstance(expr, Subscript):
+        return
+    if isinstance(expr, Apply):
+        for arg in expr.args:
+            yield from walk(arg)
+        return
+    if isinstance(expr, Reduce):
+        yield from walk(expr.body)
+
+
+def free_symbols(expr: Expr) -> frozenset[str]:
+    """Return the set of ``Sym`` names referenced under ``expr``.
+
+    ``Reduce`` bindings shadow outer symbols of the same name: a bound name
+    appearing only inside a reduction body is *not* considered free.
+
+    Args:
+        expr: Root IR expression.
+
+    Returns:
+        Frozen set of identifier strings that occur as free :class:`Sym`
+        references.
+    """
+    if isinstance(expr, Sym):
+        return frozenset({expr.name})
+    if isinstance(expr, (Literal, Subscript)):
+        return frozenset()
+    if isinstance(expr, Apply):
+        out: set[str] = set()
+        for arg in expr.args:
+            out |= free_symbols(arg)
+        return frozenset(out)
+    if isinstance(expr, Reduce):
+        bound = {bind for _, bind in expr.bindings}
+        return frozenset(free_symbols(expr.body) - bound)
+    _invalid(detail=f"unsupported IR node in free_symbols: {type(expr).__name__}")
+
+
+def substitute(expr: Expr, mapping: Mapping[str, Expr]) -> Expr:
+    """Replace named ``Sym`` leaves with their mapped IR expression.
+
+    The substitution is capture-avoiding with respect to ``Reduce`` bindings:
+    if a name is bound by an enclosing ``Reduce``, occurrences of that name
+    in the body are left untouched (the binding shadows the outer mapping).
+
+    Args:
+        expr: Root IR expression.
+        mapping: Substitution table from symbol name to replacement IR.
+
+    Returns:
+        A new IR expression with substitutions applied; structurally equal
+        to ``expr`` when no replacements occur.
+    """
+    if isinstance(expr, Sym):
+        return mapping.get(expr.name, expr)
+    if isinstance(expr, (Literal, Subscript)):
+        return expr
+    if isinstance(expr, Apply):
+        return Apply(
+            op=expr.op,
+            args=tuple(substitute(arg, mapping) for arg in expr.args),
+        )
+    if isinstance(expr, Reduce):
+        bound = {bind for _, bind in expr.bindings}
+        inner = (
+            mapping
+            if not bound
+            else {k: v for k, v in mapping.items() if k not in bound}
+        )
+        return Reduce(
+            kind=expr.kind,
+            bindings=expr.bindings,
+            body=substitute(expr.body, inner),
+        )
+    _invalid(detail=f"unsupported IR node in substitute: {type(expr).__name__}")
+
+
 def axis_kinds(
     expr: Expr, *, axis_names: frozenset[str]
 ) -> tuple[AxisKind, ...]:
@@ -488,9 +575,12 @@ __all__ = [
     "Sym",
     "axis_kinds",
     "classify_axis_index",
+    "free_symbols",
     "iter_subscripts",
     "lower_helper_calls",
     "parse_expr_to_ir",
+    "substitute",
     "to_ir",
     "unparse_ir",
+    "walk",
 ]

--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -9,9 +9,13 @@ from __future__ import annotations
 
 import ast
 from dataclasses import dataclass
-from typing import NoReturn
+from enum import StrEnum
+from typing import TYPE_CHECKING, NoReturn
 
 from ._errors import InvalidExpressionError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 @dataclass(frozen=True, slots=True)
@@ -393,14 +397,98 @@ def unparse_ir(expr: Expr) -> str:  # noqa: C901, PLR0911
     _invalid(detail=f"unsupported IR node in unparser: {type(expr).__name__}")
 
 
+class AxisKind(StrEnum):
+    """Classification of an ``AxisIndex`` after axis resolution.
+
+    Categories:
+        FREE: A known axis name with no coord or placeholder
+            (e.g. ``K[age]`` where ``age`` is a registered axis).
+        COORD: A literal coord value (e.g. ``K[0]`` or ``K['x']``).
+        PLACEHOLDER: A ``$``-prefixed independent placeholder (#88).
+        COORD_SYMBOL: An identifier used in a subscript that is not a known
+            axis - treated as a bound coord variable
+            (e.g. the ``ap`` in ``K[age, ap]`` when only ``age`` is an axis).
+    """
+
+    FREE = "free"
+    COORD = "coord"
+    PLACEHOLDER = "placeholder"
+    COORD_SYMBOL = "coord_symbol"
+
+
+def classify_axis_index(
+    idx: AxisIndex, *, axis_names: frozenset[str]
+) -> AxisKind:
+    """Classify a single ``AxisIndex`` against a registry of known axes.
+
+    Args:
+        idx: The axis index node to classify.
+        axis_names: Set of registered axis identifier strings.
+
+    Returns:
+        The :class:`AxisKind` describing this index position.
+    """
+    if idx.placeholder is not None:
+        return AxisKind.PLACEHOLDER
+    if idx.coord is not None:
+        return AxisKind.COORD
+    if idx.axis in axis_names:
+        return AxisKind.FREE
+    return AxisKind.COORD_SYMBOL
+
+
+def iter_subscripts(expr: Expr) -> Iterator[Subscript]:
+    """Yield every ``Subscript`` node reachable from ``expr`` in walk order.
+
+    Args:
+        expr: Root IR expression.
+
+    Yields:
+        Each :class:`Subscript` node encountered during a pre-order traversal.
+    """
+    if isinstance(expr, Subscript):
+        yield expr
+        return
+    if isinstance(expr, Apply):
+        for arg in expr.args:
+            yield from iter_subscripts(arg)
+        return
+    if isinstance(expr, Reduce):
+        yield from iter_subscripts(expr.body)
+
+
+def axis_kinds(
+    expr: Expr, *, axis_names: frozenset[str]
+) -> tuple[AxisKind, ...]:
+    """Classify every ``AxisIndex`` position in walk order.
+
+    Args:
+        expr: Root IR expression.
+        axis_names: Set of registered axis identifier strings.
+
+    Returns:
+        Tuple of :class:`AxisKind` values in pre-order subscript / position
+        traversal order.
+    """
+    return tuple(
+        classify_axis_index(idx, axis_names=axis_names)
+        for sub in iter_subscripts(expr)
+        for idx in sub.indices
+    )
+
+
 __all__ = [
     "Apply",
     "AxisIndex",
+    "AxisKind",
     "Expr",
     "Literal",
     "Reduce",
     "Subscript",
     "Sym",
+    "axis_kinds",
+    "classify_axis_index",
+    "iter_subscripts",
     "lower_helper_calls",
     "parse_expr_to_ir",
     "to_ir",

--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -39,11 +39,15 @@ class AxisIndex:
     For the initial parse-only phase, ``axis`` stores the token text for
     name-style indices (e.g. ``age`` in ``K[age, ap]``). Literal indices
     (e.g. ``K[0]`` or ``K['x']``) are represented by ``coord``.
+
+    The optional ``kind`` field is populated by :func:`resolve_axis_kinds`
+    once an axis registry is known. Parser output leaves ``kind`` unset.
     """
 
     axis: str
     coord: str | None = None
     placeholder: str | None = None
+    kind: AxisKind | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -416,9 +420,7 @@ class AxisKind(StrEnum):
     COORD_SYMBOL = "coord_symbol"
 
 
-def classify_axis_index(
-    idx: AxisIndex, *, axis_names: frozenset[str]
-) -> AxisKind:
+def classify_axis_index(idx: AxisIndex, *, axis_names: frozenset[str]) -> AxisKind:
     """Classify a single ``AxisIndex`` against a registry of known axes.
 
     Args:
@@ -544,9 +546,7 @@ def substitute(expr: Expr, mapping: Mapping[str, Expr]) -> Expr:
     _invalid(detail=f"unsupported IR node in substitute: {type(expr).__name__}")
 
 
-def axis_kinds(
-    expr: Expr, *, axis_names: frozenset[str]
-) -> tuple[AxisKind, ...]:
+def axis_kinds(expr: Expr, *, axis_names: frozenset[str]) -> tuple[AxisKind, ...]:
     """Classify every ``AxisIndex`` position in walk order.
 
     Args:
@@ -564,6 +564,54 @@ def axis_kinds(
     )
 
 
+def _resolve_index(idx: AxisIndex, *, axis_names: frozenset[str]) -> AxisIndex:
+    kind = classify_axis_index(idx, axis_names=axis_names)
+    if idx.kind is kind:
+        return idx
+    return AxisIndex(
+        axis=idx.axis, coord=idx.coord, placeholder=idx.placeholder, kind=kind
+    )
+
+
+def resolve_axis_kinds(expr: Expr, *, axis_names: frozenset[str]) -> Expr:  # noqa: PLR0911
+    """Return a copy of ``expr`` with every ``AxisIndex.kind`` populated.
+
+    Walks the IR tree and rewrites each :class:`AxisIndex` so its ``kind``
+    field reflects classification against ``axis_names``. Nodes that already
+    carry the correct kind are reused, so a resolved tree is idempotent.
+
+    Args:
+        expr: Root IR expression (typically straight from the parser).
+        axis_names: Set of registered axis identifier strings.
+
+    Returns:
+        Structurally equivalent IR with ``AxisIndex.kind`` set on every
+        subscript position.
+    """
+    if isinstance(expr, (Literal, Sym)):
+        return expr
+    if isinstance(expr, Subscript):
+        new_indices = tuple(
+            _resolve_index(i, axis_names=axis_names) for i in expr.indices
+        )
+        if new_indices == expr.indices:
+            return expr
+        return Subscript(name=expr.name, indices=new_indices)
+    if isinstance(expr, Apply):
+        new_args = tuple(
+            resolve_axis_kinds(arg, axis_names=axis_names) for arg in expr.args
+        )
+        if new_args == expr.args:
+            return expr
+        return Apply(op=expr.op, args=new_args)
+    if isinstance(expr, Reduce):
+        new_body = resolve_axis_kinds(expr.body, axis_names=axis_names)
+        if new_body is expr.body:
+            return expr
+        return Reduce(kind=expr.kind, bindings=expr.bindings, body=new_body)
+    _invalid(detail=f"unsupported IR node in resolve_axis_kinds: {type(expr).__name__}")
+
+
 __all__ = [
     "Apply",
     "AxisIndex",
@@ -579,6 +627,7 @@ __all__ = [
     "iter_subscripts",
     "lower_helper_calls",
     "parse_expr_to_ir",
+    "resolve_axis_kinds",
     "substitute",
     "to_ir",
     "unparse_ir",

--- a/tests/op_system/test_op_system_ir_axes.py
+++ b/tests/op_system/test_op_system_ir_axes.py
@@ -39,9 +39,7 @@ def test_classify_placeholder() -> None:
 def test_classify_unknown_symbol_is_coord_symbol() -> None:
     """An unknown identifier used as a subscript classifies as COORD_SYMBOL."""
     idx = AxisIndex(axis="ap")
-    assert (
-        classify_axis_index(idx, axis_names=AXES) == AxisKind.COORD_SYMBOL
-    )
+    assert classify_axis_index(idx, axis_names=AXES) == AxisKind.COORD_SYMBOL
 
 
 def test_iter_subscripts_walks_apply_and_reduce() -> None:

--- a/tests/op_system/test_op_system_ir_axes.py
+++ b/tests/op_system/test_op_system_ir_axes.py
@@ -1,0 +1,93 @@
+"""Tests for IR axis-resolution helpers (issue #112, paves the way for #88)."""
+
+from __future__ import annotations
+
+from op_system._ir import (
+    Apply,
+    AxisIndex,
+    AxisKind,
+    Literal,
+    Reduce,
+    Subscript,
+    Sym,
+    axis_kinds,
+    classify_axis_index,
+    iter_subscripts,
+    parse_expr_to_ir,
+)
+
+AXES = frozenset({"age", "loc"})
+
+
+def test_classify_free_axis() -> None:
+    """A bare known axis identifier classifies as FREE."""
+    assert classify_axis_index(AxisIndex(axis="age"), axis_names=AXES) == AxisKind.FREE
+
+
+def test_classify_literal_coord() -> None:
+    """A literal coord classifies as COORD regardless of axis name."""
+    idx = AxisIndex(axis="", coord="0")
+    assert classify_axis_index(idx, axis_names=AXES) == AxisKind.COORD
+
+
+def test_classify_placeholder() -> None:
+    """A placeholder classifies as PLACEHOLDER and takes priority over axis."""
+    idx = AxisIndex(axis="age", placeholder="age")
+    assert classify_axis_index(idx, axis_names=AXES) == AxisKind.PLACEHOLDER
+
+
+def test_classify_unknown_symbol_is_coord_symbol() -> None:
+    """An unknown identifier used as a subscript classifies as COORD_SYMBOL."""
+    idx = AxisIndex(axis="ap")
+    assert (
+        classify_axis_index(idx, axis_names=AXES) == AxisKind.COORD_SYMBOL
+    )
+
+
+def test_iter_subscripts_walks_apply_and_reduce() -> None:
+    """``iter_subscripts`` visits subscripts under Apply and Reduce nodes."""
+    inner = Subscript(name="I", indices=(AxisIndex(axis="age"),))
+    outer = Subscript(name="K", indices=(AxisIndex(axis="age"), AxisIndex(axis="ap")))
+    expr = Apply(
+        op="+",
+        args=(
+            outer,
+            Reduce(kind="sum_over", bindings=(("age", "age"),), body=inner),
+        ),
+    )
+
+    names = [s.name for s in iter_subscripts(expr)]
+    assert names == ["K", "I"]
+
+
+def test_axis_kinds_for_parsed_expression() -> None:
+    """``axis_kinds`` classifies all positions in walk order."""
+    expr = parse_expr_to_ir("K[age, ap] + I[age]")
+
+    assert axis_kinds(expr, axis_names=AXES) == (
+        AxisKind.FREE,
+        AxisKind.COORD_SYMBOL,
+        AxisKind.FREE,
+    )
+
+
+def test_axis_kinds_handles_placeholder_dollar_syntax() -> None:
+    """``$``-prefixed indices are classified as PLACEHOLDER."""
+    expr = Subscript(
+        name="C",
+        indices=(
+            AxisIndex(axis="age"),
+            AxisIndex(axis="age", placeholder="age"),
+        ),
+    )
+
+    assert axis_kinds(expr, axis_names=AXES) == (
+        AxisKind.FREE,
+        AxisKind.PLACEHOLDER,
+    )
+
+
+def test_iter_subscripts_ignores_non_subscript_leaves() -> None:
+    """Literal and Sym leaves yield no subscripts."""
+    expr = Apply(op="*", args=(Literal(value=2.0), Sym(name="beta")))
+    assert list(iter_subscripts(expr)) == []

--- a/tests/op_system/test_op_system_ir_resolve.py
+++ b/tests/op_system/test_op_system_ir_resolve.py
@@ -1,0 +1,88 @@
+"""Tests for ``resolve_axis_kinds`` (issue #112)."""
+
+from __future__ import annotations
+
+from op_system._ir import (
+    Apply,
+    AxisIndex,
+    AxisKind,
+    Reduce,
+    Subscript,
+    Sym,
+    parse_expr_to_ir,
+    resolve_axis_kinds,
+    unparse_ir,
+)
+
+AXES = frozenset({"age", "loc"})
+
+
+def test_resolve_axis_kinds_sets_kind_on_every_index() -> None:
+    """Each AxisIndex in a parsed expression gets its kind populated."""
+    expr = parse_expr_to_ir("K[age, ap] + I[age]")
+    out = resolve_axis_kinds(expr, axis_names=AXES)
+
+    assert isinstance(out, Apply)
+    k_sub, i_sub = out.args
+    assert isinstance(k_sub, Subscript)
+    assert isinstance(i_sub, Subscript)
+
+    assert tuple(i.kind for i in k_sub.indices) == (
+        AxisKind.FREE,
+        AxisKind.COORD_SYMBOL,
+    )
+    assert tuple(i.kind for i in i_sub.indices) == (AxisKind.FREE,)
+
+
+def test_resolve_axis_kinds_recurses_into_reduce_body() -> None:
+    """Indices inside Reduce bodies are resolved too."""
+    body = Subscript(name="K", indices=(AxisIndex(axis="age"),))
+    expr = Reduce(kind="sum_over", bindings=(("age", "age"),), body=body)
+
+    out = resolve_axis_kinds(expr, axis_names=AXES)
+
+    assert isinstance(out, Reduce)
+    assert isinstance(out.body, Subscript)
+    assert out.body.indices[0].kind == AxisKind.FREE
+
+
+def test_resolve_axis_kinds_is_idempotent() -> None:
+    """A second resolution returns the same object."""
+    expr = parse_expr_to_ir("K[age, 0]")
+    once = resolve_axis_kinds(expr, axis_names=AXES)
+    twice = resolve_axis_kinds(once, axis_names=AXES)
+
+    assert twice is once
+
+
+def test_resolve_axis_kinds_preserves_leaves() -> None:
+    """Literal and Sym leaves are returned unchanged."""
+    expr = Sym(name="beta")
+    assert resolve_axis_kinds(expr, axis_names=AXES) is expr
+
+
+def test_resolve_axis_kinds_does_not_change_unparse_output() -> None:
+    """Round-trip through the unparser is unaffected by resolution."""
+    expr = parse_expr_to_ir("K[age, ap] * I[age]")
+    out = resolve_axis_kinds(expr, axis_names=AXES)
+
+    assert unparse_ir(expr) == unparse_ir(out)
+
+
+def test_resolve_axis_kinds_preserves_placeholder_classification() -> None:
+    """Placeholder indices stay PLACEHOLDER regardless of axis registry."""
+    expr = Subscript(
+        name="C",
+        indices=(
+            AxisIndex(axis="age"),
+            AxisIndex(axis="age", placeholder="age"),
+        ),
+    )
+
+    out = resolve_axis_kinds(expr, axis_names=AXES)
+
+    assert isinstance(out, Subscript)
+    assert tuple(i.kind for i in out.indices) == (
+        AxisKind.FREE,
+        AxisKind.PLACEHOLDER,
+    )

--- a/tests/op_system/test_op_system_ir_substitute.py
+++ b/tests/op_system/test_op_system_ir_substitute.py
@@ -71,9 +71,7 @@ def test_substitute_recurses_into_apply_and_reduce_body() -> None:
     expr = Reduce(kind="sum_over", bindings=(("age", "age"),), body=body)
     out = substitute(expr, {"beta": Literal(value=0.5)})
     assert isinstance(out, Reduce)
-    assert out.body == Apply(
-        op="*", args=(Sym(name="x"), Literal(value=0.5))
-    )
+    assert out.body == Apply(op="*", args=(Sym(name="x"), Literal(value=0.5)))
 
 
 def test_substitute_does_not_capture_bound_names() -> None:
@@ -87,9 +85,7 @@ def test_substitute_does_not_capture_bound_names() -> None:
     )
 
     assert isinstance(out, Reduce)
-    assert out.body == Apply(
-        op="*", args=(Sym(name="ap"), Literal(value=0.5))
-    )
+    assert out.body == Apply(op="*", args=(Sym(name="ap"), Literal(value=0.5)))
 
 
 def test_substitute_is_identity_when_no_match() -> None:

--- a/tests/op_system/test_op_system_ir_substitute.py
+++ b/tests/op_system/test_op_system_ir_substitute.py
@@ -1,0 +1,98 @@
+"""Tests for IR traversal / substitution helpers (issue #112)."""
+
+from __future__ import annotations
+
+from op_system._ir import (
+    Apply,
+    AxisIndex,
+    Literal,
+    Reduce,
+    Subscript,
+    Sym,
+    free_symbols,
+    parse_expr_to_ir,
+    substitute,
+    walk,
+)
+
+
+def test_walk_yields_all_nodes_in_preorder() -> None:
+    """``walk`` visits root first, then children."""
+    expr = Apply(op="+", args=(Sym(name="a"), Literal(value=1)))
+    nodes = list(walk(expr))
+    assert nodes[0] is expr
+    assert Sym(name="a") in nodes
+    assert Literal(value=1) in nodes
+
+
+def test_walk_descends_into_reduce_body() -> None:
+    """``walk`` enters Reduce bodies."""
+    body = Apply(op="*", args=(Sym(name="x"), Sym(name="y")))
+    expr = Reduce(kind="sum_over", bindings=(("age", "age"),), body=body)
+    names = {n.name for n in walk(expr) if isinstance(n, Sym)}
+    assert names == {"x", "y"}
+
+
+def test_free_symbols_collects_sym_names() -> None:
+    """``free_symbols`` returns every Sym name reachable from the root."""
+    expr = parse_expr_to_ir("a * b + c")
+    assert free_symbols(expr) == frozenset({"a", "b", "c"})
+
+
+def test_free_symbols_ignores_subscript_axes() -> None:
+    """Subscript axis tokens are not Sym leaves."""
+    expr = Subscript(name="K", indices=(AxisIndex(axis="age"),))
+    assert free_symbols(expr) == frozenset()
+
+
+def test_free_symbols_respects_reduce_binding_shadowing() -> None:
+    """Bound names inside a Reduce body do not appear as free."""
+    body = Apply(op="*", args=(Sym(name="ap"), Sym(name="beta")))
+    expr = Reduce(kind="sum_over", bindings=(("age", "ap"),), body=body)
+    assert free_symbols(expr) == frozenset({"beta"})
+
+
+def test_substitute_replaces_matching_sym() -> None:
+    """``substitute`` swaps Sym leaves by name."""
+    expr = Apply(op="+", args=(Sym(name="a"), Sym(name="b")))
+    out = substitute(expr, {"a": Literal(value=2.0)})
+    assert out == Apply(op="+", args=(Literal(value=2.0), Sym(name="b")))
+
+
+def test_substitute_leaves_unmapped_symbols() -> None:
+    """Symbols absent from the mapping are returned unchanged."""
+    expr = Sym(name="z")
+    assert substitute(expr, {"a": Literal(value=1.0)}) is expr
+
+
+def test_substitute_recurses_into_apply_and_reduce_body() -> None:
+    """``substitute`` rewrites nested Apply and Reduce subtrees."""
+    body = Apply(op="*", args=(Sym(name="x"), Sym(name="beta")))
+    expr = Reduce(kind="sum_over", bindings=(("age", "age"),), body=body)
+    out = substitute(expr, {"beta": Literal(value=0.5)})
+    assert isinstance(out, Reduce)
+    assert out.body == Apply(
+        op="*", args=(Sym(name="x"), Literal(value=0.5))
+    )
+
+
+def test_substitute_does_not_capture_bound_names() -> None:
+    """A mapping for a Reduce-bound name is shadowed inside the body."""
+    body = Apply(op="*", args=(Sym(name="ap"), Sym(name="beta")))
+    expr = Reduce(kind="sum_over", bindings=(("age", "ap"),), body=body)
+
+    out = substitute(
+        expr,
+        {"ap": Literal(value=99.0), "beta": Literal(value=0.5)},
+    )
+
+    assert isinstance(out, Reduce)
+    assert out.body == Apply(
+        op="*", args=(Sym(name="ap"), Literal(value=0.5))
+    )
+
+
+def test_substitute_is_identity_when_no_match() -> None:
+    """Substituting an empty mapping yields a structurally equal tree."""
+    expr = parse_expr_to_ir("a + b * c")
+    assert substitute(expr, {}) == expr


### PR DESCRIPTION
Second slice of the typed-IR migration tracked under #112. Pure additive scaffolding on `_ir.py` — no runtime / compile / normalize paths are touched yet.

## What's in here

Three commits, each a self-contained pass:

1. **Axis classification** (`16e94ff`)
   - `AxisKind` enum: `FREE` / `COORD` / `PLACEHOLDER` / `COORD_SYMBOL`
   - `classify_axis_index(idx, *, axis_names)`
   - `iter_subscripts(expr)` pre-order traversal
   - `axis_kinds(expr, *, axis_names)` walk-order classification

2. **Traversal & substitution** (`4dd01a6`)
   - `walk(expr)` pre-order iterator over every IR node
   - `free_symbols(expr)` Sym names, respecting `Reduce` binding shadows
   - `substitute(expr, mapping)` capture-avoiding name → IR rewrite

3. **Resolved AxisIndex** (`a23452d`)
   - `AxisIndex` gains an optional `kind: AxisKind | None = None` field
     (parser output and existing tests unaffected — default is `None`)
   - `resolve_axis_kinds(expr, *, axis_names)` returns a new tree with
     `kind` populated on every position; idempotent (reuses nodes that
     already match)
   - Unparser ignores `kind` so round-trip output is unchanged

## Why now

These primitives unblock the next non-runtime-impact slices on the #112 roadmap:
- IR-level template / alias substitution (uses `substitute`)
- IR CSE pass (#111) (uses structural equality + `walk`)
- `_vectorize` lowering can dispatch on `AxisIndex.kind` directly instead
  of re-classifying at every call site
- Paves the way for #88 `$`-placeholder semantics

## Validation

- 275 tests pass (+24 vs main): `just test-root`
- Lint + mypy clean: `just lint-root`, `just mypy-root`
- Full `just ci` green (root + provider + docs)
- Branch delta: ~511 insertions across `_ir.py` and 3 new test files

No issues are fully closed by this PR — #112 remains open, and the
$-placeholder issue (#88) gets its first plumbing.