### PR TITLE
feat(#112): IR-level template and alias expansion helpers

### DIFF
--- a/src/op_system/_ir_templates.py
+++ b/src/op_system/_ir_templates.py
@@ -21,13 +21,14 @@ template expansion in ``_normalize.py``.
 
 from __future__ import annotations
 
+from itertools import product
 from typing import TYPE_CHECKING
 
 from ._ir import Apply, AxisIndex, Expr, Literal, Reduce, Subscript, Sym
 from ._templates import _render_template_name
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterable, Mapping, Sequence
 
 
 def _expandable_axes(indices: Sequence[AxisIndex]) -> list[str] | None:
@@ -176,4 +177,113 @@ def expand_inline_templates(
     raise TypeError(msg)
 
 
-__all__ = ["expand_inline_templates"]
+__all__ = ["expand_inline_templates", "expand_over_axes", "placeholder_axes"]
+
+
+def _collect_subscript_axes(
+    sub: Subscript,
+    *,
+    shaped: Mapping[str, tuple[str, ...]],
+    out: dict[str, None],
+) -> None:
+    if sub.name in shaped:
+        return
+    for idx in sub.indices:
+        if idx.coord is not None or idx.placeholder is not None:
+            continue
+        if idx.axis:
+            out.setdefault(idx.axis, None)
+
+
+def _walk_for_axes(
+    node: Expr,
+    *,
+    shaped: Mapping[str, tuple[str, ...]],
+    seen: dict[str, None],
+) -> None:
+    if isinstance(node, (Literal, Sym)):
+        return
+    if isinstance(node, Subscript):
+        _collect_subscript_axes(node, shaped=shaped, out=seen)
+        return
+    if isinstance(node, Apply):
+        for arg in node.args:
+            _walk_for_axes(arg, shaped=shaped, seen=seen)
+        return
+    if isinstance(node, Reduce):
+        _walk_for_axes(node.body, shaped=shaped, seen=seen)
+        for _, bind in node.bindings:
+            seen.pop(bind, None)
+
+
+def placeholder_axes(
+    expr: Expr,
+    *,
+    shaped_params: Mapping[str, tuple[str, ...]] | None = None,
+) -> tuple[str, ...]:
+    """Collect placeholder axis names referenced by ``expr``.
+
+    Walks the IR and gathers every bare-identifier axis appearing inside a
+    ``Subscript`` whose base name is *not* a registered shaped parameter.
+    Literal-coord and ``$``-placeholder positions are skipped. Order is
+    deterministic: first appearance in pre-order traversal wins.
+
+    Args:
+        expr: Root IR expression.
+        shaped_params: Optional mapping of shaped-parameter base names
+            (whose subscripts are rewritten to literal indices rather than
+            expanded into scalar symbols).
+
+    Returns:
+        Tuple of distinct axis names in first-seen order.
+    """
+    shaped = shaped_params or {}
+    seen: dict[str, None] = {}
+    _walk_for_axes(expr, shaped=shaped, seen=seen)
+    return tuple(seen)
+
+
+def expand_over_axes(
+    expr: Expr,
+    *,
+    axes: Iterable[str],
+    axis_lookup: Mapping[str, Sequence[str]],
+    shaped_params: Mapping[str, tuple[str, ...]] | None = None,
+) -> list[tuple[dict[str, str], Expr]]:
+    """Cross-expand ``expr`` over the coordinate product of ``axes``.
+
+    For every combination of coords drawn from ``axis_lookup[ax]`` for each
+    ``ax in axes``, builds an assignment and applies
+    :func:`expand_inline_templates` to ``expr``.
+
+    Args:
+        expr: Root IR expression to expand.
+        axes: Axis names to cross-expand over. Typical callers pass
+            ``placeholder_axes(expr, shaped_params=...)``.
+        axis_lookup: Mapping of axis name to its ordered coord list. Must
+            contain every entry in ``axes``.
+        shaped_params: Optional shaped-parameter registry forwarded to
+            :func:`expand_inline_templates`.
+
+    Returns:
+        List of ``(assignment, expanded_expr)`` pairs, one per coordinate
+        combination. When ``axes`` is empty, returns ``[({}, expr)]``.
+    """
+    axis_list = list(axes)
+    if not axis_list:
+        return [({}, expr)]
+
+    coord_lists = [list(axis_lookup[ax]) for ax in axis_list]
+    out: list[tuple[dict[str, str], Expr]] = []
+    for combo in product(*coord_lists):
+        assignment = dict(zip(axis_list, combo, strict=True))
+        out.append((
+            assignment,
+            expand_inline_templates(
+                expr,
+                assignment=assignment,
+                shaped_params=shaped_params,
+                axis_lookup=axis_lookup,
+            ),
+        ))
+    return out

--- a/src/op_system/_ir_templates.py
+++ b/src/op_system/_ir_templates.py
@@ -24,7 +24,17 @@ from __future__ import annotations
 from itertools import product
 from typing import TYPE_CHECKING
 
-from ._ir import Apply, AxisIndex, Expr, Literal, Reduce, Subscript, Sym
+from ._ir import (
+    Apply,
+    AxisIndex,
+    Expr,
+    Literal,
+    Reduce,
+    Subscript,
+    Sym,
+    free_symbols,
+    substitute,
+)
 from ._templates import _render_template_name
 
 if TYPE_CHECKING:
@@ -177,7 +187,16 @@ def expand_inline_templates(
     raise TypeError(msg)
 
 
-__all__ = ["expand_inline_templates", "expand_over_axes", "placeholder_axes"]
+__all__ = [
+    "expand_inline_templates",
+    "expand_over_axes",
+    "inline_aliases",
+    "placeholder_axes",
+]
+
+_CYCLE_WHITE = 0
+_CYCLE_GREY = 1
+_CYCLE_BLACK = 2
 
 
 def _collect_subscript_axes(
@@ -287,3 +306,90 @@ def expand_over_axes(
             ),
         ))
     return out
+
+
+def _detect_alias_cycle(aliases: Mapping[str, Expr]) -> list[str] | None:
+    """Return a cycle of alias names if one exists, else ``None``.
+
+    Builds a name -> referenced-alias-names graph (only edges into the
+    alias namespace itself count) and DFS-checks for a back edge.
+    """
+    keys = set(aliases)
+    graph: dict[str, frozenset[str]] = {
+        name: frozenset(free_symbols(body) & keys) for name, body in aliases.items()
+    }
+
+    color: dict[str, int] = dict.fromkeys(graph, _CYCLE_WHITE)
+    stack: list[str] = []
+
+    def visit(node: str) -> list[str] | None:
+        color[node] = _CYCLE_GREY
+        stack.append(node)
+        for nxt in graph[node]:
+            if color[nxt] == _CYCLE_GREY:
+                i = stack.index(nxt)
+                return [*stack[i:], nxt]
+            if color[nxt] == _CYCLE_WHITE:
+                found = visit(nxt)
+                if found is not None:
+                    return found
+        color[node] = _CYCLE_BLACK
+        stack.pop()
+        return None
+
+    for n in graph:
+        if color[n] == _CYCLE_WHITE:
+            cyc = visit(n)
+            if cyc is not None:
+                return cyc
+    return None
+
+
+def inline_aliases(
+    expr: Expr,
+    aliases: Mapping[str, Expr],
+    *,
+    max_depth: int = 64,
+) -> Expr:
+    """Fixed-point inline ``Sym`` references that match ``aliases`` keys.
+
+    Repeatedly applies :func:`op_system._ir.substitute` until no free
+    symbols in the result are in ``aliases``, or ``max_depth`` is reached.
+
+    Aliases may reference one another transitively; this function expands
+    chains in one pass per iteration. Self-referential or mutually
+    recursive aliases are rejected up front via a cycle check.
+
+    Args:
+        expr: Root IR expression to inline into.
+        aliases: Mapping from alias name (a ``Sym`` name) to its IR body.
+            Keys are expected to be fully expanded alias names (after
+            template expansion), and bodies are expected to be IR.
+        max_depth: Safety bound on the number of substitution rounds.
+
+    Returns:
+        A new IR expression with all alias references resolved.
+
+    Raises:
+        ValueError: If the alias graph contains a cycle, or if expansion
+            does not converge within ``max_depth`` iterations.
+    """
+    if not aliases:
+        return expr
+
+    cycle = _detect_alias_cycle(aliases)
+    if cycle is not None:
+        msg = f"alias cycle detected: {' -> '.join(cycle)}"
+        raise ValueError(msg)
+
+    keys = set(aliases)
+    current = expr
+    for _ in range(max_depth):
+        live = free_symbols(current) & keys
+        if not live:
+            return current
+        mapping = {name: aliases[name] for name in live}
+        current = substitute(current, mapping)
+
+    msg = f"alias inlining did not converge within {max_depth} iterations"
+    raise ValueError(msg)

--- a/src/op_system/_ir_templates.py
+++ b/src/op_system/_ir_templates.py
@@ -1,0 +1,179 @@
+"""IR-level template expansion (issue #112).
+
+Mirrors the inline template-substitution semantics of
+:func:`op_system._templates._apply_template_substitutions` but operates on
+typed IR rather than expression strings.
+
+Two rewrite modes are supported per ``Subscript``:
+
+- **Named expansion**: ``S[age]`` with ``assignment={"age": "0_5"}`` becomes
+  ``Sym(name="S__age_0_5")`` - a scalar reference to the expanded state.
+- **Shaped-parameter indexing**: when the base name is a registered shaped
+  parameter and the placeholder axes match the registered axes, the
+  ``AxisIndex`` entries are rewritten to literal integer coords resolved
+  via ``axis_lookup`` (so ``theta[imm]`` becomes ``theta[5]`` into the
+  shaped buffer).
+
+This module is intentionally pure: it does not touch compile / normalize.
+It exists to back the eventual replacement of string-based alias and
+template expansion in ``_normalize.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ._ir import Apply, AxisIndex, Expr, Literal, Reduce, Subscript, Sym
+from ._templates import _render_template_name
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+
+def _expandable_axes(indices: Sequence[AxisIndex]) -> list[str] | None:
+    """Return the list of bare-identifier axis names from ``indices``.
+
+    Returns ``None`` if any index carries a literal coord or placeholder, in
+    which case the subscript is not eligible for template expansion.
+    """
+    out: list[str] = []
+    for idx in indices:
+        if idx.coord is not None or idx.placeholder is not None:
+            return None
+        out.append(idx.axis)
+    return out
+
+
+def _rewrite_shaped_indices(
+    axes: Sequence[str],
+    *,
+    assignment: Mapping[str, str],
+    registered: tuple[str, ...],
+    axis_lookup: Mapping[str, Sequence[str]],
+) -> tuple[AxisIndex, ...] | None:
+    """Rewrite shaped-parameter placeholders to literal integer coords.
+
+    Returns:
+        Tuple of literal-coord ``AxisIndex`` entries, or ``None`` if the
+        axes don't match the registered axes order, an axis is missing
+        from ``axis_lookup``, or a coord isn't in its axis.
+    """
+    if tuple(axes) != registered:
+        return None
+    out: list[AxisIndex] = []
+    for ax in registered:
+        coords = axis_lookup.get(ax)
+        if coords is None:
+            return None
+        try:
+            i = coords.index(assignment[ax])
+        except (KeyError, ValueError):
+            return None
+        out.append(AxisIndex(axis="", coord=str(i)))
+    return tuple(out)
+
+
+def _expand_subscript(
+    sub: Subscript,
+    *,
+    assignment: Mapping[str, str],
+    shaped_params: Mapping[str, tuple[str, ...]],
+    axis_lookup: Mapping[str, Sequence[str]] | None,
+) -> Expr:
+    axes = _expandable_axes(sub.indices)
+    if axes is None or not axes:
+        return sub
+    if any(ax not in assignment for ax in axes):
+        return sub
+
+    if sub.name in shaped_params and axis_lookup is not None:
+        new_indices = _rewrite_shaped_indices(
+            axes,
+            assignment=assignment,
+            registered=shaped_params[sub.name],
+            axis_lookup=axis_lookup,
+        )
+        if new_indices is None:
+            return sub
+        return Subscript(name=sub.name, indices=new_indices)
+
+    rendered = _render_template_name(sub.name, list(axes), assignment)
+    return Sym(name=rendered)
+
+
+def expand_inline_templates(
+    expr: Expr,
+    *,
+    assignment: Mapping[str, str],
+    shaped_params: Mapping[str, tuple[str, ...]] | None = None,
+    axis_lookup: Mapping[str, Sequence[str]] | None = None,
+) -> Expr:
+    """Expand placeholder subscripts in ``expr`` using ``assignment``.
+
+    Args:
+        expr: Root IR expression.
+        assignment: Mapping from placeholder axis name to concrete coord
+            string (e.g. ``{"age": "0_5", "pop": "p1"}``).
+        shaped_params: Optional mapping from shaped-parameter base name to
+            its registered axis tuple. When provided alongside
+            ``axis_lookup``, subscripts whose base names match are rewritten
+            to literal integer coords instead of being expanded to scalar
+            symbols.
+        axis_lookup: Optional mapping from axis name to its coord list,
+            used to resolve shaped-parameter indices.
+
+    Returns:
+        A new IR expression with templated subscripts expanded. Subscripts
+        that are not eligible (literal coords, placeholders, unknown axis
+        names) are left untouched.
+
+    Raises:
+        TypeError: If ``expr`` contains an unsupported IR node type.
+    """
+    shaped = shaped_params or {}
+
+    if isinstance(expr, (Literal, Sym)):
+        return expr
+    if isinstance(expr, Subscript):
+        return _expand_subscript(
+            expr,
+            assignment=assignment,
+            shaped_params=shaped,
+            axis_lookup=axis_lookup,
+        )
+    if isinstance(expr, Apply):
+        new_args = tuple(
+            expand_inline_templates(
+                arg,
+                assignment=assignment,
+                shaped_params=shaped,
+                axis_lookup=axis_lookup,
+            )
+            for arg in expr.args
+        )
+        if new_args == expr.args:
+            return expr
+        return Apply(op=expr.op, args=new_args)
+    if isinstance(expr, Reduce):
+        # Reduce bindings shadow placeholder names: a bound name in this
+        # scope should not be substituted from the outer assignment.
+        bound = {bind for _, bind in expr.bindings}
+        inner_assignment = (
+            assignment
+            if not bound
+            else {k: v for k, v in assignment.items() if k not in bound}
+        )
+        new_body = expand_inline_templates(
+            expr.body,
+            assignment=inner_assignment,
+            shaped_params=shaped,
+            axis_lookup=axis_lookup,
+        )
+        if new_body is expr.body:
+            return expr
+        return Reduce(kind=expr.kind, bindings=expr.bindings, body=new_body)
+    msg = f"unsupported IR node in expand_inline_templates: {type(expr).__name__}"
+    raise TypeError(msg)
+
+
+__all__ = ["expand_inline_templates"]

--- a/tests/op_system/test_op_system_ir_templates.py
+++ b/tests/op_system/test_op_system_ir_templates.py
@@ -1,0 +1,148 @@
+"""Tests for IR-level template expansion (issue #112)."""
+
+from __future__ import annotations
+
+from op_system._ir import (
+    Apply,
+    AxisIndex,
+    Literal,
+    Reduce,
+    Subscript,
+    Sym,
+    parse_expr_to_ir,
+)
+from op_system._ir_templates import expand_inline_templates
+from op_system._templates import _apply_template_substitutions
+
+AXIS_LOOKUP = {"age": ["0_5", "5_18", "18_65", "65p"], "imm": ["x0", "x1"]}
+
+
+def test_expand_renders_named_placeholder_to_sym() -> None:
+    """A bare placeholder subscript becomes a Sym with the rendered name."""
+    expr = Subscript(name="S", indices=(AxisIndex(axis="age"),))
+    out = expand_inline_templates(expr, assignment={"age": "0_5"})
+    assert out == Sym(name="S__age_0_5")
+
+
+def test_expand_renders_multi_axis_subscript() -> None:
+    """Multi-axis subscripts render placeholders in declared order."""
+    expr = Subscript(
+        name="X",
+        indices=(AxisIndex(axis="age"), AxisIndex(axis="pop")),
+    )
+    out = expand_inline_templates(expr, assignment={"age": "0_5", "pop": "p1"})
+    assert out == Sym(name="X__age_0_5__pop_p1")
+
+
+def test_expand_leaves_subscript_when_axis_not_in_assignment() -> None:
+    """Subscripts with unresolved axes are returned unchanged."""
+    expr = Subscript(name="S", indices=(AxisIndex(axis="age"),))
+    assert expand_inline_templates(expr, assignment={"pop": "p1"}) is expr
+
+
+def test_expand_leaves_subscript_with_literal_coord() -> None:
+    """Subscripts that already carry a literal coord are not eligible."""
+    expr = Subscript(
+        name="theta",
+        indices=(AxisIndex(axis="", coord="0"),),
+    )
+    assert expand_inline_templates(expr, assignment={"age": "0_5"}) is expr
+
+
+def test_expand_leaves_subscript_with_placeholder() -> None:
+    """``$``-style placeholders are preserved, not expanded."""
+    expr = Subscript(
+        name="C",
+        indices=(AxisIndex(axis="age", placeholder="age"),),
+    )
+    assert expand_inline_templates(expr, assignment={"age": "0_5"}) is expr
+
+
+def test_expand_rewrites_shaped_param_to_literal_index() -> None:
+    """Shaped-param subscripts become literal integer coord indices."""
+    expr = Subscript(name="theta", indices=(AxisIndex(axis="imm"),))
+    out = expand_inline_templates(
+        expr,
+        assignment={"imm": "x1"},
+        shaped_params={"theta": ("imm",)},
+        axis_lookup=AXIS_LOOKUP,
+    )
+    assert out == Subscript(name="theta", indices=(AxisIndex(axis="", coord="1"),))
+
+
+def test_expand_shaped_param_axis_mismatch_falls_through() -> None:
+    """If axes don't match the registered order, the subscript is unchanged."""
+    expr = Subscript(
+        name="theta",
+        indices=(AxisIndex(axis="age"), AxisIndex(axis="imm")),
+    )
+    out = expand_inline_templates(
+        expr,
+        assignment={"age": "0_5", "imm": "x1"},
+        shaped_params={"theta": ("imm",)},
+        axis_lookup=AXIS_LOOKUP,
+    )
+    assert out is expr
+
+
+def test_expand_recurses_into_apply() -> None:
+    """Nested Apply args are expanded recursively."""
+    expr = Apply(
+        op="*",
+        args=(
+            Subscript(name="S", indices=(AxisIndex(axis="age"),)),
+            Literal(value=2.0),
+        ),
+    )
+    out = expand_inline_templates(expr, assignment={"age": "0_5"})
+    assert out == Apply(op="*", args=(Sym(name="S__age_0_5"), Literal(value=2.0)))
+
+
+def test_expand_respects_reduce_binding_shadowing() -> None:
+    """A Reduce binding shadows the outer assignment for its bound name."""
+    body = Subscript(
+        name="C",
+        indices=(AxisIndex(axis="age"), AxisIndex(axis="ap")),
+    )
+    expr = Reduce(kind="sum_over", bindings=(("age", "ap"),), body=body)
+    out = expand_inline_templates(expr, assignment={"age": "0_5", "ap": "1_2"})
+    # "ap" is bound -> not substituted; "age" only -> not all axes covered
+    # so the subscript is left intact.
+    assert out is expr
+
+
+def test_expand_parity_with_string_path_named_only() -> None:
+    """IR expansion matches the string-based expansion (named-only case)."""
+    src = "beta * S[age] + I[age] * 0.5"
+    assignment = {"age": "0_5"}
+
+    string_out = _apply_template_substitutions(
+        src, assignment=assignment, template_map={}
+    )
+    ir_out = expand_inline_templates(parse_expr_to_ir(src), assignment=assignment)
+
+    # Parse the string-path result and compare structurally.
+    assert ir_out == parse_expr_to_ir(string_out)
+
+
+def test_expand_parity_with_string_path_shaped_param() -> None:
+    """IR expansion matches the string-based expansion (shaped-param case)."""
+    src = "theta[imm] * S[age]"
+    assignment = {"age": "0_5", "imm": "x1"}
+    shaped = {"theta": ("imm",)}
+
+    string_out = _apply_template_substitutions(
+        src,
+        assignment=assignment,
+        template_map={},
+        shaped_params=shaped,
+        axis_lookup=AXIS_LOOKUP,
+    )
+    ir_out = expand_inline_templates(
+        parse_expr_to_ir(src),
+        assignment=assignment,
+        shaped_params=shaped,
+        axis_lookup=AXIS_LOOKUP,
+    )
+
+    assert ir_out == parse_expr_to_ir(string_out)

--- a/tests/op_system/test_op_system_ir_templates.py
+++ b/tests/op_system/test_op_system_ir_templates.py
@@ -11,7 +11,11 @@ from op_system._ir import (
     Sym,
     parse_expr_to_ir,
 )
-from op_system._ir_templates import expand_inline_templates
+from op_system._ir_templates import (
+    expand_inline_templates,
+    expand_over_axes,
+    placeholder_axes,
+)
 from op_system._templates import _apply_template_substitutions
 
 AXIS_LOOKUP = {"age": ["0_5", "5_18", "18_65", "65p"], "imm": ["x0", "x1"]}
@@ -146,3 +150,94 @@ def test_expand_parity_with_string_path_shaped_param() -> None:
     )
 
     assert ir_out == parse_expr_to_ir(string_out)
+
+
+def test_placeholder_axes_collects_in_first_seen_order() -> None:
+    """Placeholder axes are returned deterministically by walk order."""
+    expr = parse_expr_to_ir("S[age] * theta[imm] + I[pop] * S[age]")
+    assert placeholder_axes(expr) == ("age", "imm", "pop")
+
+
+def test_placeholder_axes_skips_shaped_param_subscripts() -> None:
+    """Subscripts whose base is a shaped param do not contribute axes."""
+    expr = parse_expr_to_ir("theta[imm] * S[age]")
+    out = placeholder_axes(expr, shaped_params={"theta": ("imm",)})
+    assert out == ("age",)
+
+
+def test_placeholder_axes_ignores_literal_coords_and_placeholders() -> None:
+    """Literal coords and ``$``-placeholders are not collected."""
+    expr = Subscript(
+        name="K",
+        indices=(
+            AxisIndex(axis="", coord="0"),
+            AxisIndex(axis="age", placeholder="age"),
+        ),
+    )
+    assert placeholder_axes(expr) == ()
+
+
+def test_placeholder_axes_drops_reduce_bound_names() -> None:
+    """Names bound by a Reduce do not appear in the result set."""
+    body = Subscript(name="C", indices=(AxisIndex(axis="age"), AxisIndex(axis="ap")))
+    expr = Reduce(kind="sum_over", bindings=(("age", "ap"),), body=body)
+    # "age" is still a free placeholder; "ap" is bound and dropped.
+    assert placeholder_axes(expr) == ("age",)
+
+
+def test_expand_over_axes_empty_axes_returns_singleton() -> None:
+    """With no axes, the input is returned as a single ({}, expr) entry."""
+    expr = parse_expr_to_ir("beta * S")
+    out = expand_over_axes(expr, axes=(), axis_lookup=AXIS_LOOKUP)
+    assert out == [({}, expr)]
+
+
+def test_expand_over_axes_cross_product_count() -> None:
+    """The result length equals the product of coord-list lengths."""
+    expr = parse_expr_to_ir("S[age] * theta[imm]")
+    out = expand_over_axes(
+        expr,
+        axes=("age", "imm"),
+        axis_lookup=AXIS_LOOKUP,
+        shaped_params={"theta": ("imm",)},
+    )
+    assert len(out) == len(AXIS_LOOKUP["age"]) * len(AXIS_LOOKUP["imm"])
+
+
+def test_expand_over_axes_matches_string_path_named_only() -> None:
+    """Each IR expansion matches parsing the string-path expansion."""
+    src = "beta * S[age] + I[age]"
+    expr = parse_expr_to_ir(src)
+    axes = placeholder_axes(expr)
+    ir_results = expand_over_axes(expr, axes=axes, axis_lookup=AXIS_LOOKUP)
+
+    for assignment, ir_expr in ir_results:
+        string_expr = _apply_template_substitutions(
+            src, assignment=assignment, template_map={}
+        )
+        assert ir_expr == parse_expr_to_ir(string_expr)
+
+
+def test_expand_over_axes_matches_string_path_with_shaped_param() -> None:
+    """Cross-product expansion matches the string path for shaped params."""
+    src = "theta[imm] * S[age]"
+    shaped = {"theta": ("imm",)}
+    expr = parse_expr_to_ir(src)
+    axes = placeholder_axes(expr, shaped_params=shaped)
+    ir_results = expand_over_axes(
+        expr,
+        axes=("age", "imm"),  # include imm so theta gets rewritten
+        axis_lookup=AXIS_LOOKUP,
+        shaped_params=shaped,
+    )
+
+    assert axes == ("age",)
+    for assignment, ir_expr in ir_results:
+        string_expr = _apply_template_substitutions(
+            src,
+            assignment=assignment,
+            template_map={},
+            shaped_params=shaped,
+            axis_lookup=AXIS_LOOKUP,
+        )
+        assert ir_expr == parse_expr_to_ir(string_expr)

--- a/tests/op_system/test_op_system_ir_templates.py
+++ b/tests/op_system/test_op_system_ir_templates.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from op_system._ir import (
     Apply,
     AxisIndex,
@@ -14,6 +16,7 @@ from op_system._ir import (
 from op_system._ir_templates import (
     expand_inline_templates,
     expand_over_axes,
+    inline_aliases,
     placeholder_axes,
 )
 from op_system._templates import _apply_template_substitutions
@@ -241,3 +244,62 @@ def test_expand_over_axes_matches_string_path_with_shaped_param() -> None:
             axis_lookup=AXIS_LOOKUP,
         )
         assert ir_expr == parse_expr_to_ir(string_expr)
+
+
+def test_inline_aliases_basic_substitution() -> None:
+    """A single alias reference is replaced with its body."""
+    expr = parse_expr_to_ir("rho * S")
+    aliases = {"rho": parse_expr_to_ir("beta * I")}
+    out = inline_aliases(expr, aliases)
+    assert out == parse_expr_to_ir("(beta * I) * S")
+
+
+def test_inline_aliases_chained_references() -> None:
+    """Aliases referencing other aliases fully expand to leaves."""
+    aliases = {
+        "rho": parse_expr_to_ir("beta * gamma"),
+        "force": parse_expr_to_ir("rho * I"),
+    }
+    out = inline_aliases(parse_expr_to_ir("force * S"), aliases)
+    assert out == parse_expr_to_ir("((beta * gamma) * I) * S")
+
+
+def test_inline_aliases_returns_input_when_no_aliases() -> None:
+    """An empty alias map returns the original expression unchanged."""
+    expr = parse_expr_to_ir("a + b")
+    assert inline_aliases(expr, {}) is expr
+
+
+def test_inline_aliases_leaves_unrelated_symbols() -> None:
+    """Symbols not in the alias map are preserved."""
+    expr = parse_expr_to_ir("alpha + rho")
+    out = inline_aliases(expr, {"rho": Literal(value=0.5)})
+    assert out == Apply(op="+", args=(Sym(name="alpha"), Literal(value=0.5)))
+
+
+def test_inline_aliases_rejects_self_cycle() -> None:
+    """A self-referential alias raises immediately."""
+    aliases = {"rho": parse_expr_to_ir("rho + 1")}
+    with pytest.raises(ValueError, match="alias cycle"):
+        inline_aliases(parse_expr_to_ir("rho"), aliases)
+
+
+def test_inline_aliases_rejects_mutual_cycle() -> None:
+    """Mutually recursive aliases raise."""
+    aliases = {
+        "a": parse_expr_to_ir("b + 1"),
+        "b": parse_expr_to_ir("a * 2"),
+    }
+    with pytest.raises(ValueError, match="alias cycle"):
+        inline_aliases(parse_expr_to_ir("a"), aliases)
+
+
+def test_inline_aliases_respects_reduce_binding_shadowing() -> None:
+    """An alias name shadowed by a Reduce binding is not substituted."""
+    body = Apply(op="*", args=(Sym(name="rho"), Sym(name="S")))
+    expr = Reduce(kind="sum_over", bindings=(("age", "rho"),), body=body)
+    aliases = {"rho": Literal(value=0.5)}
+    out = inline_aliases(expr, aliases)
+    # The Reduce shadows "rho" -> body's "rho" stays a Sym.
+    assert isinstance(out, Reduce)
+    assert out.body == body


### PR DESCRIPTION
Adds a new `op_system._ir_templates` module with IR-equivalent expansion helpers, on the way to retiring the regex-based template/alias machinery (issue #112). No runtime paths are wired up yet, so behaviour of the existing string pipeline is unchanged.

### What's in here

Three commits, each a focused slice:

1. `expand_inline_templates(expr, *, assignment, shaped_params=None, axis_lookup=None)` — substitutes axis placeholders inside templated `Subscript` references, producing either a renamed `Sym` (named template) or a `Subscript` with literal coords (shaped param). Reduce bindings shadow the assignment for their body.
2. `placeholder_axes(expr, *, shaped_params=None)` and `expand_over_axes(expr, *, axes, axis_lookup, shaped_params=None)` — discover the free placeholder axes in an expression (first-seen order, skipping literal coords, $-placeholders, shaped-param subscripts, and Reduce-bound names) and cross-product-expand over them via `itertools.product`.
3. `inline_aliases(expr, aliases, *, max_depth=64)` — fixed-point substitution of alias `Sym` references with their IR bodies, using the existing capture-avoiding `substitute`. Performs an explicit DFS cycle check up front and raises `ValueError` for self-references, mutual recursion, or non-convergence.

### Tests

26 unit tests in `tests/op_system/test_op_system_ir_templates.py`, including parity checks against `_apply_template_substitutions` for both named and shaped-param cases. Full suite: 301 passed, `just ci` green.

### Issues

Does not close any issues. #112 stays open; follow-up slices will wire these helpers into the alias-expansion and vectorization paths.