### PR TITLE
feat(#112): IR-to-vector-AST lowering foundation

### DIFF
--- a/src/op_system/_ir_lower.py
+++ b/src/op_system/_ir_lower.py
@@ -1,0 +1,336 @@
+"""op_system._ir_lower.
+
+Lower typed IR expressions to vectorized Python AST nodes.
+
+This module is the foundation for migrating ``_vectorize`` off the per-cell
+AST-rewriting pipeline. It produces buffer-access expressions directly from
+the typed IR — skipping per-cell scalar-name expansion entirely — for the
+subset of expressions where every templated reference is in pure wildcard
+form (e.g. ``S[age, vax]`` rather than ``S[age=ap, vax=unvac]``).
+
+v1 scope (intentionally narrow; callers fall back on
+:class:`UnsupportedIRLowering`):
+
+- Expressions composed of :class:`Literal`, :class:`Sym`, arithmetic /
+  unary / comparison :class:`Apply` nodes, and :class:`Subscript`
+  references to declared templated buffers.
+- Every :class:`Subscript` must reference a known templated buffer name
+  and use only FREE-axis indices (no coord literals, no placeholders, no
+  COORD_SYMBOL bindings). The subscript's axis set must equal the
+  buffer's declared axes (in any order) and be a subset of
+  ``target_axes``.
+- :class:`Reduce` nodes, function-call ``Apply`` nodes whose ``op`` isn't
+  a recognized arithmetic/comparison operator, and any unsupported
+  subscript shape raise :class:`UnsupportedIRLowering`.
+
+Wiring this into the main vectorize path is left to a follow-up PR; this
+module exists so the lowering can be developed and tested in isolation.
+"""
+
+from __future__ import annotations
+
+import ast
+from typing import TYPE_CHECKING
+
+from op_system._ir import (
+    Apply,
+    AxisKind,
+    Expr,
+    Literal,
+    Reduce,
+    Subscript,
+    Sym,
+    classify_axis_index,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+__all__ = [
+    "UnsupportedIRLoweringError",
+    "lower_subscript_to_buffer",
+    "lower_to_vector_ast",
+]
+
+
+class UnsupportedIRLoweringError(NotImplementedError):
+    """Raised when an IR expression falls outside the v1 lowering subset.
+
+    Callers should catch this and fall back to the existing per-cell AST
+    rewriting path. The detail message identifies the offending node.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Operator tables (kept local; mirrored from _ir.ir_to_ast_expr)
+# ---------------------------------------------------------------------------
+
+_BINOP: dict[str, type[ast.operator]] = {
+    "+": ast.Add,
+    "-": ast.Sub,
+    "*": ast.Mult,
+    "/": ast.Div,
+    "%": ast.Mod,
+    "pow": ast.Pow,
+}
+
+_CMPOP: dict[str, type[ast.cmpop]] = {
+    "==": ast.Eq,
+    "!=": ast.NotEq,
+    "<": ast.Lt,
+    "<=": ast.LtE,
+    ">": ast.Gt,
+    ">=": ast.GtE,
+}
+
+
+def _name(ident: str) -> ast.Name:
+    return ast.Name(id=ident, ctx=ast.Load())
+
+
+# ---------------------------------------------------------------------------
+# Subscript lowering
+# ---------------------------------------------------------------------------
+
+
+def lower_subscript_to_buffer(  # noqa: C901
+    sub: Subscript,
+    *,
+    src_axes: tuple[str, ...],
+    target_axes: tuple[str, ...],
+    axis_names: frozenset[str],
+) -> ast.expr:
+    """Lower a wildcard IR :class:`Subscript` to a buffer-access AST.
+
+    The returned AST evaluates to an array that broadcasts cleanly against
+    a tensor of shape implied by ``target_axes`` — i.e. it carries a
+    singleton (``None``) dimension for every axis in ``target_axes`` not
+    present in the subscript and is transposed so kept axes appear in
+    ``target_axes`` order.
+
+    Args:
+        sub: IR subscript to lower. Must have one :class:`AxisKind.FREE`
+            index per element, and its axis set must equal ``src_axes`` as
+            a set (any permutation accepted).
+        src_axes: Declared axis order of the source buffer
+            (the ordering used to flatten ``<name>_buf``).
+        target_axes: Axis order of the cell layout the result must
+            broadcast against.
+        axis_names: Registered axis identifiers; used to classify indices.
+
+    Returns:
+        An ``ast.expr`` accessing ``<sub.name>_buf`` with the necessary
+        transpose / size-1 insertions to align with ``target_axes``.
+
+    Raises:
+        UnsupportedIRLoweringError: If any index is non-FREE, the index axis
+            set doesn't match ``src_axes``, or ``src_axes`` is not a
+            subset of ``target_axes``.
+    """
+    if len(sub.indices) != len(src_axes):
+        msg = (
+            f"subscript {sub.name!r} has {len(sub.indices)} indices but "
+            f"buffer has {len(src_axes)} axes"
+        )
+        raise UnsupportedIRLoweringError(msg)
+
+    sub_axes: list[str] = []
+    for idx in sub.indices:
+        kind = idx.kind or classify_axis_index(idx, axis_names=axis_names)
+        if kind is not AxisKind.FREE:
+            msg = (
+                f"subscript {sub.name!r} has non-FREE index "
+                f"({kind.value}) — v1 lowering supports only wildcard "
+                "axis references"
+            )
+            raise UnsupportedIRLoweringError(msg)
+        sub_axes.append(idx.axis)
+
+    if set(sub_axes) != set(src_axes):
+        msg = (
+            f"subscript {sub.name!r} axes {tuple(sub_axes)} do not match "
+            f"buffer axes {tuple(src_axes)} as a set"
+        )
+        raise UnsupportedIRLoweringError(msg)
+
+    if not set(src_axes).issubset(target_axes):
+        msg = (
+            f"buffer axes {tuple(src_axes)} not a subset of target axes "
+            f"{tuple(target_axes)}"
+        )
+        raise UnsupportedIRLoweringError(msg)
+
+    buf: ast.expr = _name(f"{sub.name}_buf")
+
+    # Reorder buffer (stored in src_axes order) to sub_axes order if the
+    # user wrote them out of declaration order (e.g. ``S[vax, age]``
+    # against ``src_axes=(age, vax)``).
+    if tuple(sub_axes) != tuple(src_axes):
+        perm = tuple(src_axes.index(a) for a in sub_axes)
+        buf = _transpose(buf, perm)
+
+    # If sub_axes already cover target_axes in matching order, no further
+    # alignment is needed.
+    if tuple(sub_axes) == tuple(target_axes):
+        return buf
+
+    # Reorder sub_axes to match the order they appear in target_axes
+    # before inserting singleton dimensions.
+    target_kept = tuple(a for a in target_axes if a in sub_axes)
+    if tuple(sub_axes) != target_kept:
+        perm = tuple(sub_axes.index(a) for a in target_kept)
+        buf = _transpose(buf, perm)
+
+    if tuple(target_kept) == tuple(target_axes):
+        return buf
+
+    # Insert ``None`` placeholders for target axes not present.
+    elts: list[ast.expr] = []
+    for ax in target_axes:
+        if ax in target_kept:
+            elts.append(ast.Slice(lower=None, upper=None, step=None))
+        else:
+            elts.append(ast.Constant(value=None))
+    return ast.Subscript(
+        value=buf,
+        slice=ast.Tuple(elts=elts, ctx=ast.Load()),
+        ctx=ast.Load(),
+    )
+
+
+def _transpose(node: ast.expr, perm: tuple[int, ...]) -> ast.expr:
+    return ast.Call(
+        func=ast.Attribute(value=_name("np"), attr="transpose", ctx=ast.Load()),
+        args=[
+            node,
+            ast.Tuple(elts=[ast.Constant(value=p) for p in perm], ctx=ast.Load()),
+        ],
+        keywords=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Full expression lowering
+# ---------------------------------------------------------------------------
+
+
+def lower_to_vector_ast(
+    expr: Expr,
+    *,
+    target_axes: tuple[str, ...],
+    buffer_axes: Mapping[str, tuple[str, ...]],
+    axis_names: frozenset[str],
+) -> ast.expr:
+    """Lower an IR expression to a vector-shape AST.
+
+    Walks ``expr`` and produces an :class:`ast.expr` whose value is shaped
+    to broadcast against a tensor with axes ``target_axes``.
+
+    Args:
+        expr: Typed IR expression to lower. Must satisfy the v1 subset
+            described in the module docstring.
+        target_axes: Axis order of the cell layout the result must
+            broadcast against. Use ``()`` for a scalar result.
+        buffer_axes: Mapping from templated-buffer name (state or alias)
+            to the buffer's declared axis order. Names not in this
+            mapping are treated as scalar (``ast.Name``) leaves.
+        axis_names: Registered axis identifier set; passed through to
+            :func:`lower_subscript_to_buffer` for index classification.
+
+    Returns:
+        An ``ast.expr`` suitable for ``compile(ast.Expression(body=...))``
+        once enclosed and ``ast.fix_missing_locations``-ed by the caller.
+
+    Raises:
+        UnsupportedIRLoweringError: If ``expr`` (or any subexpression)
+            contains a node outside the v1 subset.
+    """
+    if isinstance(expr, Literal):
+        return ast.Constant(value=expr.value)
+
+    if isinstance(expr, Sym):
+        return _name(expr.name)
+
+    if isinstance(expr, Subscript):
+        src_axes = buffer_axes.get(expr.name)
+        if src_axes is None:
+            msg = (
+                f"subscript {expr.name!r} is not a registered templated "
+                "buffer — v1 lowering cannot resolve it"
+            )
+            raise UnsupportedIRLoweringError(msg)
+        return lower_subscript_to_buffer(
+            expr,
+            src_axes=src_axes,
+            target_axes=target_axes,
+            axis_names=axis_names,
+        )
+
+    if isinstance(expr, Apply):
+        return _lower_apply(
+            expr,
+            target_axes=target_axes,
+            buffer_axes=buffer_axes,
+            axis_names=axis_names,
+        )
+
+    if isinstance(expr, Reduce):
+        msg = (
+            f"Reduce({expr.kind!r}) nodes are not supported by v1 "
+            "lowering; expand helpers before invoking the lowering"
+        )
+        raise UnsupportedIRLoweringError(msg)
+
+    msg = f"unsupported IR node for v1 lowering: {type(expr).__name__}"
+    raise UnsupportedIRLoweringError(msg)
+
+
+def _lower_apply(
+    expr: Apply,
+    *,
+    target_axes: tuple[str, ...],
+    buffer_axes: Mapping[str, tuple[str, ...]],
+    axis_names: frozenset[str],
+) -> ast.expr:
+    def lower(child: Expr) -> ast.expr:
+        return lower_to_vector_ast(
+            child,
+            target_axes=target_axes,
+            buffer_axes=buffer_axes,
+            axis_names=axis_names,
+        )
+
+    if expr.op == "neg" and len(expr.args) == 1:
+        return ast.UnaryOp(op=ast.USub(), operand=lower(expr.args[0]))
+    if expr.op == "pos" and len(expr.args) == 1:
+        return ast.UnaryOp(op=ast.UAdd(), operand=lower(expr.args[0]))
+
+    if expr.op in _BINOP and len(expr.args) == 2:
+        return ast.BinOp(
+            left=lower(expr.args[0]),
+            op=_BINOP[expr.op](),
+            right=lower(expr.args[1]),
+        )
+    if expr.op in _CMPOP and len(expr.args) == 2:
+        return ast.Compare(
+            left=lower(expr.args[0]),
+            ops=[_CMPOP[expr.op]()],
+            comparators=[lower(expr.args[1])],
+        )
+    if expr.op in {"and", "or"}:
+        bool_op: ast.boolop = ast.And() if expr.op == "and" else ast.Or()
+        return ast.BoolOp(op=bool_op, values=[lower(a) for a in expr.args])
+    if expr.op == "ifelse" and len(expr.args) == 3:
+        return ast.IfExp(
+            test=lower(expr.args[0]),
+            body=lower(expr.args[1]),
+            orelse=lower(expr.args[2]),
+        )
+
+    msg = (
+        f"Apply op {expr.op!r} (arity {len(expr.args)}) is outside the "
+        "v1 lowering subset — only arithmetic, comparison, boolean, and "
+        "ifelse operators are supported"
+    )
+    raise UnsupportedIRLoweringError(msg)

--- a/tests/op_system/test_op_system_ir_lower.py
+++ b/tests/op_system/test_op_system_ir_lower.py
@@ -1,0 +1,277 @@
+"""Tests for the IR → vector AST lowering (issue #112)."""
+
+from __future__ import annotations
+
+import ast
+import math
+from typing import Any
+
+import numpy as np
+import pytest
+
+from op_system._ir import (
+    AxisIndex,
+    AxisKind,
+    Literal,
+    Reduce,
+    Subscript,
+    Sym,
+    parse_expr_to_ir,
+    resolve_axis_kinds,
+)
+from op_system._ir_lower import (
+    UnsupportedIRLoweringError,
+    lower_subscript_to_buffer,
+    lower_to_vector_ast,
+)
+
+
+def _eval(expr: ast.expr, env: dict[str, Any]) -> Any:  # noqa: ANN401
+    tree = ast.Expression(body=expr)
+    ast.fix_missing_locations(tree)
+    code = compile(tree, "<test>", "eval")
+    return eval(code, {"__builtins__": {}}, env)  # noqa: S307
+
+
+def _make_subscript(name: str, axes: tuple[str, ...]) -> Subscript:
+    return Subscript(
+        name=name,
+        indices=tuple(AxisIndex(axis=a, kind=AxisKind.FREE) for a in axes),
+    )
+
+
+# ---------------------------------------------------------------------------
+# lower_subscript_to_buffer
+# ---------------------------------------------------------------------------
+
+
+def test_lower_subscript_identity_when_axes_match_target() -> None:
+    """Wildcard subscript matching target axes returns the bare buffer name."""
+    sub = _make_subscript("S", ("age", "vax"))
+    node = lower_subscript_to_buffer(
+        sub,
+        src_axes=("age", "vax"),
+        target_axes=("age", "vax"),
+        axis_names=frozenset({"age", "vax"}),
+    )
+    s_buf = np.arange(6).reshape(3, 2)
+    assert np.array_equal(_eval(node, {"S_buf": s_buf, "np": np}), s_buf)
+
+
+def test_lower_subscript_transposes_when_user_reorders_axes() -> None:
+    """Subscript axes in non-declaration order trigger a transpose."""
+    sub = _make_subscript("S", ("vax", "age"))
+    node = lower_subscript_to_buffer(
+        sub,
+        src_axes=("age", "vax"),
+        target_axes=("vax", "age"),
+        axis_names=frozenset({"age", "vax"}),
+    )
+    s_buf = np.arange(6).reshape(3, 2)
+    got = _eval(node, {"S_buf": s_buf, "np": np})
+    assert np.array_equal(got, s_buf.T)
+
+
+def test_lower_subscript_broadcasts_missing_target_axis() -> None:
+    """Target axis not in subscript becomes a singleton (``None``) dim."""
+    sub = _make_subscript("p", ("age",))
+    node = lower_subscript_to_buffer(
+        sub,
+        src_axes=("age",),
+        target_axes=("age", "vax"),
+        axis_names=frozenset({"age", "vax"}),
+    )
+    p_buf = np.array([1.0, 2.0, 3.0])
+    got = _eval(node, {"p_buf": p_buf, "np": np})
+    assert got.shape == (3, 1)
+    assert np.array_equal(got[:, 0], p_buf)
+
+
+def test_lower_subscript_rejects_coord_literal() -> None:
+    """Coord indices are out of scope for v1 and raise."""
+    sub = Subscript(
+        name="S",
+        indices=(
+            AxisIndex(axis="age", kind=AxisKind.FREE),
+            AxisIndex(axis="vax", coord="unvac", kind=AxisKind.COORD),
+        ),
+    )
+    with pytest.raises(UnsupportedIRLoweringError, match="non-FREE"):
+        lower_subscript_to_buffer(
+            sub,
+            src_axes=("age", "vax"),
+            target_axes=("age", "vax"),
+            axis_names=frozenset({"age", "vax"}),
+        )
+
+
+def test_lower_subscript_rejects_arity_mismatch() -> None:
+    """A subscript whose index count differs from buffer axes raises."""
+    sub = _make_subscript("S", ("age",))
+    with pytest.raises(UnsupportedIRLoweringError, match="indices"):
+        lower_subscript_to_buffer(
+            sub,
+            src_axes=("age", "vax"),
+            target_axes=("age", "vax"),
+            axis_names=frozenset({"age", "vax"}),
+        )
+
+
+def test_lower_subscript_rejects_axes_not_subset_of_target() -> None:
+    """If the buffer has an axis not in target_axes, lowering fails."""
+    sub = _make_subscript("S", ("age", "vax"))
+    with pytest.raises(UnsupportedIRLoweringError, match="subset"):
+        lower_subscript_to_buffer(
+            sub,
+            src_axes=("age", "vax"),
+            target_axes=("age",),
+            axis_names=frozenset({"age", "vax"}),
+        )
+
+
+# ---------------------------------------------------------------------------
+# lower_to_vector_ast
+# ---------------------------------------------------------------------------
+
+
+def test_lower_to_vector_ast_scalar_arithmetic() -> None:
+    """Pure arithmetic over scalars lowers and evaluates as expected."""
+    ir = parse_expr_to_ir("beta * 2.0 - gamma")
+    node = lower_to_vector_ast(
+        ir,
+        target_axes=(),
+        buffer_axes={},
+        axis_names=frozenset(),
+    )
+    env = {"beta": 0.3, "gamma": 0.1}
+    assert _eval(node, env) == pytest.approx(0.3 * 2.0 - 0.1)
+
+
+def test_lower_to_vector_ast_mixes_scalar_and_buffer() -> None:
+    """A scalar param multiplied by a templated state buffer broadcasts."""
+    ir = resolve_axis_kinds(
+        parse_expr_to_ir("beta * S[age, vax]"),
+        axis_names=frozenset({"age", "vax"}),
+    )
+    node = lower_to_vector_ast(
+        ir,
+        target_axes=("age", "vax"),
+        buffer_axes={"S": ("age", "vax")},
+        axis_names=frozenset({"age", "vax"}),
+    )
+    s_buf = np.arange(6, dtype=float).reshape(3, 2)
+    got = _eval(node, {"beta": 0.5, "S_buf": s_buf, "np": np})
+    assert np.array_equal(got, 0.5 * s_buf)
+
+
+def test_lower_to_vector_ast_unary_negation() -> None:
+    """Unary minus lowers to ``ast.USub``."""
+    ir = parse_expr_to_ir("-x")
+    node = lower_to_vector_ast(
+        ir,
+        target_axes=(),
+        buffer_axes={},
+        axis_names=frozenset(),
+    )
+    assert _eval(node, {"x": 4.5}) == pytest.approx(-4.5)
+
+
+def test_lower_to_vector_ast_comparison_and_ifelse() -> None:
+    """Comparison and conditional expressions lower correctly."""
+    ir = parse_expr_to_ir("a if a > b else b")
+    node = lower_to_vector_ast(
+        ir,
+        target_axes=(),
+        buffer_axes={},
+        axis_names=frozenset(),
+    )
+    assert _eval(node, {"a": 3, "b": 7}) == 7
+    assert _eval(node, {"a": 9, "b": 7}) == 9
+
+
+def test_lower_to_vector_ast_rejects_reduce_node() -> None:
+    """``Reduce`` nodes are out of scope for v1 lowering."""
+    expr = Reduce(
+        kind="sum_over",
+        bindings=(("age", "a"),),
+        body=Sym(name="x"),
+    )
+    with pytest.raises(UnsupportedIRLoweringError, match="Reduce"):
+        lower_to_vector_ast(
+            expr,
+            target_axes=(),
+            buffer_axes={},
+            axis_names=frozenset({"age"}),
+        )
+
+
+def test_lower_to_vector_ast_rejects_function_call() -> None:
+    """Generic function-call ``Apply`` nodes raise (only operators in v1)."""
+    ir = parse_expr_to_ir("np.exp(x)")
+    with pytest.raises(UnsupportedIRLoweringError, match=r"np\.exp"):
+        lower_to_vector_ast(
+            ir,
+            target_axes=(),
+            buffer_axes={},
+            axis_names=frozenset(),
+        )
+
+
+def test_lower_to_vector_ast_rejects_unregistered_subscript() -> None:
+    """A subscript whose name isn't a registered buffer raises."""
+    ir = parse_expr_to_ir("K[age]")
+    ir = resolve_axis_kinds(ir, axis_names=frozenset({"age"}))
+    with pytest.raises(UnsupportedIRLoweringError, match="not a registered"):
+        lower_to_vector_ast(
+            ir,
+            target_axes=("age",),
+            buffer_axes={},
+            axis_names=frozenset({"age"}),
+        )
+
+
+def test_lower_to_vector_ast_literal_passthrough() -> None:
+    """Literals lower to ``ast.Constant`` and evaluate to themselves."""
+    node = lower_to_vector_ast(
+        Literal(value=math.pi),
+        target_axes=(),
+        buffer_axes={},
+        axis_names=frozenset(),
+    )
+    assert _eval(node, {}) == pytest.approx(math.pi)
+
+
+def test_lower_to_vector_ast_two_templated_buffers_broadcast() -> None:
+    """Two templated buffers over a subset of target axes broadcast correctly."""
+    ir = resolve_axis_kinds(
+        parse_expr_to_ir("S[age] * p[vax]"),
+        axis_names=frozenset({"age", "vax"}),
+    )
+    node = lower_to_vector_ast(
+        ir,
+        target_axes=("age", "vax"),
+        buffer_axes={"S": ("age",), "p": ("vax",)},
+        axis_names=frozenset({"age", "vax"}),
+    )
+    s_buf = np.array([1.0, 2.0, 3.0])
+    p_buf = np.array([10.0, 20.0])
+    got = _eval(node, {"S_buf": s_buf, "p_buf": p_buf, "np": np})
+    assert got.shape == (3, 2)
+    expected = np.outer(s_buf, p_buf)
+    assert np.array_equal(got, expected)
+
+
+def test_lower_subscript_resolves_axis_kinds_when_unset() -> None:
+    """When ``AxisIndex.kind`` is unset, the lowering classifies on the fly."""
+    sub = Subscript(
+        name="S",
+        indices=(AxisIndex(axis="age"), AxisIndex(axis="vax")),
+    )
+    node = lower_subscript_to_buffer(
+        sub,
+        src_axes=("age", "vax"),
+        target_axes=("age", "vax"),
+        axis_names=frozenset({"age", "vax"}),
+    )
+    s_buf = np.arange(6).reshape(3, 2)
+    assert np.array_equal(_eval(node, {"S_buf": s_buf, "np": np}), s_buf)


### PR DESCRIPTION
## Summary

Adds a new internal `_ir_lower` module that lowers typed IR expressions directly into a vector-shape `ast.expr` suitable for evaluation against pre-extracted state/alias buffers. This is the first slice of the IR-based vectorization path that will eventually replace the per-cell string-expansion + `_NameRewriter` pipeline in `_vectorize.py`.

Refs #112.

## What's new

Public API of `op_system._ir_lower`:

- **`UnsupportedIRLoweringError`** (subclass of `NotImplementedError`) — signals any IR node outside the v1 lowering subset, so callers can fall back to the existing pipeline.
- **`lower_subscript_to_buffer(sub, *, src_axes, target_axes, axis_names)`** — lowers a wildcard `Subscript` (all FREE axis indices) to a `<name>_buf` access, inserting `np.transpose` and `None` broadcast slots so the result aligns with the requested `target_axes` layout.
- **`lower_to_vector_ast(expr, *, target_axes, buffer_axes, axis_names)`** — recursively lowers `Literal`, `Sym`, `Subscript`, and `Apply` nodes covering arithmetic, comparison, boolean, and `ifelse` operators.

## v1 scope

Intentionally narrow so each shape can be migrated incrementally:

- Scalar-state / wildcard-only subscripts (every `AxisIndex.kind` is `FREE`).
- Operator-only `Apply` nodes (unary `neg`/`pos`, binary `+ - * / % **`, comparisons, `and`/`or`, ternary `ifelse`).
- **No** `Reduce`, **no** shaped-parameter coord literals, **no** function calls (`np.exp`, etc.).

Anything else raises `UnsupportedIRLoweringError` so the existing vectorizer stays the source of truth until each shape is migrated.

## Wiring

The module is **purely additive** — `_vectorize.py` is unchanged and does not yet import it. Follow-up PRs will wire `lower_to_vector_ast` into the simplest vectorization paths first (scalar-state, no `apply_along`) with `UnsupportedIRLoweringError` as the fallback signal.

## Tests

16 new cases in `tests/op_system/test_op_system_ir_lower.py`:

- Subscript lowering: identity, axis transpose, missing-axis broadcast, unset-`kind` classification.
- Subscript rejection: coord literal, arity mismatch, non-subset `src_axes`.
- Expression lowering: scalar arithmetic, mixed buffer × scalar, unary, comparison + `ifelse`, `Literal` passthrough, two-buffer outer-product broadcast.
- Expression rejection: `Reduce`, function-call `Apply`, unregistered subscript name.

Full suite: **340 passed**.
