### PR TITLE
feat(#112): wire IR alias inlining into runtime alias-expansion path

### DIFF
--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -15,8 +15,9 @@ types and functions are re-exported from ``specs.py`` for backward compat.
 from __future__ import annotations
 
 import re
+import sys
 from collections.abc import Mapping as _MappingABC
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from itertools import product
 from typing import TYPE_CHECKING, Any
 
@@ -35,6 +36,8 @@ from op_system._helpers import (
     _ensure_str_list,
     _sorted_unique,
 )
+from op_system._ir import Expr, parse_expr_to_ir
+from op_system._ir_templates import inline_aliases
 from op_system._symbols import _collect_names, _parse_expr
 from op_system._templates import (
     _INLINE_TEMPLATE_RE,
@@ -120,6 +123,7 @@ class NormalizedRhs:
     state_templates: tuple[StateTemplate, ...] = ()
     shaped_params: tuple[tuple[str, tuple[str, ...]], ...] = ()
     time_varying_params: tuple[tuple[str, tuple[str, ...]], ...] = ()
+    aliases_ir: Mapping[str, Expr] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -1124,6 +1128,44 @@ def _expand_alias_templates(
             )
 
     return aliases_out, alias_template_map
+
+
+def _build_aliases_ir(aliases: Mapping[str, str]) -> dict[str, Expr]:
+    """Parse each alias body to IR and inline alias-to-alias references.
+
+    Best-effort: when parsing or inlining fails (cyclic aliases, AST recursion
+    on very long expanded chains, unsupported syntax), the failing alias is
+    omitted rather than aborting normalization. Existing string-based consumers
+    rely on lazy cycle detection at evaluation time, so this preserves
+    backward-compatible behaviour while still exposing IR where available.
+
+    Returns:
+        Mapping from alias name to its (fully inlined) IR expression. Entries
+        that could not be parsed or inlined are omitted.
+    """
+    # Long expanded Add chains (e.g. ``apply_along`` over many coords) can
+    # exceed Python's default recursion limit during AST descent / inlining.
+    old_limit = sys.getrecursionlimit()
+    needed = max(old_limit, 10_000)
+    try:
+        if needed > old_limit:
+            sys.setrecursionlimit(needed)
+        parsed: dict[str, Expr] = {}
+        for name, body in aliases.items():
+            try:
+                parsed[name] = parse_expr_to_ir(body)
+            except (ValueError, RecursionError):
+                continue
+        inlined: dict[str, Expr] = {}
+        for name, expr in parsed.items():
+            try:
+                inlined[name] = inline_aliases(expr, parsed)
+            except (ValueError, RecursionError):
+                inlined[name] = expr
+        return inlined
+    finally:
+        if needed > old_limit:
+            sys.setrecursionlimit(old_limit)
 
 
 _INITIAL_STATE_SHAPED_KEY = "shaped"
@@ -3003,6 +3045,7 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:  # noqa: C901,
         ),
         shaped_params=tuple(sorted(shaped_params.items())),
         time_varying_params=tuple(sorted(time_varying_full.items())),
+        aliases_ir=_build_aliases_ir(aliases),
     )
 
 
@@ -3265,4 +3308,5 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
         ),
         shaped_params=tuple(sorted(shaped_params.items())),
         time_varying_params=tuple(sorted(time_varying_full.items())),
+        aliases_ir=_build_aliases_ir(aliases),
     )

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -18,6 +18,7 @@ import pytest
 from op_system import compile_rhs
 from op_system._constraints import _ConstraintRule, _normalize_constraints
 from op_system._errors import InvalidRhsSpecError
