### PR TITLE
perf(#112): memoize free_symbols and track live aliases incrementally

### DIFF
--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -605,7 +605,10 @@ def walk(expr: Expr) -> Iterator[Expr]:
         yield from walk(expr.body)
 
 
-def free_symbols(expr: Expr) -> frozenset[str]:
+def free_symbols(
+    expr: Expr,
+    memo: dict[int, frozenset[str]] | None = None,
+) -> frozenset[str]:
     """Return the set of ``Sym`` names referenced under ``expr``.
 
     ``Reduce`` bindings shadow outer symbols of the same name: a bound name
@@ -613,27 +616,45 @@ def free_symbols(expr: Expr) -> frozenset[str]:
 
     Args:
         expr: Root IR expression.
+        memo: Optional identity-keyed cache (``id(node) -> frozenset``) used
+            to share subtree results across calls on shared (frozen) IR.
+            Callers that invoke ``free_symbols`` many times over the same
+            substructure (e.g. inlining one alias body into many equations)
+            should pass a single memo dict to avoid O(alias_size) per call.
 
     Returns:
         Frozen set of identifier strings that occur as free :class:`Sym`
         references.
     """
+    if memo is None:
+        memo = {}
+    key = id(expr)
+    cached = memo.get(key)
+    if cached is not None:
+        return cached
     if isinstance(expr, Sym):
-        return frozenset({expr.name})
-    if isinstance(expr, (Literal, Subscript)):
-        return frozenset()
-    if isinstance(expr, Apply):
-        out: set[str] = set()
+        out: frozenset[str] = frozenset({expr.name})
+    elif isinstance(expr, (Literal, Subscript)):
+        out = frozenset()
+    elif isinstance(expr, Apply):
+        acc: set[str] = set()
         for arg in expr.args:
-            out |= free_symbols(arg)
-        return frozenset(out)
-    if isinstance(expr, Reduce):
+            acc |= free_symbols(arg, memo)
+        out = frozenset(acc)
+    elif isinstance(expr, Reduce):
         bound = {bind for _, bind in expr.bindings}
-        return frozenset(free_symbols(expr.body) - bound)
-    _invalid(detail=f"unsupported IR node in free_symbols: {type(expr).__name__}")
+        out = frozenset(free_symbols(expr.body, memo) - bound)
+    else:
+        _invalid(detail=f"unsupported IR node in free_symbols: {type(expr).__name__}")
+    memo[key] = out
+    return out
 
 
-def substitute(expr: Expr, mapping: Mapping[str, Expr]) -> Expr:
+def substitute(
+    expr: Expr,
+    mapping: Mapping[str, Expr],
+    memo: dict[int, frozenset[str]] | None = None,
+) -> Expr:
     """Replace named ``Sym`` leaves with their mapped IR expression.
 
     The substitution is capture-avoiding with respect to ``Reduce`` bindings:
@@ -643,11 +664,18 @@ def substitute(expr: Expr, mapping: Mapping[str, Expr]) -> Expr:
     Args:
         expr: Root IR expression.
         mapping: Substitution table from symbol name to replacement IR.
+        memo: Optional identity-keyed cache shared with :func:`free_symbols`.
+            When provided, subtrees with no free symbols intersecting
+            ``mapping`` keys are returned unchanged in O(1), avoiding a full
+            re-walk of large alias bodies that were just inlined.
 
     Returns:
         A new IR expression with substitutions applied; structurally equal
         to ``expr`` when no replacements occur.
     """
+    keys = mapping.keys()
+    if memo is not None and not (free_symbols(expr, memo) & keys):
+        return expr
     if isinstance(expr, Sym):
         return mapping.get(expr.name, expr)
     if isinstance(expr, (Literal, Subscript)):
@@ -655,7 +683,7 @@ def substitute(expr: Expr, mapping: Mapping[str, Expr]) -> Expr:
     if isinstance(expr, Apply):
         return Apply(
             op=expr.op,
-            args=tuple(substitute(arg, mapping) for arg in expr.args),
+            args=tuple(substitute(arg, mapping, memo) for arg in expr.args),
         )
     if isinstance(expr, Reduce):
         bound = {bind for _, bind in expr.bindings}
@@ -667,7 +695,7 @@ def substitute(expr: Expr, mapping: Mapping[str, Expr]) -> Expr:
         return Reduce(
             kind=expr.kind,
             bindings=expr.bindings,
-            body=substitute(expr.body, inner),
+            body=substitute(expr.body, inner, memo),
         )
     _invalid(detail=f"unsupported IR node in substitute: {type(expr).__name__}")
 

--- a/src/op_system/_ir_templates.py
+++ b/src/op_system/_ir_templates.py
@@ -350,6 +350,8 @@ def inline_aliases(
     aliases: Mapping[str, Expr],
     *,
     max_depth: int = 64,
+    memo: dict[int, frozenset[str]] | None = None,
+    skip_cycle_check: bool = False,
 ) -> Expr:
     """Fixed-point inline ``Sym`` references that match ``aliases`` keys.
 
@@ -366,6 +368,14 @@ def inline_aliases(
             Keys are expected to be fully expanded alias names (after
             template expansion), and bodies are expected to be IR.
         max_depth: Safety bound on the number of substitution rounds.
+        memo: Optional identity-keyed cache shared with
+            :func:`op_system._ir.free_symbols`. Pass a single dict across
+            many inline calls that share the same alias bodies to avoid
+            re-walking each body per equation.
+        skip_cycle_check: If ``True``, bypass :func:`_detect_alias_cycle`.
+            Callers that batch-inline many expressions against the same
+            ``aliases`` mapping should validate once and set this flag on
+            subsequent calls.
 
     Returns:
         A new IR expression with all alias references resolved.
@@ -377,19 +387,34 @@ def inline_aliases(
     if not aliases:
         return expr
 
-    cycle = _detect_alias_cycle(aliases)
-    if cycle is not None:
-        msg = f"alias cycle detected: {' -> '.join(cycle)}"
-        raise ValueError(msg)
+    if not skip_cycle_check:
+        cycle = _detect_alias_cycle(aliases)
+        if cycle is not None:
+            msg = f"alias cycle detected: {' -> '.join(cycle)}"
+            raise ValueError(msg)
 
+    if memo is None:
+        memo = {}
     keys = set(aliases)
+    # Precompute, for each alias body, which other alias names it references.
+    # The next "live" set after a substitution is exactly the union of these
+    # entries over the just-inlined names, so we never need to re-walk the
+    # substituted expression with ``free_symbols`` (which on large inlined
+    # bodies dominates inline cost when many equations share one alias).
+    body_refs: dict[str, frozenset[str]] = {
+        name: free_symbols(body, memo) & keys for name, body in aliases.items()
+    }
     current = expr
+    live = free_symbols(current, memo) & keys
     for _ in range(max_depth):
-        live = free_symbols(current) & keys
         if not live:
             return current
         mapping = {name: aliases[name] for name in live}
-        current = substitute(current, mapping)
+        current = substitute(current, mapping, memo)
+        next_live: set[str] = set()
+        for name in live:
+            next_live |= body_refs[name]
+        live = frozenset(next_live)
 
     msg = f"alias inlining did not converge within {max_depth} iterations"
     raise ValueError(msg)

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -37,7 +37,7 @@ from op_system._helpers import (
     _sorted_unique,
 )
 from op_system._ir import Expr, parse_expr_to_ir
-from op_system._ir_templates import inline_aliases
+from op_system._ir_templates import _detect_alias_cycle, inline_aliases
 from op_system._symbols import _collect_names, _parse_expr
 from op_system._templates import (
     _INLINE_TEMPLATE_RE,
@@ -1158,10 +1158,26 @@ def _build_aliases_ir(aliases: Mapping[str, str]) -> dict[str, Expr]:
                 parsed[name] = parse_expr_to_ir(body)
             except (ValueError, RecursionError):
                 continue
+        # Validate the alias graph once and share a free_symbols memo across
+        # all per-alias inline_aliases calls: alias bodies are reused by
+        # identity, so id-keyed caching turns the inner traversal cost from
+        # O(#aliases * body_size) into O(body_size).
+        memo: dict[int, frozenset[str]] = {}
+        cycle_validated = False
+        try:
+            cycle = _detect_alias_cycle(parsed)
+            cycle_validated = cycle is None
+        except (ValueError, RecursionError):
+            cycle_validated = False
         inlined: dict[str, Expr] = {}
         for name, expr in parsed.items():
             try:
-                inlined[name] = inline_aliases(expr, parsed)
+                inlined[name] = inline_aliases(
+                    expr,
+                    parsed,
+                    memo=memo,
+                    skip_cycle_check=cycle_validated,
+                )
             except (ValueError, RecursionError):
                 inlined[name] = expr
         return inlined
@@ -1190,6 +1206,18 @@ def _build_equations_ir(
     try:
         if needed > old_limit:
             sys.setrecursionlimit(needed)
+        # Share one free_symbols memo across every equation and validate the
+        # alias cycle once: alias bodies are reused by identity, so id-keyed
+        # caching turns the per-equation inline cost from O(alias_size) into
+        # O(equation_size) after the first call warms the memo.
+        memo: dict[int, frozenset[str]] = {}
+        cycle_validated = False
+        if aliases_ir:
+            try:
+                cycle = _detect_alias_cycle(aliases_ir)
+                cycle_validated = cycle is None
+            except (ValueError, RecursionError):
+                cycle_validated = False
         out: list[Expr | None] = []
         for eq in equations:
             try:
@@ -1201,7 +1229,14 @@ def _build_equations_ir(
                 out.append(expr)
                 continue
             try:
-                out.append(inline_aliases(expr, aliases_ir))
+                out.append(
+                    inline_aliases(
+                        expr,
+                        aliases_ir,
+                        memo=memo,
+                        skip_cycle_check=cycle_validated,
+                    )
+                )
             except (ValueError, RecursionError):
                 out.append(expr)
         return tuple(out)


### PR DESCRIPTION
Investigation of a hanging test (`test_long_add_chain_does_not_raise_recursionerror`, ~260s) revealed that `_build_equations_ir` re-walks the (already string-expanded) `S_scaled` alias body once per equation when inlining IR. With 5000 templated equations and a ~2500-node alias body, this dominated the entire test suite.

### Root cause
The string layer pre-expands `apply_along(...)` aliases into thousands of `Add` arguments before IR parsing. `_build_equations_ir(eqs, aliases_ir)` then calls `inline_aliases` per equation, and each call:
1. Re-ran `_detect_alias_cycle` on the alias graph,
2. Walked the small equation with `free_symbols`,
3. Substituted the giant alias body into a Sym leaf,
4. Re-walked the now-giant equation with `free_symbols` to find converging `live` set.

Step 4 was O(alias_body_size) per equation \u2192 ~50M recursive `free_symbols` calls during normalize.

### Fix
- `_ir.free_symbols` and `_ir.substitute` accept an identity-keyed memo (`dict[int, frozenset[str]]`) so callers sharing alias bodies amortize per-subtree cost. `substitute` also short-circuits subtrees with no relevant free symbols in O(1).
- `inline_aliases` precomputes per-alias-body alias references once and tracks the live set incrementally across iterations \u2014 no second `free_symbols` walk needed after each substitution. New `memo=` and `skip_cycle_check=` kwargs let batched callers reuse work.
- `_build_aliases_ir` and `_build_equations_ir` validate the alias graph once and share one memo across all per-alias / per-equation inline calls.

### Effect
- `test_long_add_chain_does_not_raise_recursionerror`: **~260s \u2192 ~1.7s**
- Full pytest suite: **~88s \u2192 ~4.6s**

All 321 tests still pass; `just ci` green.

Refs #112