### PR TITLE
feat(#112): make CompiledRhs picklable via NormalizedRhs rehydration

### DIFF
--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -199,12 +199,31 @@ class EvalFn(Protocol):
 
 @dataclass(frozen=True, slots=True)
 class CompiledRhs:
-    """Container for a compiled RHS evaluation function."""
+    """Container for a compiled RHS evaluation function.
+
+    Instances produced by :func:`compile_rhs` retain a private reference to
+    their source :class:`NormalizedRhs` so the container can be pickled and
+    re-hydrated by re-running the compile pipeline on load. ``eval_fn``
+    itself is a closure (and on the vectorized path captures compiled code
+    objects), so it is dropped from the pickle and rebuilt by
+    :func:`compile_rhs` in :meth:`__setstate__`. Round-tripping a
+    ``CompiledRhs`` therefore costs one compile on load and yields a
+    functionally equivalent instance whose ``eval_fn`` produces identical
+    outputs for identical inputs.
+    """
 
     state_names: tuple[str, ...]
     param_names: tuple[str, ...]
     eval_fn: EvalFn
     meta: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+    # Private: source spec retained for pickling. ``compile_rhs`` populates
+    # this; direct constructions without ``_rhs`` are not picklable (the
+    # ``eval_fn`` closure cannot be serialized) and will raise from
+    # ``__getstate__``. Excluded from equality and repr so it doesn't leak
+    # into the public surface.
+    _rhs: NormalizedRhs | None = field(
+        default=None, repr=False, compare=False, hash=False
+    )
 
     def bind(
         self, params: Mapping[str, object]
@@ -223,6 +242,39 @@ class CompiledRhs:
             return self.eval_fn(t, y, **params_dict)
 
         return rhs
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Return picklable state.
+
+        The compiled ``eval_fn`` is a closure (and on the vectorized path
+        captures compiled :class:`types.CodeType` objects), which is not
+        portably picklable. Instead we serialize just the source
+        :class:`NormalizedRhs` and let :meth:`__setstate__` recompile.
+
+        Raises:
+            TypeError: If the source ``NormalizedRhs`` was not retained
+                (i.e. the instance was constructed directly rather than
+                via :func:`compile_rhs`).
+        """
+        if self._rhs is None:
+            msg = (
+                "CompiledRhs is not picklable: the source NormalizedRhs was "
+                "not retained. Construct via compile_rhs() to produce a "
+                "picklable CompiledRhs."
+            )
+            raise TypeError(msg)
+        return {"_rhs": self._rhs}
+
+    def __setstate__(self, state: Mapping[str, Any]) -> None:
+        """Restore by recompiling from the pickled :class:`NormalizedRhs`."""
+        rhs = state["_rhs"]
+        rebuilt = compile_rhs(rhs)
+        # frozen+slots dataclass: bypass __setattr__ via object.__setattr__
+        object.__setattr__(self, "state_names", rebuilt.state_names)
+        object.__setattr__(self, "param_names", rebuilt.param_names)
+        object.__setattr__(self, "eval_fn", rebuilt.eval_fn)
+        object.__setattr__(self, "meta", rebuilt.meta)
+        object.__setattr__(self, "_rhs", rhs)
 
 
 # -----------------------------------------------------------------------------
@@ -813,4 +865,5 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
         param_names=tuple(rhs.param_names),
         eval_fn=eval_fn,
         meta=rhs.meta,
+        _rhs=rhs,
     )

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -19,6 +19,7 @@ Note:
 
 from __future__ import annotations
 
+import pickle  # noqa: S403
 import re
 from dataclasses import replace
 
@@ -593,3 +594,61 @@ def test_compile_rhs_traces_through_blackjax_nuts() -> None:
 
     next_state, _info = jax.jit(nuts.step)(key, state)
     assert np.isfinite(float(next_state.logdensity))
+
+
+# -----------------------------------------------------------------------------
+# Pickling round-trip
+# -----------------------------------------------------------------------------
+
+
+def test_compiledrhs_pickle_roundtrip_scalar_path(
+    compiled_xy: CompiledRhs,
+) -> None:
+    """A CompiledRhs from the scalar path round-trips through pickle."""
+    blob = pickle.dumps(compiled_xy)
+    restored = pickle.loads(blob)  # noqa: S301
+
+    assert isinstance(restored, CompiledRhs)
+    assert restored.state_names == compiled_xy.state_names
+    assert restored.param_names == compiled_xy.param_names
+
+    y = np.array([2.0, 3.0], dtype=np.float64)
+    expected = compiled_xy.eval_fn(np.float64(0.0), y, a=2.0, b=1.0)
+    got = restored.eval_fn(np.float64(0.0), y, a=2.0, b=1.0)
+    assert np.allclose(got, expected)
+
+
+def test_compiledrhs_pickle_roundtrip_vectorized_path() -> None:
+    """A CompiledRhs from the vectorized path round-trips through pickle."""
+    spec = {
+        "kind": "expr",
+        "axes": [{"name": "age", "coords": ["y", "o"]}],
+        "state": ["S[age]", "I[age]"],
+        "param": ["beta", "gamma"],
+        "equations": {
+            "S[age]": "-beta * S[age] * I[age]",
+            "I[age]": "beta * S[age] * I[age] - gamma * I[age]",
+        },
+    }
+    cr = compile_rhs(normalize_rhs(spec))
+    blob = pickle.dumps(cr)
+    restored = pickle.loads(blob)  # noqa: S301
+
+    assert restored.state_names == cr.state_names
+    y = np.array([99.0, 99.0, 1.0, 1.0], dtype=np.float64)
+    expected = cr.eval_fn(0.0, y, beta=0.3, gamma=0.1)
+    got = restored.eval_fn(0.0, y, beta=0.3, gamma=0.1)
+    assert np.allclose(got, expected)
+
+
+def test_compiledrhs_pickle_rejects_direct_construction(
+    rhs_xy: NormalizedRhs,
+) -> None:
+    """A CompiledRhs built without ``_rhs`` raises a clear error on pickle."""
+    cr = compile_rhs(rhs_xy)
+    # Drop the retained source via dataclasses.replace and re-attach the
+    # original eval_fn so the instance is still callable but no longer
+    # carries a recipe for rebuilding itself.
+    stripped = replace(cr, _rhs=None)
+    with pytest.raises(TypeError, match=r"not picklable"):
+        pickle.dumps(stripped)


### PR DESCRIPTION
## Summary

Adds `__getstate__` / `__setstate__` to `CompiledRhs` so it round-trips through `pickle` (and any caching layer built on it). The `eval_fn` closure — which on the vectorized path also captures non-portable `types.CodeType` objects — is dropped from the pickle; we serialize only the source `NormalizedRhs` and rebuild by re-running `compile_rhs(rhs)` on load.

`compile_rhs` now retains the source rhs on a new private `_rhs` field (`compare=False, repr=False, hash=False`) so any `CompiledRhs` produced via the public API is picklable. Direct constructions without `_rhs` raise a clear `TypeError` pointing to `compile_rhs()`.

## Why

- Closes one acceptance criterion of the #112 IR tracking issue ("cache + pickle CompiledRhs").
- Closes the serializability ask in #30 ("Make helpers serializable so CompiledRhs can be cached/pickled").
- Unblocks downstream caching: a CompiledRhs can now be stashed alongside (or even keyed by) the YAML hash of its source spec.

## Cost model

Pickle: one extra reference to the (already picklable) `NormalizedRhs`, no compile time.
Unpickle: one `compile_rhs` invocation — same cost as the original compile. Round-tripped instance is functionally equivalent (asserted in tests via numeric equality on both scalar and vectorized paths).

## Tests

`tests/op_system/test_op_system_compile.py`:
- `test_compiledrhs_pickle_roundtrip_scalar_path` — scalar 2-state spec.
- `test_compiledrhs_pickle_roundtrip_vectorized_path` — templated spec that hits the vectorized plan + CodeType capture path.
- `test_compiledrhs_pickle_rejects_direct_construction` — clear error when `_rhs` is absent.

All 324 tests pass, `just ci` green.

Refs #112, #30