### PR TITLE
feat(#112): wire IR lowering into _vectorize as fast path

### DIFF
--- a/src/op_system/_ir_lower.py
+++ b/src/op_system/_ir_lower.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING
 
 from op_system._ir import (
     Apply,
+    AxisIndex,
     AxisKind,
     Expr,
     Literal,
@@ -41,6 +42,8 @@ from op_system._ir import (
     Subscript,
     Sym,
     classify_axis_index,
+    substitute,
+    walk,
 )
 
 if TYPE_CHECKING:
@@ -49,6 +52,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "UnsupportedIRLoweringError",
+    "lift_cell_ir_to_template",
     "lower_subscript_to_buffer",
     "lower_to_vector_ast",
 ]
@@ -334,3 +338,90 @@ def _lower_apply(
         "ifelse operators are supported"
     )
     raise UnsupportedIRLoweringError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Per-cell → template-form lift
+# ---------------------------------------------------------------------------
+
+
+def lift_cell_ir_to_template(
+    expr: Expr,
+    *,
+    cell_to_template: Mapping[str, tuple[str, tuple[str, ...]]],
+) -> Expr:
+    """Lift per-cell IR to template-form IR.
+
+    The normalizer expands templated states/aliases/params into per-cell
+    scalar names (e.g. ``S__age_y__loc_a``) before parsing into IR, so the
+    resulting :class:`Sym` leaves carry expanded names rather than
+    :class:`Subscript` nodes against base buffers. This function walks
+    ``expr`` and rewrites each ``Sym(name)`` whose ``name`` appears in
+    ``cell_to_template`` (with non-empty axes) into a wildcard
+    :class:`Subscript` against the buffer's base name, suitable as input to
+    :func:`lower_to_vector_ast`.
+
+    Symbols not in ``cell_to_template`` — scalar parameters or unbound
+    names — are left unchanged. Mappings whose template has ``axes == ()``
+    (e.g. scalar aliases) rewrite the symbol to a bare ``Sym(f"{base}_buf")``
+    leaf so the result evaluates against the runtime's ``<base>_buf``
+    binding.
+
+    Args:
+        expr: Per-cell IR expression (typically from
+            ``NormalizedRhs.equations_ir_raw`` or
+            ``NormalizedRhs.aliases_ir``).
+        cell_to_template: Mapping from expanded per-cell name to a
+            ``(base_name, axes)`` pair describing the buffer the cell
+            belongs to. Empty-axes entries are treated as scalar aliases
+            (rewritten to ``Sym(f"{base}_buf")``); non-empty entries are
+            rewritten to FREE-index :class:`Subscript` nodes.
+
+    Returns:
+        A new IR expression equivalent to ``expr`` but with all matched
+        cell-name :class:`Sym` leaves replaced — by FREE-index
+        :class:`Subscript` nodes (templated buffers) or scalar-buffer
+        :class:`Sym` leaves (scalar aliases).
+
+    Raises:
+        UnsupportedIRLoweringError: If two distinct per-cell symbols
+            sharing the same templated ``base`` co-occur in ``expr``
+            (signals a string-expanded axis reduction that cannot be
+            represented as a single FREE-axis subscript).
+    """
+    mapping: dict[str, Expr] = {}
+    for cell_name, (base, axes) in cell_to_template.items():
+        if not axes:
+            mapping[cell_name] = Sym(name=f"{base}_buf")
+            continue
+        mapping[cell_name] = Subscript(
+            name=base,
+            indices=tuple(AxisIndex(axis=ax, kind=AxisKind.FREE) for ax in axes),
+        )
+    if not mapping:
+        return expr
+    # Refuse the lift when multiple distinct per-cell symbols of the same
+    # templated buffer co-occur in ``expr``: that signals an axis reduction
+    # (e.g. ``apply_along`` or ``sum_over``) that the normalizer expanded
+    # to a per-cell sum at the string level. Collapsing those cells back to
+    # a single FREE-axis subscript would silently broadcast instead of
+    # reduce, producing wrong results.
+    seen_bases: dict[str, str] = {}
+    for node in walk(expr):
+        if not isinstance(node, Sym):
+            continue
+        entry = cell_to_template.get(node.name)
+        if entry is None or not entry[1]:
+            continue
+        base = entry[0]
+        prior = seen_bases.get(base)
+        if prior is None:
+            seen_bases[base] = node.name
+        elif prior != node.name:
+            msg = (
+                f"cannot lift per-cell IR for buffer {base!r}: multiple "
+                f"distinct cells co-occur ({prior!r} and {node.name!r}); "
+                "this signals a string-expanded axis reduction"
+            )
+            raise UnsupportedIRLoweringError(msg)
+    return substitute(expr, mapping)

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -35,6 +35,11 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 
 from op_system._ir import Expr, ir_to_ast_expr
+from op_system._ir_lower import (
+    UnsupportedIRLoweringError,
+    lift_cell_ir_to_template,
+    lower_to_vector_ast,
+)
 from op_system.compile import (
     _SAFE_BUILTINS,
     _check_numeric_dtype,
@@ -575,6 +580,55 @@ class _NameRewriter(ast.NodeTransformer):
         )
 
 
+def _try_ir_fast_path(
+    expr_ir: Expr,
+    *,
+    target_axes: tuple[str, ...],
+    name_to_template: Mapping[str, _BufferTemplate],
+    axis_index: Mapping[str, Mapping[str, int]],
+) -> ast.Expression | None:
+    """Attempt to lower per-cell IR straight to a vector AST.
+
+    Lifts ``expr_ir`` (per-cell scalar names) to template-form IR via
+    :func:`lift_cell_ir_to_template`, then runs the typed lowering in
+    :func:`lower_to_vector_ast`. On any v1-scope violation (raises
+    :class:`UnsupportedIRLoweringError`) returns ``None`` so the caller
+    falls back to the legacy :class:`_NameRewriter` path.
+
+    The fast path bypasses per-cell name expansion entirely: it produces
+    the same shaped buffer expression for every cell of a template, which
+    makes the downstream "first cell == last cell" structural check
+    trivially pass and lets the vectorizer emit a single compiled code
+    object for the whole template.
+
+    Returns:
+        A complete ``ast.Expression`` whose body broadcasts to
+        ``target_axes``, or ``None`` if the IR falls outside the v1
+        lowering subset.
+    """
+    cell_to_template: dict[str, tuple[str, tuple[str, ...]]] = {}
+    buffer_axes: dict[str, tuple[str, ...]] = {}
+    for cell_name, tpl in name_to_template.items():
+        cell_to_template[cell_name] = (tpl.base, tpl.axes)
+        if tpl.axes:
+            buffer_axes[tpl.base] = tpl.axes
+    if not buffer_axes:
+        return None
+    try:
+        lifted = lift_cell_ir_to_template(expr_ir, cell_to_template=cell_to_template)
+        body = lower_to_vector_ast(
+            lifted,
+            target_axes=target_axes,
+            buffer_axes=buffer_axes,
+            axis_names=frozenset(axis_index.keys()),
+        )
+    except UnsupportedIRLoweringError:
+        return None
+    tree = ast.Expression(body=body)
+    ast.fix_missing_locations(tree)
+    return tree
+
+
 def _rewrite_cell_to_vector(  # noqa: PLR0913
     *,
     expr: str,
@@ -599,6 +653,15 @@ def _rewrite_cell_to_vector(  # noqa: PLR0913
     )
     ast.fix_missing_locations(tree)
     _validate_ast(tree, expr=expr)
+    if expr_ir is not None:
+        fast = _try_ir_fast_path(
+            expr_ir,
+            target_axes=target_axes,
+            name_to_template=name_to_template,
+            axis_index=axis_index,
+        )
+        if fast is not None:
+            return fast
     rewriter = _NameRewriter(
         target_axes=target_axes,
         cell_coords=cell_coords,

--- a/tests/op_system/test_op_system_ir_lower.py
+++ b/tests/op_system/test_op_system_ir_lower.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from op_system._ir import (
+    Apply,
     AxisIndex,
     AxisKind,
     Literal,
@@ -21,6 +22,7 @@ from op_system._ir import (
 )
 from op_system._ir_lower import (
     UnsupportedIRLoweringError,
+    lift_cell_ir_to_template,
     lower_subscript_to_buffer,
     lower_to_vector_ast,
 )
@@ -275,3 +277,81 @@ def test_lower_subscript_resolves_axis_kinds_when_unset() -> None:
     )
     s_buf = np.arange(6).reshape(3, 2)
     assert np.array_equal(_eval(node, {"S_buf": s_buf, "np": np}), s_buf)
+
+
+# ---------------------------------------------------------------------------
+# lift_cell_ir_to_template
+# ---------------------------------------------------------------------------
+
+
+def test_lift_replaces_templated_cell_syms_with_free_subscripts() -> None:
+    """Per-cell ``Sym`` leaves lift to FREE-axis ``Subscript`` nodes."""
+    ir = parse_expr_to_ir("beta * S__age_y__loc_a")
+    lifted = lift_cell_ir_to_template(
+        ir,
+        cell_to_template={
+            "S__age_y__loc_a": ("S", ("age", "loc")),
+            "S__age_y__loc_b": ("S", ("age", "loc")),
+            "S__age_o__loc_a": ("S", ("age", "loc")),
+            "S__age_o__loc_b": ("S", ("age", "loc")),
+        },
+    )
+    assert isinstance(lifted, Apply)
+    assert lifted.op == "*"
+    sub = lifted.args[1]
+    assert isinstance(sub, Subscript)
+    assert sub.name == "S"
+    assert tuple(idx.axis for idx in sub.indices) == ("age", "loc")
+    assert all(idx.kind == AxisKind.FREE for idx in sub.indices)
+
+
+def test_lift_leaves_scalar_params_alone() -> None:
+    """Symbols absent from the cell map (scalar params) survive intact."""
+    ir = parse_expr_to_ir("beta + gamma * 2")
+    lifted = lift_cell_ir_to_template(ir, cell_to_template={})
+    assert lifted == ir
+
+
+def test_lift_rewrites_scalar_aliases_to_buf_syms() -> None:
+    """Empty-axes mapping rewrites the symbol to its ``<base>_buf`` form."""
+    ir = parse_expr_to_ir("I_total * 0.5")
+    lifted = lift_cell_ir_to_template(ir, cell_to_template={"I_total": ("I_total", ())})
+    assert isinstance(lifted, Apply)
+    assert lifted.op == "*"
+    assert lifted.args[0] == Sym(name="I_total_buf")
+
+
+def test_lift_refuses_when_multiple_cells_of_same_base_cooccur() -> None:
+    """String-expanded axis reductions must be rejected, not silently merged."""
+    # Mimics ``apply_along(pop=j, I[pop=j])`` after string expansion to
+    # ``I__pop_p1 + I__pop_p2`` — collapsing both to ``I[pop]`` would
+    # broadcast instead of reduce.
+    ir = parse_expr_to_ir("I__pop_p1 + I__pop_p2")
+    with pytest.raises(UnsupportedIRLoweringError, match="multiple"):
+        lift_cell_ir_to_template(
+            ir,
+            cell_to_template={
+                "I__pop_p1": ("I", ("pop",)),
+                "I__pop_p2": ("I", ("pop",)),
+            },
+        )
+
+
+def test_lift_then_lower_round_trip_evaluates_to_buffer_product() -> None:
+    """Lift + lower of ``S * I`` produces a shaped element-wise product."""
+    ir = parse_expr_to_ir("S__age_0__vax_0 * I__age_0__vax_0")
+    cell_to_template = {
+        "S__age_0__vax_0": ("S", ("age", "vax")),
+        "I__age_0__vax_0": ("I", ("age", "vax")),
+    }
+    lifted = lift_cell_ir_to_template(ir, cell_to_template=cell_to_template)
+    node = lower_to_vector_ast(
+        lifted,
+        target_axes=("age", "vax"),
+        buffer_axes={"S": ("age", "vax"), "I": ("age", "vax")},
+        axis_names=frozenset({"age", "vax"}),
+    )
+    s_buf = np.array([[1.0, 2.0], [3.0, 4.0]])
+    i_buf = np.array([[5.0, 6.0], [7.0, 8.0]])
+    out = _eval(node, {"S_buf": s_buf, "I_buf": i_buf, "np": np})
+    assert np.array_equal(out, s_buf * i_buf)

--- a/tests/op_system/test_op_system_vectorize.py
+++ b/tests/op_system/test_op_system_vectorize.py
@@ -613,3 +613,38 @@ def test_long_add_chain_does_not_raise_recursionerror() -> None:
     assert s_buf_loads == 1, (
         f"long chain should still collapse to a single S_buf load, got {s_buf_loads}"
     )
+
+
+# ---------------------------------------------------------------------------
+# IR-based vectorization fast path (issue #112)
+# ---------------------------------------------------------------------------
+
+
+def test_ir_fast_path_emits_no_per_cell_names_on_clean_templated_spec() -> None:
+    """Equations lowered via the IR fast path reference only buffer names.
+
+    On a templated spec whose equations contain no string-expanded axis
+    reductions (no ``apply_along``, ``sum_over``, etc.), the IR-based
+    lowering in ``_rewrite_cell_to_vector`` should produce code objects
+    that reference only ``<base>_buf`` / scalar-param names — never the
+    per-cell expanded names like ``S__age_y__loc_a`` that the legacy
+    ``_NameRewriter`` path produces as intermediates.
+    """
+    rhs = normalize_rhs(_sir_two_axis_spec())
+    plan = build_vector_plan(rhs)
+    assert plan is not None
+    for grp in plan.eq_groups:
+        for code in grp.codes:
+            for name in code.co_names:
+                assert "__" not in name, (
+                    f"per-cell name {name!r} leaked into vectorized "
+                    f"code for template {grp.base!r}"
+                )
+
+
+def test_ir_fast_path_preserves_numerical_parity_with_scalar() -> None:
+    """The IR fast path produces numerically identical output to scalar eval."""
+    # Same equivalence check as test_vectorized_matches_scalar_two_axis_sir,
+    # but kept distinct so a regression that disables the fast path is
+    # caught by the structural test above without masking the parity check.
+    _eval_equal(_sir_two_axis_spec(), beta=0.3, gamma=0.1)


### PR DESCRIPTION
## Summary

First real consumer of `_ir_lower` (PR #122). Adds an IR-based fast path
to `_rewrite_cell_to_vector` that lowers per-cell IR straight to a
vectorized AST when the equation's shape is supported. On any
`UnsupportedIRLoweringError` it transparently falls back to the existing
`_NameRewriter` pipeline, so behavior and numerics are preserved.

Refs #112.

## Changes

- **`_ir_lower.py`**: new helper `lift_cell_ir_to_template(expr, *, cell_to_template)`
  that rewrites per-cell `Sym` leaves (e.g. `S__age_y__loc_a`) into either:
  - FREE-axis `Subscript(base, [...])` for templated buffers, or
  - `Sym(f"{base}_buf")` for scalar aliases (matches the runtime env binding).
  - Safety: refuses (raises `UnsupportedIRLoweringError`) if two distinct
    cell symbols sharing the same templated `base` co-occur in `expr` —
    this signals a string-expanded axis reduction (`apply_along` /
    `sum_over`) that cannot be represented as a single FREE-axis
    subscript and must go through the legacy path.
- **`_vectorize.py`**: new `_try_ir_fast_path(...)` calls `lift_cell_ir_to_template`
  then `lower_to_vector_ast`; wired into `_rewrite_cell_to_vector` before
  the `_NameRewriter` instantiation. Returns `None` (→ fallback) on any
  `UnsupportedIRLoweringError`.

## Tests

- 5 new unit tests for `lift_cell_ir_to_template` (templated cells →
  FREE subscripts, scalar params untouched, scalar aliases → `<base>_buf`,
  refuses multi-cell co-occurrence, end-to-end round-trip to a vectorized
  buffer product).
- 2 new vectorize-level tests: a structural assertion that no per-cell
  expanded names (`__` infixed) leak into compiled `co_names` for a clean
  templated SIR — proving the fast path actually fired — plus a parity
  check against scalar eval.
- Full suite: **347 passed**, `just ci` clean.
