### PR TITLE
feat(#112): carry equation IR into compile and vector paths

### DIFF
--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -334,6 +334,132 @@ def parse_expr_to_ir(expr: str, *, lower_helpers: bool = False) -> Expr:
     return ir
 
 
+def _literal_coord_value(coord: str) -> int | float | str:
+    try:
+        return int(coord)
+    except ValueError:
+        try:
+            return float(coord)
+        except ValueError:
+            return coord
+
+
+def _axis_index_to_ast(idx: AxisIndex) -> ast.expr:
+    if idx.coord is not None:
+        return ast.Constant(value=_literal_coord_value(idx.coord))
+    return ast.Name(id=idx.placeholder or idx.axis, ctx=ast.Load())
+
+
+def _call_func_ast(name: str) -> ast.expr:
+    parts = name.split(".")
+    node: ast.expr = ast.Name(id=parts[0], ctx=ast.Load())
+    for part in parts[1:]:
+        node = ast.Attribute(value=node, attr=part, ctx=ast.Load())
+    return node
+
+
+def _binary_ast(op: str) -> ast.operator:
+    if op == "+":
+        return ast.Add()
+    if op == "-":
+        return ast.Sub()
+    if op == "*":
+        return ast.Mult()
+    if op == "/":
+        return ast.Div()
+    if op == "%":
+        return ast.Mod()
+    if op == "pow":
+        return ast.Pow()
+    _invalid(detail=f"unsupported binary IR op: {op}")
+
+
+def _compare_ast(op: str) -> ast.cmpop:
+    if op == "==":
+        return ast.Eq()
+    if op == "!=":
+        return ast.NotEq()
+    if op == "<":
+        return ast.Lt()
+    if op == "<=":
+        return ast.LtE()
+    if op == ">":
+        return ast.Gt()
+    if op == ">=":
+        return ast.GtE()
+    _invalid(detail=f"unsupported comparison IR op: {op}")
+
+
+def ir_to_ast_expr(expr: Expr) -> ast.expr:  # noqa: C901, PLR0911, PLR0912
+    """Convert typed IR back to a Python AST expression node.
+
+    Args:
+        expr: Typed IR expression.
+
+    Returns:
+        Equivalent Python ``ast.expr`` node, suitable for validation,
+        rewriting, and compilation by the existing runtime paths.
+    """
+    if isinstance(expr, Literal):
+        return ast.Constant(value=expr.value)
+    if isinstance(expr, Sym):
+        return ast.Name(id=expr.name, ctx=ast.Load())
+    if isinstance(expr, Subscript):
+        parts = [_axis_index_to_ast(idx) for idx in expr.indices]
+        slc: ast.expr = (
+            parts[0] if len(parts) == 1 else ast.Tuple(parts, ctx=ast.Load())
+        )
+        return ast.Subscript(
+            value=ast.Name(id=expr.name, ctx=ast.Load()),
+            slice=slc,
+            ctx=ast.Load(),
+        )
+    if isinstance(expr, Reduce):
+        _invalid(detail="structured Reduce nodes cannot be converted to Python AST yet")
+    if isinstance(expr, Apply):
+        if expr.op == "neg" and len(expr.args) == 1:
+            return ast.UnaryOp(op=ast.USub(), operand=ir_to_ast_expr(expr.args[0]))
+        if expr.op == "pos" and len(expr.args) == 1:
+            return ast.UnaryOp(op=ast.UAdd(), operand=ir_to_ast_expr(expr.args[0]))
+        if expr.op in {"+", "-", "*", "/", "%", "pow"} and len(expr.args) == 2:
+            return ast.BinOp(
+                left=ir_to_ast_expr(expr.args[0]),
+                op=_binary_ast(expr.op),
+                right=ir_to_ast_expr(expr.args[1]),
+            )
+        if expr.op in {"==", "!=", "<", "<=", ">", ">="} and len(expr.args) == 2:
+            return ast.Compare(
+                left=ir_to_ast_expr(expr.args[0]),
+                ops=[_compare_ast(expr.op)],
+                comparators=[ir_to_ast_expr(expr.args[1])],
+            )
+        if expr.op in {"and", "or"}:
+            bool_op: ast.boolop = ast.And() if expr.op == "and" else ast.Or()
+            return ast.BoolOp(op=bool_op, values=[ir_to_ast_expr(a) for a in expr.args])
+        if expr.op == "ifelse" and len(expr.args) == 3:
+            return ast.IfExp(
+                test=ir_to_ast_expr(expr.args[0]),
+                body=ir_to_ast_expr(expr.args[1]),
+                orelse=ir_to_ast_expr(expr.args[2]),
+            )
+        call_args: list[ast.expr] = []
+        keywords: list[ast.keyword] = []
+        for arg in expr.args:
+            if isinstance(arg, Apply) and arg.op == "kwarg" and len(arg.args) == 2:
+                key_node = arg.args[0]
+                if not isinstance(key_node, Literal) or not isinstance(
+                    key_node.value, str
+                ):
+                    _invalid(detail="malformed kwarg IR node")
+                keywords.append(
+                    ast.keyword(arg=key_node.value, value=ir_to_ast_expr(arg.args[1]))
+                )
+            else:
+                call_args.append(ir_to_ast_expr(arg))
+        return ast.Call(func=_call_func_ast(expr.op), args=call_args, keywords=keywords)
+    _invalid(detail=f"unsupported IR node for AST conversion: {type(expr).__name__}")
+
+
 def _unparse_axis_index(idx: AxisIndex) -> str:
     if idx.placeholder is not None:
         return f"${idx.placeholder}"

--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, NoReturn
 from ._errors import InvalidExpressionError
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping
+    from collections.abc import Callable, Iterator, Mapping, Sequence
 
 
 @dataclass(frozen=True, slots=True)
@@ -672,6 +672,87 @@ def substitute(expr: Expr, mapping: Mapping[str, Expr]) -> Expr:
     _invalid(detail=f"unsupported IR node in substitute: {type(expr).__name__}")
 
 
+def _map_children(expr: Expr, fn: Callable[[Expr], Expr]) -> Expr:
+    if isinstance(expr, Apply):
+        new_args = tuple(fn(arg) for arg in expr.args)
+        if new_args == expr.args:
+            return expr
+        return Apply(op=expr.op, args=new_args)
+    if isinstance(expr, Reduce):
+        new_body = fn(expr.body)
+        if new_body == expr.body:
+            return expr
+        return Reduce(kind=expr.kind, bindings=expr.bindings, body=new_body)
+    return expr
+
+
+def _is_cse_candidate(expr: Expr) -> bool:
+    return isinstance(expr, (Apply, Reduce))
+
+
+def _expr_cost(expr: Expr) -> int:
+    if isinstance(expr, Apply):
+        return 1 + sum(_expr_cost(arg) for arg in expr.args)
+    if isinstance(expr, Reduce):
+        return 1 + _expr_cost(expr.body)
+    return 1
+
+
+def _postorder(expr: Expr, out: dict[Expr, int]) -> None:
+    if isinstance(expr, Apply):
+        for arg in expr.args:
+            _postorder(arg, out)
+    elif isinstance(expr, Reduce):
+        _postorder(expr.body, out)
+    out[expr] = out.get(expr, 0) + 1
+
+
+def extract_common_subexpressions(
+    exprs: Sequence[Expr],
+    *,
+    prefix: str = "_cse",
+    min_cost: int = 2,
+) -> tuple[tuple[tuple[str, Expr], ...], tuple[Expr, ...]]:
+    """Extract repeated IR subtrees into deterministic symbol bindings.
+
+    This is a pure planning pass for the #112 IR migration. It does not
+    perform code generation; callers receive a list of temporary bindings and
+    rewritten root expressions that reference those temporaries. Bindings are
+    emitted in child-before-parent order so later bindings may depend on
+    earlier temporary names.
+
+    Args:
+        exprs: Root IR expressions to analyze together.
+        prefix: Prefix used for generated temporary symbol names.
+        min_cost: Minimum subtree cost eligible for extraction.
+
+    Returns:
+        ``(bindings, rewritten_exprs)`` where ``bindings`` is a tuple of
+        ``(name, expr)`` pairs and ``rewritten_exprs`` is positionally aligned
+        with ``exprs``.
+    """
+    counts: dict[Expr, int] = {}
+    for expr in exprs:
+        _postorder(expr, counts)
+
+    selected = tuple(
+        expr
+        for expr, count in counts.items()
+        if count > 1 and _is_cse_candidate(expr) and _expr_cost(expr) >= min_cost
+    )
+    names = {expr: f"{prefix}{i}" for i, expr in enumerate(selected)}
+
+    def replace(expr: Expr) -> Expr:
+        name = names.get(expr)
+        if name is not None:
+            return Sym(name=name)
+        return _map_children(expr, replace)
+
+    bindings = tuple((names[expr], _map_children(expr, replace)) for expr in selected)
+    rewritten = tuple(replace(expr) for expr in exprs)
+    return bindings, rewritten
+
+
 def axis_kinds(expr: Expr, *, axis_names: frozenset[str]) -> tuple[AxisKind, ...]:
     """Classify every ``AxisIndex`` position in walk order.
 
@@ -749,7 +830,9 @@ __all__ = [
     "Sym",
     "axis_kinds",
     "classify_axis_index",
+    "extract_common_subexpressions",
     "free_symbols",
+    "ir_to_ast_expr",
     "iter_subscripts",
     "lower_helper_calls",
     "parse_expr_to_ir",

--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, NoReturn
 from ._errors import InvalidExpressionError
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator, Mapping, Sequence
+    from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 
 
 @dataclass(frozen=True, slots=True)
@@ -712,6 +712,7 @@ def extract_common_subexpressions(
     *,
     prefix: str = "_cse",
     min_cost: int = 2,
+    reserved_names: Iterable[str] = (),
 ) -> tuple[tuple[tuple[str, Expr], ...], tuple[Expr, ...]]:
     """Extract repeated IR subtrees into deterministic symbol bindings.
 
@@ -725,6 +726,7 @@ def extract_common_subexpressions(
         exprs: Root IR expressions to analyze together.
         prefix: Prefix used for generated temporary symbol names.
         min_cost: Minimum subtree cost eligible for extraction.
+        reserved_names: Names that generated temporaries must not use.
 
     Returns:
         ``(bindings, rewritten_exprs)`` where ``bindings`` is a tuple of
@@ -740,7 +742,17 @@ def extract_common_subexpressions(
         for expr, count in counts.items()
         if count > 1 and _is_cse_candidate(expr) and _expr_cost(expr) >= min_cost
     )
-    names = {expr: f"{prefix}{i}" for i, expr in enumerate(selected)}
+    reserved = set(reserved_names)
+    names: dict[Expr, str] = {}
+    next_index = 0
+    for expr in selected:
+        while True:
+            candidate = f"{prefix}{next_index}"
+            next_index += 1
+            if candidate not in reserved:
+                break
+        names[expr] = candidate
+        reserved.add(candidate)
 
     def replace(expr: Expr) -> Expr:
         name = names.get(expr)

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -124,6 +124,7 @@ class NormalizedRhs:
     shaped_params: tuple[tuple[str, tuple[str, ...]], ...] = ()
     time_varying_params: tuple[tuple[str, tuple[str, ...]], ...] = ()
     aliases_ir: Mapping[str, Expr] = field(default_factory=dict)
+    equations_ir: tuple[Expr | None, ...] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -1163,6 +1164,43 @@ def _build_aliases_ir(aliases: Mapping[str, str]) -> dict[str, Expr]:
             except (ValueError, RecursionError):
                 inlined[name] = expr
         return inlined
+    finally:
+        if needed > old_limit:
+            sys.setrecursionlimit(old_limit)
+
+
+def _build_equations_ir(
+    equations: tuple[str, ...],
+    aliases_ir: Mapping[str, Expr],
+) -> tuple[Expr | None, ...]:
+    """Parse each equation RHS to IR, inlining alias references.
+
+    Best-effort: entries that fail to parse or inline are returned as ``None``
+    so positional alignment with ``equations`` is preserved. Mirrors the
+    fallback policy of :func:`_build_aliases_ir` to keep this slice purely
+    additive — existing string-based consumers remain authoritative.
+
+    Returns:
+        Tuple of IR expressions (or ``None`` for failed entries) aligned
+        positionally with ``equations``.
+    """
+    old_limit = sys.getrecursionlimit()
+    needed = max(old_limit, 10_000)
+    try:
+        if needed > old_limit:
+            sys.setrecursionlimit(needed)
+        out: list[Expr | None] = []
+        for eq in equations:
+            try:
+                expr = parse_expr_to_ir(eq)
+            except (ValueError, RecursionError):
+                out.append(None)
+                continue
+            try:
+                out.append(inline_aliases(expr, aliases_ir))
+            except (ValueError, RecursionError):
+                out.append(expr)
+        return tuple(out)
     finally:
         if needed > old_limit:
             sys.setrecursionlimit(old_limit)
@@ -2878,7 +2916,7 @@ def normalize_rhs(spec: Mapping[str, Any] | None) -> NormalizedRhs:
     return normalize_expr_rhs(spec)  # unreachable; satisfies return type checker
 
 
-def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:  # noqa: C901, PLR0914
+def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:  # noqa: C901, PLR0914, PLR0915
     """Normalize an expression-based RHS specification.
 
     Args:
@@ -3019,10 +3057,12 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:  # noqa: C901,
     time_varying_set = set(time_varying_full)
     axis_name_set = set(axis_lookup_dict)
     template_base_set = {parse_selector(k)[0] for k in template_map_all}
+    eqs_tuple = tuple(eqs)
+    aliases_ir_map = _build_aliases_ir(aliases)
     return NormalizedRhs(
         kind="expr",
         state_names=tuple(state_expanded),
-        equations=tuple(eqs),
+        equations=eqs_tuple,
         aliases=aliases,
         param_names=_sorted_unique(
             sym
@@ -3045,7 +3085,8 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:  # noqa: C901,
         ),
         shaped_params=tuple(sorted(shaped_params.items())),
         time_varying_params=tuple(sorted(time_varying_full.items())),
-        aliases_ir=_build_aliases_ir(aliases),
+        aliases_ir=aliases_ir_map,
+        equations_ir=_build_equations_ir(eqs_tuple, aliases_ir_map),
     )
 
 
@@ -3282,10 +3323,12 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
     time_varying_set = set(time_varying_full)
     axis_name_set = set(axis_lookup_dict)
     template_base_set = {parse_selector(k)[0] for k in template_map_all}
+    eqs_tuple = tuple(_build_transition_equations(state_expanded, d_terms))
+    aliases_ir_map = _build_aliases_ir(aliases)
     return NormalizedRhs(
         kind="transitions",
         state_names=tuple(state_expanded),
-        equations=tuple(_build_transition_equations(state_expanded, d_terms)),
+        equations=eqs_tuple,
         aliases=aliases,
         param_names=_sorted_unique(
             sym
@@ -3308,5 +3351,6 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
         ),
         shaped_params=tuple(sorted(shaped_params.items())),
         time_varying_params=tuple(sorted(time_varying_full.items())),
-        aliases_ir=_build_aliases_ir(aliases),
+        aliases_ir=aliases_ir_map,
+        equations_ir=_build_equations_ir(eqs_tuple, aliases_ir_map),
     )

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -125,6 +125,7 @@ class NormalizedRhs:
     time_varying_params: tuple[tuple[str, tuple[str, ...]], ...] = ()
     aliases_ir: Mapping[str, Expr] = field(default_factory=dict)
     equations_ir: tuple[Expr | None, ...] = ()
+    equations_ir_raw: tuple[Expr | None, ...] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -1171,9 +1172,9 @@ def _build_aliases_ir(aliases: Mapping[str, str]) -> dict[str, Expr]:
 
 def _build_equations_ir(
     equations: tuple[str, ...],
-    aliases_ir: Mapping[str, Expr],
+    aliases_ir: Mapping[str, Expr] | None = None,
 ) -> tuple[Expr | None, ...]:
-    """Parse each equation RHS to IR, inlining alias references.
+    """Parse each equation RHS to IR, optionally inlining alias references.
 
     Best-effort: entries that fail to parse or inline are returned as ``None``
     so positional alignment with ``equations`` is preserved. Mirrors the
@@ -1195,6 +1196,9 @@ def _build_equations_ir(
                 expr = parse_expr_to_ir(eq)
             except (ValueError, RecursionError):
                 out.append(None)
+                continue
+            if aliases_ir is None:
+                out.append(expr)
                 continue
             try:
                 out.append(inline_aliases(expr, aliases_ir))
@@ -3087,6 +3091,7 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:  # noqa: C901,
         time_varying_params=tuple(sorted(time_varying_full.items())),
         aliases_ir=aliases_ir_map,
         equations_ir=_build_equations_ir(eqs_tuple, aliases_ir_map),
+        equations_ir_raw=_build_equations_ir(eqs_tuple),
     )
 
 
@@ -3353,4 +3358,5 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
         time_varying_params=tuple(sorted(time_varying_full.items())),
         aliases_ir=aliases_ir_map,
         equations_ir=_build_equations_ir(eqs_tuple, aliases_ir_map),
+        equations_ir_raw=_build_equations_ir(eqs_tuple),
     )

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 
+from op_system._ir import Expr, ir_to_ast_expr
 from op_system.compile import (
     _SAFE_BUILTINS,
     _check_numeric_dtype,
@@ -577,6 +578,7 @@ class _NameRewriter(ast.NodeTransformer):
 def _rewrite_cell_to_vector(  # noqa: PLR0913
     *,
     expr: str,
+    expr_ir: Expr | None = None,
     target_axes: tuple[str, ...],
     cell_coords: Mapping[str, str],
     name_to_template: Mapping[str, _BufferTemplate],
@@ -590,7 +592,12 @@ def _rewrite_cell_to_vector(  # noqa: PLR0913
         An ``ast.Expression`` whose body evaluates to an array shaped per
         ``target_axes`` (or a scalar when ``target_axes`` is empty).
     """
-    tree = _parse_expr(expr)
+    tree = (
+        ast.Expression(body=ir_to_ast_expr(expr_ir))
+        if expr_ir is not None
+        else _parse_expr(expr)
+    )
+    ast.fix_missing_locations(tree)
     _validate_ast(tree, expr=expr)
     rewriter = _NameRewriter(
         target_axes=target_axes,
@@ -1437,6 +1444,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
             if buf.axes:
                 tree = _rewrite_cell_to_vector(
                     expr=rhs.aliases[buf.expanded_names[0]],
+                    expr_ir=rhs.aliases_ir.get(buf.expanded_names[0]),
                     target_axes=buf.axes,
                     cell_coords=buf.coord_assignments[0],
                     name_to_template=name_to_template,
@@ -1447,6 +1455,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
                 if len(buf.expanded_names) > 1:
                     last_tree = _rewrite_cell_to_vector(
                         expr=rhs.aliases[buf.expanded_names[-1]],
+                        expr_ir=rhs.aliases_ir.get(buf.expanded_names[-1]),
                         target_axes=buf.axes,
                         cell_coords=buf.coord_assignments[-1],
                         name_to_template=name_to_template,
@@ -1461,6 +1470,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
                 # templated state cells become buffer-index accesses.
                 tree = _rewrite_cell_to_vector(
                     expr=rhs.aliases[buf.expanded_names[0]],
+                    expr_ir=rhs.aliases_ir.get(buf.expanded_names[0]),
                     target_axes=(),
                     cell_coords={},
                     name_to_template=name_to_template,

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -1136,6 +1136,7 @@ def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR
     *,
     template: _BufferTemplate,
     equations: tuple[str, ...],
+    equations_ir: tuple[Expr | None, ...] | None = None,
     name_to_template: Mapping[str, _BufferTemplate],
     name_to_coords: Mapping[str, Mapping[str, str]],
     axis_index: Mapping[str, Mapping[str, int]],
@@ -1170,6 +1171,11 @@ def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR
     cell_exprs = equations[template.offset : template.offset + size]
     if len(cell_exprs) != size or size == 0:
         return None
+    cell_irs = (
+        equations_ir[template.offset : template.offset + size]
+        if equations_ir is not None and len(equations_ir) == len(equations)
+        else ()
+    )
     n_axes = len(template.axes)
 
     # Enumerate candidate unroll-axis index subsets, smallest first.
@@ -1228,6 +1234,7 @@ def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR
             try:
                 first_tree = _rewrite_cell_to_vector(
                     expr=cell_exprs[first_idx],
+                    expr_ir=cell_irs[first_idx] if cell_irs else None,
                     target_axes=vec_axes,
                     cell_coords=template.coord_assignments[first_idx],
                     name_to_template=name_to_template,
@@ -1242,6 +1249,7 @@ def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR
                 try:
                     last_tree = _rewrite_cell_to_vector(
                         expr=cell_exprs[last_idx],
+                        expr_ir=cell_irs[last_idx] if cell_irs else None,
                         target_axes=vec_axes,
                         cell_coords=template.coord_assignments[last_idx],
                         name_to_template=name_to_template,
@@ -1491,6 +1499,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
         result = _vectorize_template_equations(
             template=buf,
             equations=rhs.equations,
+            equations_ir=rhs.equations_ir_raw,
             name_to_template=name_to_template,
             name_to_coords=name_to_coords,
             axis_index=axis_index,

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -38,7 +38,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from op_system._errors import InvalidExpressionError
-from op_system._ir import Expr, ir_to_ast_expr
+from op_system._ir import Expr, extract_common_subexpressions, ir_to_ast_expr
 from op_system._symbols import parse_expression_string
 
 if TYPE_CHECKING:
@@ -407,7 +407,7 @@ def _collect_alias_code(
 def _collect_eq_code(
     equations: tuple[str, ...],
     equations_ir: tuple[Expr | None, ...] | None = None,
-) -> list[CodeType]:
+) -> tuple[tuple[tuple[str, CodeType], ...], list[CodeType]]:
     """Compile equation expressions into code objects.
 
     Args:
@@ -416,15 +416,44 @@ def _collect_eq_code(
             aligned with ``equations``.
 
     Returns:
-        List of compiled code objects.
+        CSE binding code objects plus equation code objects.
     """
-    ir_tuple = (
-        equations_ir if equations_ir and len(equations_ir) == len(equations) else ()
-    )
-    return [
-        _compile_expr(expr, ir_tuple[i] if ir_tuple else None)
-        for i, expr in enumerate(equations)
-    ]
+    if (
+        equations_ir
+        and len(equations_ir) == len(equations)
+        and all(expr is not None for expr in equations_ir)
+    ):
+        concrete_ir = tuple(expr for expr in equations_ir if expr is not None)
+        bindings, rewritten = extract_common_subexpressions(
+            concrete_ir,
+            prefix="__op_system_cse_",
+        )
+        cse_code = tuple((name, _compile_expr(name, expr)) for name, expr in bindings)
+        eq_code = [  # noqa: FURB140
+            _compile_expr(expr_s, expr_ir)
+            for expr_s, expr_ir in zip(equations, rewritten, strict=True)
+        ]
+        return cse_code, eq_code
+    return (), [_compile_expr(expr) for expr in equations]
+
+
+def _evaluate_cse_bindings(
+    cse_code: tuple[tuple[str, CodeType], ...],
+    *,
+    env: dict[str, object],
+) -> None:
+    """Evaluate CSE temporaries into ``env`` before equation evaluation."""
+    for name, codeobj in cse_code:
+        try:
+            env[name] = eval(  # noqa: S307
+                codeobj,
+                {"__builtins__": _SAFE_BUILTINS},
+                env,
+            )
+        except NameError as exc:
+            _raise_parameter_error(detail=f"unknown symbol in CSE binding: {exc!s}")
+        except (ValueError, TypeError, ArithmeticError) as exc:
+            _raise_invalid_expression(detail=f"CSE binding evaluation failed: {exc!r}")
 
 
 def _resolve_aliases(
@@ -538,7 +567,7 @@ def _make_eval_fn(
     n_state = len(state_names)
     name_to_idx = {s: i for i, s in enumerate(state_names)}
     alias_code = _collect_alias_code(aliases, aliases_ir)
-    eq_code = _collect_eq_code(equations, equations_ir)
+    cse_code, eq_code = _collect_eq_code(equations, equations_ir)
 
     def eval_fn(t: object, y: object, **params: object) -> Float64Array:
         xp = _namespace_of(y)
@@ -571,6 +600,8 @@ def _make_eval_fn(
 
         if alias_code:
             env.update(_resolve_aliases(alias_code, base_env=env))
+        if cse_code:
+            _evaluate_cse_bindings(cse_code, env=env)
 
         return _evaluate_equations(eq_code=eq_code, env=env, xp=xp)
 

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -42,7 +42,7 @@ from op_system._ir import Expr, extract_common_subexpressions, ir_to_ast_expr
 from op_system._symbols import parse_expression_string
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable, Iterable, Mapping
     from types import CodeType
 
     from .specs import NormalizedRhs
@@ -407,6 +407,7 @@ def _collect_alias_code(
 def _collect_eq_code(
     equations: tuple[str, ...],
     equations_ir: tuple[Expr | None, ...] | None = None,
+    reserved_names: Iterable[str] = (),
 ) -> tuple[tuple[tuple[str, CodeType], ...], list[CodeType]]:
     """Compile equation expressions into code objects.
 
@@ -414,6 +415,7 @@ def _collect_eq_code(
         equations: Tuple of equation expression strings.
         equations_ir: Optional tuple of typed IR expressions, positionally
             aligned with ``equations``.
+        reserved_names: Runtime names that generated CSE temporaries must avoid.
 
     Returns:
         CSE binding code objects plus equation code objects.
@@ -427,6 +429,7 @@ def _collect_eq_code(
         bindings, rewritten = extract_common_subexpressions(
             concrete_ir,
             prefix="__op_system_cse_",
+            reserved_names=reserved_names,
         )
         cse_code = tuple((name, _compile_expr(name, expr)) for name, expr in bindings)
         eq_code = [  # noqa: FURB140
@@ -567,7 +570,12 @@ def _make_eval_fn(
     n_state = len(state_names)
     name_to_idx = {s: i for i, s in enumerate(state_names)}
     alias_code = _collect_alias_code(aliases, aliases_ir)
-    cse_code, eq_code = _collect_eq_code(equations, equations_ir)
+    reserved_names = {*state_names, *aliases, "np", "t", "sum_state", "sum_prefix"}
+    cse_code, eq_code = _collect_eq_code(
+        equations,
+        equations_ir,
+        reserved_names=reserved_names,
+    )
 
     def eval_fn(t: object, y: object, **params: object) -> Float64Array:
         xp = _namespace_of(y)

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -38,6 +38,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from op_system._errors import InvalidExpressionError
+from op_system._ir import Expr, ir_to_ast_expr
 from op_system._symbols import parse_expression_string
 
 if TYPE_CHECKING:
@@ -359,16 +360,22 @@ def _validate_ast(tree: ast.AST, *, expr: str) -> None:
             _validate_call(node.func, expr=expr)
 
 
-def _compile_expr(expr: str) -> CodeType:
+def _compile_expr(expr: str, expr_ir: Expr | None = None) -> CodeType:
     """Parse, validate, and compile an expression into a code object.
 
     Args:
         expr: Expression string.
+        expr_ir: Optional typed IR expression to compile directly.
 
     Returns:
         Compiled code object.
     """
-    tree = _parse_expr(expr)
+    tree = (
+        ast.Expression(body=ir_to_ast_expr(expr_ir))
+        if expr_ir is not None
+        else _parse_expr(expr)
+    )
+    ast.fix_missing_locations(tree)
     _validate_ast(tree, expr=expr)
     try:
         return compile(tree, filename="<op_system>", mode="eval")
@@ -378,28 +385,46 @@ def _compile_expr(expr: str) -> CodeType:
         )
 
 
-def _collect_alias_code(aliases: Mapping[str, str]) -> dict[str, CodeType]:
+def _collect_alias_code(
+    aliases: Mapping[str, str],
+    aliases_ir: Mapping[str, Expr] | None = None,
+) -> dict[str, CodeType]:
     """Compile alias expressions into code objects.
 
     Args:
         aliases: Mapping from alias name to expression string.
+        aliases_ir: Optional mapping from alias name to typed IR.
 
     Returns:
         Dictionary mapping alias name to compiled code object.
     """
-    return {name: _compile_expr(expr) for name, expr in aliases.items()}
+    ir_map = aliases_ir or {}
+    return {
+        name: _compile_expr(expr, ir_map.get(name)) for name, expr in aliases.items()
+    }
 
 
-def _collect_eq_code(equations: tuple[str, ...]) -> list[CodeType]:
+def _collect_eq_code(
+    equations: tuple[str, ...],
+    equations_ir: tuple[Expr | None, ...] | None = None,
+) -> list[CodeType]:
     """Compile equation expressions into code objects.
 
     Args:
         equations: Tuple of equation expression strings.
+        equations_ir: Optional tuple of typed IR expressions, positionally
+            aligned with ``equations``.
 
     Returns:
         List of compiled code objects.
     """
-    return [_compile_expr(expr) for expr in equations]
+    ir_tuple = (
+        equations_ir if equations_ir and len(equations_ir) == len(equations) else ()
+    )
+    return [
+        _compile_expr(expr, ir_tuple[i] if ir_tuple else None)
+        for i, expr in enumerate(equations)
+    ]
 
 
 def _resolve_aliases(
@@ -494,6 +519,8 @@ def _make_eval_fn(
     state_names: tuple[str, ...],
     aliases: Mapping[str, str],
     equations: tuple[str, ...],
+    aliases_ir: Mapping[str, Expr] | None = None,
+    equations_ir: tuple[Expr | None, ...] | None = None,
 ) -> EvalFn:
     """Build a namespace-polymorphic ``eval_fn(t, y, **params) -> dydt``.
 
@@ -510,8 +537,8 @@ def _make_eval_fn(
     """
     n_state = len(state_names)
     name_to_idx = {s: i for i, s in enumerate(state_names)}
-    alias_code = _collect_alias_code(aliases)
-    eq_code = _collect_eq_code(equations)
+    alias_code = _collect_alias_code(aliases, aliases_ir)
+    eq_code = _collect_eq_code(equations, equations_ir)
 
     def eval_fn(t: object, y: object, **params: object) -> Float64Array:
         xp = _namespace_of(y)
@@ -731,6 +758,8 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
             state_names=rhs.state_names,
             aliases=rhs.aliases,
             equations=rhs.equations,
+            aliases_ir=rhs.aliases_ir,
+            equations_ir=rhs.equations_ir,
         )
 
     eval_fn = _wrap_eval_fn_for_time_varying(

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -20,6 +20,7 @@ Note:
 from __future__ import annotations
 
 import re
+from dataclasses import replace
 
 import numpy as np
 import pytest
@@ -295,6 +296,25 @@ def test_alias_cycle_is_rejected() -> None:
     compiled = compile_rhs(rhs, xp=np)
     with pytest.raises(ValueError, match=r"could not resolve alias dependencies"):
         compiled.eval_fn(np.float64(0.0), np.array([1.0], dtype=np.float64))
+
+
+def test_scalar_compile_uses_normalized_ir_when_available() -> None:
+    """Scalar fallback should compile from IR instead of reparsing strings."""
+    rhs = normalize_rhs({
+        "kind": "expr",
+        "state": ["x"],
+        "aliases": {"double": "x * 2"},
+        "equations": {"x": "double + 1"},
+    })
+    rhs = replace(
+        rhs,
+        aliases={"double": "not valid python !!!"},
+        equations=("also not valid python !!!",),
+    )
+
+    compiled = compile_rhs(rhs, xp=np)
+    out = compiled.eval_fn(np.float64(0.0), np.array([2.0], dtype=np.float64))
+    assert np.allclose(out, np.array([5.0]))
 
 
 def test_transitions_rhs_compiles_and_evaluates() -> None:

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -26,7 +26,7 @@ import numpy as np
 import pytest
 
 from op_system import compile_spec
-from op_system.compile import CompiledRhs, compile_rhs
+from op_system.compile import CompiledRhs, _collect_eq_code, compile_rhs
 from op_system.specs import NormalizedRhs, normalize_rhs
 
 
@@ -315,6 +315,30 @@ def test_scalar_compile_uses_normalized_ir_when_available() -> None:
     compiled = compile_rhs(rhs, xp=np)
     out = compiled.eval_fn(np.float64(0.0), np.array([2.0], dtype=np.float64))
     assert np.allclose(out, np.array([5.0]))
+
+
+def test_scalar_compile_extracts_equation_ir_cse() -> None:
+    """Repeated equation IR subtrees should compile as scalar temporaries."""
+    rhs = normalize_rhs({
+        "kind": "expr",
+        "state": ["x", "y"],
+        "equations": {
+            "x": "(a + b) * (a + b)",
+            "y": "(a + b) + 1",
+        },
+    })
+
+    cse_code, _ = _collect_eq_code(rhs.equations, rhs.equations_ir)
+    assert tuple(name for name, _ in cse_code) == ("__op_system_cse_0",)
+
+    compiled = compile_rhs(rhs, xp=np)
+    out = compiled.eval_fn(
+        np.float64(0.0),
+        np.array([0.0, 0.0], dtype=np.float64),
+        a=2.0,
+        b=3.0,
+    )
+    assert np.allclose(out, np.array([25.0, 6.0]))
 
 
 def test_transitions_rhs_compiles_and_evaluates() -> None:

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -328,8 +328,12 @@ def test_scalar_compile_extracts_equation_ir_cse() -> None:
         },
     })
 
-    cse_code, _ = _collect_eq_code(rhs.equations, rhs.equations_ir)
-    assert tuple(name for name, _ in cse_code) == ("__op_system_cse_0",)
+    cse_code, _ = _collect_eq_code(
+        rhs.equations,
+        rhs.equations_ir,
+        reserved_names={"__op_system_cse_0"},
+    )
+    assert tuple(name for name, _ in cse_code) == ("__op_system_cse_1",)
 
     compiled = compile_rhs(rhs, xp=np)
     out = compiled.eval_fn(

--- a/tests/op_system/test_op_system_ir.py
+++ b/tests/op_system/test_op_system_ir.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import ast
+
 import pytest
 
 from op_system._errors import InvalidExpressionError
@@ -13,6 +15,7 @@ from op_system._ir import (
     Subscript,
     Sym,
     extract_common_subexpressions,
+    ir_to_ast_expr,
     lower_helper_calls,
     parse_expr_to_ir,
 )
@@ -95,6 +98,46 @@ def test_lower_helper_calls_preserves_non_helper_apply() -> None:
     assert lowered.op == "np.maximum"
 
 
+def _eval_ir_expr(expr: str, **env: object) -> object:
+    tree = ast.Expression(body=ir_to_ast_expr(parse_expr_to_ir(expr)))
+    ast.fix_missing_locations(tree)
+    code = compile(tree, filename="<test_ir_to_ast>", mode="eval")
+    return eval(code, {"__builtins__": {}, **env})  # noqa: S307
+
+
+def test_ir_to_ast_expr_evaluates_arithmetic_equivalently() -> None:
+    """The IR-to-AST bridge should preserve arithmetic semantics."""
+    out = _eval_ir_expr(
+        "beta * S * I / N - gamma * I", beta=0.3, S=9, I=2, N=11, gamma=0.1
+    )
+    assert out == pytest.approx(0.3 * 9 * 2 / 11 - 0.1 * 2)
+
+
+def test_ir_to_ast_expr_preserves_calls_and_kwargs() -> None:
+    """Function calls, attributes, and kwargs round-trip through AST."""
+
+    class _Np:
+        @staticmethod
+        def maximum(x: float, y: float) -> float:
+            return max(x, y)
+
+    assert _eval_ir_expr("np.maximum(x, y)", np=_Np, x=1.0, y=2.0) == pytest.approx(2.0)
+
+
+def test_ir_to_ast_expr_preserves_subscripts_and_literal_indices() -> None:
+    """Subscript indices should become executable Python AST indices."""
+    assert (
+        _eval_ir_expr("arr[1] + K[age]", arr=[10, 20], K={"young": 3}, age="young")
+        == 23
+    )
+
+
+def test_ir_to_ast_expr_preserves_conditionals_and_comparisons() -> None:
+    """Conditionals and comparisons should remain executable."""
+    assert _eval_ir_expr("1 if x > 0 else -1", x=2) == 1
+    assert _eval_ir_expr("1 if x > 0 else -1", x=-2) == -1
+
+
 def test_extract_common_subexpressions_reuses_repeated_apply() -> None:
     """Repeated non-leaf subexpressions become generated symbol bindings."""
     bindings, rewritten = extract_common_subexpressions((
@@ -130,3 +173,14 @@ def test_extract_common_subexpressions_ignores_repeated_leaves() -> None:
 
     assert bindings == ()
     assert rewritten == (expr,)
+
+
+def test_extract_common_subexpressions_skips_reserved_names() -> None:
+    """Generated temporaries must avoid caller-reserved runtime names."""
+    bindings, rewritten = extract_common_subexpressions(
+        (parse_expr_to_ir("(a + b) * (a + b)"),),
+        reserved_names={"_cse0"},
+    )
+
+    assert bindings == (("_cse1", parse_expr_to_ir("a + b")),)
+    assert rewritten == (parse_expr_to_ir("_cse1 * _cse1"),)

--- a/tests/op_system/test_op_system_ir.py
+++ b/tests/op_system/test_op_system_ir.py
@@ -12,6 +12,7 @@ from op_system._ir import (
     Reduce,
     Subscript,
     Sym,
+    extract_common_subexpressions,
     lower_helper_calls,
     parse_expr_to_ir,
 )
@@ -92,3 +93,40 @@ def test_lower_helper_calls_preserves_non_helper_apply() -> None:
 
     assert isinstance(lowered, Apply)
     assert lowered.op == "np.maximum"
+
+
+def test_extract_common_subexpressions_reuses_repeated_apply() -> None:
+    """Repeated non-leaf subexpressions become generated symbol bindings."""
+    bindings, rewritten = extract_common_subexpressions((
+        parse_expr_to_ir("(a + b) * (a + b)"),
+        parse_expr_to_ir("c + (a + b)"),
+    ))
+
+    assert bindings == (("_cse0", parse_expr_to_ir("a + b")),)
+    assert rewritten == (
+        parse_expr_to_ir("_cse0 * _cse0"),
+        parse_expr_to_ir("c + _cse0"),
+    )
+
+
+def test_extract_common_subexpressions_orders_children_before_parents() -> None:
+    """Nested CSE bindings should be emitted child-before-parent."""
+    repeated = "(a + b) * (a + b)"
+    bindings, rewritten = extract_common_subexpressions((
+        parse_expr_to_ir(f"({repeated}) + ({repeated})"),
+    ))
+
+    assert bindings == (
+        ("_cse0", parse_expr_to_ir("a + b")),
+        ("_cse1", parse_expr_to_ir("_cse0 * _cse0")),
+    )
+    assert rewritten == (parse_expr_to_ir("_cse1 + _cse1"),)
+
+
+def test_extract_common_subexpressions_ignores_repeated_leaves() -> None:
+    """Bare symbol repetition alone should not introduce temporaries."""
+    expr = parse_expr_to_ir("a + a")
+    bindings, rewritten = extract_common_subexpressions((expr,))
+
+    assert bindings == ()
+    assert rewritten == (expr,)

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -2092,11 +2092,17 @@ def test_equations_ir_aligned_with_equations_expr_kind() -> None:
     }
     out = normalize_expr_rhs(spec)
     assert len(out.equations_ir) == len(out.equations)
+    assert len(out.equations_ir_raw) == len(out.equations)
     assert all(expr is not None for expr in out.equations_ir)
     # Aliases inlined: ``N`` should not appear in any equation IR.
     for expr in out.equations_ir:
         assert expr is not None
         assert "N" not in free_symbols(expr)
+    # Raw equation IR is available for consumers that still want alias-buffer
+    # references rather than inlined alias bodies.
+    assert any(
+        expr is not None and "N" in free_symbols(expr) for expr in out.equations_ir_raw
+    )
 
 
 def test_equations_ir_present_for_transitions_kind() -> None:
@@ -2112,6 +2118,7 @@ def test_equations_ir_present_for_transitions_kind() -> None:
     }
     out = normalize_transitions_rhs(spec)
     assert len(out.equations_ir) == len(out.equations)
+    assert len(out.equations_ir_raw) == len(out.equations)
     assert all(expr is not None for expr in out.equations_ir)
     for expr in out.equations_ir:
         assert expr is not None

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -2071,3 +2071,59 @@ def test_aliases_ir_present_for_transitions_kind() -> None:
     }
     out = normalize_transitions_rhs(spec)
     assert "N" in out.aliases_ir
+
+
+# ---------------------------------------------------------------------------
+# equations_ir field (typed IR exposed alongside string equations)
+# ---------------------------------------------------------------------------
+
+
+def test_equations_ir_aligned_with_equations_expr_kind() -> None:
+    """``equations_ir`` should be positionally aligned with ``equations``."""
+    spec = {
+        "kind": "expr",
+        "state": ["S", "I", "R"],
+        "aliases": {"N": "S + I + R"},
+        "equations": {
+            "S": "-beta * S * I / N",
+            "I": "beta * S * I / N - gamma * I",
+            "R": "gamma * I",
+        },
+    }
+    out = normalize_expr_rhs(spec)
+    assert len(out.equations_ir) == len(out.equations)
+    assert all(expr is not None for expr in out.equations_ir)
+    # Aliases inlined: ``N`` should not appear in any equation IR.
+    for expr in out.equations_ir:
+        assert expr is not None
+        assert "N" not in free_symbols(expr)
+
+
+def test_equations_ir_present_for_transitions_kind() -> None:
+    """``transitions`` kind should also populate ``equations_ir`` with IR."""
+    spec = {
+        "kind": "transitions",
+        "state": ["S", "I", "R"],
+        "aliases": {"N": "S + I + R"},
+        "transitions": [
+            {"from": "S", "to": "I", "rate": "beta * I / N"},
+            {"from": "I", "to": "R", "rate": "gamma"},
+        ],
+    }
+    out = normalize_transitions_rhs(spec)
+    assert len(out.equations_ir) == len(out.equations)
+    assert all(expr is not None for expr in out.equations_ir)
+    for expr in out.equations_ir:
+        assert expr is not None
+        assert "N" not in free_symbols(expr)
+
+
+def test_equations_ir_round_trip_matches_parse_expr_to_ir() -> None:
+    """For simple equations, ``equations_ir`` entries equal direct IR parse."""
+    spec = {
+        "kind": "expr",
+        "state": ["x"],
+        "equations": {"x": "a + b"},
+    }
+    out = normalize_expr_rhs(spec)
+    assert out.equations_ir[0] == parse_expr_to_ir("a + b")

--- a/tests/op_system/test_op_system_vectorize.py
+++ b/tests/op_system/test_op_system_vectorize.py
@@ -131,6 +131,35 @@ def test_vectorizer_uses_aliases_ir_for_alias_code() -> None:
     assert "I_buf" in alias_codes["I_total"].co_names
 
 
+def test_vectorizer_uses_equations_ir_for_alias_free_equations() -> None:
+    """Alias-free equation vectorization should consume ``equations_ir``."""
+    rhs = normalize_rhs(_sir_templated_param_spec())
+    rhs = replace(
+        rhs,
+        equations=tuple("not valid python !!!" for _ in rhs.equations),
+    )
+
+    plan = build_vector_plan(rhs)
+    assert plan is not None
+    assert len(plan.eq_groups) == 2
+    assert all(group.codes for group in plan.eq_groups)
+
+
+def test_vectorizer_uses_raw_equations_ir_with_alias_buffers() -> None:
+    """Equation vectorization should use raw IR while preserving aliases."""
+    rhs = normalize_rhs(_sir_two_axis_spec())
+    rhs = replace(
+        rhs,
+        equations=tuple("not valid python !!!" for _ in rhs.equations),
+    )
+
+    plan = build_vector_plan(rhs)
+    assert plan is not None
+    alias_codes = {base: code for base, code, _shape in plan.alias_codes}
+    assert "I_total" in alias_codes
+    assert all(group.codes for group in plan.eq_groups)
+
+
 def test_full_vectorization_when_no_structural_variation() -> None:
     """Fully-vectorize when all cells of a template are structurally identical.
 

--- a/tests/op_system/test_op_system_vectorize.py
+++ b/tests/op_system/test_op_system_vectorize.py
@@ -11,6 +11,7 @@ Covers:
 from __future__ import annotations
 
 import dis
+from dataclasses import replace
 
 import numpy as np
 
@@ -116,6 +117,18 @@ def test_sum_pattern_recognized_for_alias_over_full_template() -> None:
     assert len(code.co_code) < 50, (
         f"alias bytecode unexpectedly large: {len(code.co_code)}"
     )
+
+
+def test_vectorizer_uses_aliases_ir_for_alias_code() -> None:
+    """Alias vectorization should consume ``aliases_ir`` when available."""
+    rhs = normalize_rhs(_sir_two_axis_spec())
+    rhs = replace(rhs, aliases={**rhs.aliases, "I_total": "not valid python !!!"})
+
+    plan = build_vector_plan(rhs)
+    assert plan is not None
+    alias_codes = {base: code for base, code, _shape in plan.alias_codes}
+    assert "I_total" in alias_codes
+    assert "I_buf" in alias_codes["I_total"].co_names
 
 
 def test_full_vectorization_when_no_structural_variation() -> None:


### PR DESCRIPTION
## Summary

Continues the #112 typed-IR migration after `aliases_ir` by making `NormalizedRhs` carry equation IR and putting that IR on runtime paths.

Highlights:
- Adds `equations_ir` (alias-inlined) and `equations_ir_raw` (non-inlined) to `NormalizedRhs`.
- Adds a shared `ir_to_ast_expr` bridge in `_ir.py`.
- Scalar compile consumes `aliases_ir` / `equations_ir` when available.
- Vectorized alias compilation consumes `aliases_ir`.
- Vectorized equation lowering consumes `equations_ir_raw`, preserving alias-buffer references.
- Adds deterministic IR CSE extraction and uses it for scalar equation temporaries when full equation IR is present.
- Generated CSE names avoid known runtime/reserved names.

## Behavior

This remains additive/backward-compatible:
- Existing string fields remain present and are still the fallback.
- Partial or unavailable IR falls back to the existing string compile path.
- `equations_ir` is inlined for scalar compile/CSE; `equations_ir_raw` is preserved for vector lowering where alias buffers are still useful.

## Tests

- Added normalization coverage for `equations_ir` and `equations_ir_raw`.
- Added scalar compile tests proving corrupted post-normalization strings still compile/evaluate from IR.
- Added vectorizer tests proving aliases/equations can lower from IR.
- Added IR-to-AST bridge tests.
- Added IR CSE extraction tests, including nested child-before-parent ordering and reserved-name avoidance.

Validation: `just ci` green.

Diff size: ~639 changed LOC vs `main`.

Refs #112