+from op_system._ir import Apply, free_symbols, parse_expr_to_ir
 from op_system.specs import (
     NormalizedRhs,
     StateTemplate,
@@ -2007,3 +2008,66 @@ def test_state_templates_expr_kind_populated() -> None:
     assert len(out.state_templates) == 2
     flat = tuple(n for tpl in out.state_templates for n in tpl.expanded_names)
     assert flat == out.state_names
+
+
+# ---------------------------------------------------------------------------
+# aliases_ir field (typed IR exposed alongside string aliases)
+# ---------------------------------------------------------------------------
+
+
+def test_aliases_ir_exposes_parsed_ir_for_simple_alias() -> None:
+    """``aliases_ir`` should contain a parsed IR Expr for each string alias."""
+    spec = {
+        "kind": "expr",
+        "state": ["S", "I", "R"],
+        "aliases": {"N": "S + I + R"},
+        "equations": {"S": "0", "I": "0", "R": "0"},
+    }
+    out = normalize_expr_rhs(spec)
+    assert "N" in out.aliases_ir
+    assert out.aliases_ir["N"] == parse_expr_to_ir("S + I + R")
+    assert isinstance(out.aliases_ir["N"], Apply)
+    assert free_symbols(out.aliases_ir["N"]) == {"S", "I", "R"}
+
+
+def test_aliases_ir_inlines_chained_aliases() -> None:
+    """Alias bodies that reference other aliases should be flattened in IR."""
+    spec = {
+        "kind": "expr",
+        "state": ["S", "I"],
+        "aliases": {"N": "S + I", "frac": "S / N"},
+        "equations": {"S": "0", "I": "0"},
+    }
+    out = normalize_expr_rhs(spec)
+    # ``frac`` should no longer reference ``N`` after inlining.
+    assert "N" not in free_symbols(out.aliases_ir["frac"])
+    assert {"S", "I"} <= free_symbols(out.aliases_ir["frac"])
+
+
+def test_aliases_ir_falls_back_for_cyclic_aliases() -> None:
+    """Cyclic aliases must not abort normalization; cycle survives at eval time."""
+    spec = {
+        "kind": "expr",
+        "state": ["x"],
+        "aliases": {"a": "b + 1", "b": "a + 1"},
+        "equations": {"x": "a"},
+    }
+    out = normalize_expr_rhs(spec)
+    # Both entries are present (un-inlined) so existing string-based consumers
+    # remain authoritative; lazy cycle detection still fires at eval time.
+    assert set(out.aliases_ir) == {"a", "b"}
+
+
+def test_aliases_ir_present_for_transitions_kind() -> None:
+    """``transitions`` kind should also populate the typed IR alias map."""
+    spec = {
+        "kind": "transitions",
+        "state": ["S", "I", "R"],
+        "aliases": {"N": "S + I + R"},
+        "transitions": [
+            {"from": "S", "to": "I", "rate": "beta * I / N"},
+            {"from": "I", "to": "R", "rate": "gamma"},
+        ],
+    }
+    out = normalize_transitions_rhs(spec)
+    assert "N" in out.aliases_ir


### PR DESCRIPTION
## Summary

Adds an additive `aliases_ir: Mapping[str, Expr]` field to `NormalizedRhs`, populated during `normalize_expr_rhs`/`normalize_transitions_rhs` from the string aliases via a new `_build_aliases_ir` helper.

The helper:
1. Parses each alias body to typed IR using `parse_expr_to_ir`.
2. Runs `inline_aliases` to flatten alias-to-alias references into self-contained IR expressions.

## Behaviour preservation

The field is **best-effort and additive** — it never aborts normalization:
- Aliases whose bodies fail to parse to IR (e.g. very long expanded Add chains exceeding Python's default recursion limit, regression-tested by `test_long_add_chain_does_not_raise_recursionerror`) are omitted from `aliases_ir`.
- Aliases whose inlining detects a cycle (regression-tested by `test_alias_cycle_is_rejected`) fall back to un-inlined parsed IR so existing lazy cycle detection at evaluation time still fires.
- Recursion limit is bumped to 10k temporarily during the build and restored in `finally`.

String-based consumers (`_vectorize`, `compile`) continue to read from `rhs.aliases` unchanged.

## Tests

Adds 4 new tests in `tests/op_system/test_op_system_specs.py`:
- `test_aliases_ir_exposes_parsed_ir_for_simple_alias` — IR Expr matches `parse_expr_to_ir` round-trip.
- `test_aliases_ir_inlines_chained_aliases` — `frac = S / N` with `N = S + I` flattens to no `N` reference.
- `test_aliases_ir_falls_back_for_cyclic_aliases` — cyclic aliases still normalize, both entries present.
- `test_aliases_ir_present_for_transitions_kind` — transitions kind also populates IR map.

Full suite: 305 passed. `just ci` green.

## Scope

This is a foundation slice for #112. Does not change any existing consumers; future PRs will migrate `_vectorize` / `compile` to read `aliases_ir` directly.

Refs #112