### PR TITLE
feat(#112): Stage 1b — lower Reduce(apply_along) to np.sum in IR fast path

### DIFF
--- a/src/op_system/_ir_lower.py
+++ b/src/op_system/_ir_lower.py
@@ -225,6 +225,7 @@ def lower_to_vector_ast(
     target_axes: tuple[str, ...],
     buffer_axes: Mapping[str, tuple[str, ...]],
     axis_names: frozenset[str],
+    reducible_axes: frozenset[str] = frozenset(),
 ) -> ast.expr:
     """Lower an IR expression to a vector-shape AST.
 
@@ -241,6 +242,10 @@ def lower_to_vector_ast(
             mapping are treated as scalar (``ast.Name``) leaves.
         axis_names: Registered axis identifier set; passed through to
             :func:`lower_subscript_to_buffer` for index classification.
+        reducible_axes: Axes that may be summed over inside a
+            :class:`Reduce` node. Typically the set of categorical/ordinal
+            axes (uniform-weight kernel). Empty by default — when empty,
+            any :class:`Reduce` raises :class:`UnsupportedIRLoweringError`.
 
     Returns:
         An ``ast.expr`` suitable for ``compile(ast.Expression(body=...))``
@@ -277,17 +282,140 @@ def lower_to_vector_ast(
             target_axes=target_axes,
             buffer_axes=buffer_axes,
             axis_names=axis_names,
+            reducible_axes=reducible_axes,
         )
 
-    if isinstance(expr, Reduce):
+    return _lower_reduce(
+        expr,
+        target_axes=target_axes,
+        buffer_axes=buffer_axes,
+        axis_names=axis_names,
+        reducible_axes=reducible_axes,
+    )
+
+
+_REDUCE_SUM_KINDS: frozenset[str] = frozenset({"apply_along", "sum_over"})
+
+
+def _lower_reduce(
+    expr: Reduce,
+    *,
+    target_axes: tuple[str, ...],
+    buffer_axes: Mapping[str, tuple[str, ...]],
+    axis_names: frozenset[str],
+    reducible_axes: frozenset[str],
+) -> ast.expr:
+    """Lower a :class:`Reduce` node to ``np.sum(body, axis=...)``.
+
+    Restricted to uniform-weight kernels (``apply_along`` / ``sum_over``)
+    over axes that appear in ``reducible_axes`` — i.e. categorical or
+    ordinal axes where the reduction collapses to a plain sum. The
+    ``integrate_over`` kind and any continuous-axis binding raise
+    :class:`UnsupportedIRLoweringError` so callers fall back to the
+    legacy string-expansion path.
+
+    Returns:
+        An ``ast.expr`` invoking ``np.sum`` on the lowered body, with the
+        bound axes collapsed.
+
+    Raises:
+        UnsupportedIRLoweringError: If ``expr.kind`` is not a uniform-sum
+            kind, if any bound axis is not in ``reducible_axes``, or if
+            the body itself violates the v1 lowering subset.
+    """
+    if expr.kind not in _REDUCE_SUM_KINDS:
         msg = (
-            f"Reduce({expr.kind!r}) nodes are not supported by v1 "
-            "lowering; expand helpers before invoking the lowering"
+            f"Reduce kind {expr.kind!r} requires shaped weights; v1 "
+            "lowering supports only uniform-weight reductions "
+            f"({sorted(_REDUCE_SUM_KINDS)})"
         )
         raise UnsupportedIRLoweringError(msg)
 
-    msg = f"unsupported IR node for v1 lowering: {type(expr).__name__}"
-    raise UnsupportedIRLoweringError(msg)
+    bound_axes: list[str] = []
+    rebind: dict[str, str] = {}
+    for axis, binding in expr.bindings:
+        if axis not in reducible_axes:
+            msg = (
+                f"Reduce binding {axis}={binding} targets a non-reducible "
+                "axis (likely continuous) — v1 lowering supports "
+                "uniform-weight categorical reductions only"
+            )
+            raise UnsupportedIRLoweringError(msg)
+        if axis in bound_axes:
+            msg = f"Reduce has duplicate axis binding {axis!r}"
+            raise UnsupportedIRLoweringError(msg)
+        bound_axes.append(axis)
+        rebind[binding] = axis
+
+    rebound_body = _rebind_subscript_indices(expr.body, rebind=rebind)
+
+    extended_target = target_axes + tuple(
+        ax for ax in bound_axes if ax not in target_axes
+    )
+    body_ast = lower_to_vector_ast(
+        rebound_body,
+        target_axes=extended_target,
+        buffer_axes=buffer_axes,
+        axis_names=axis_names,
+        reducible_axes=reducible_axes,
+    )
+
+    reduce_positions = tuple(extended_target.index(ax) for ax in bound_axes)
+    if len(reduce_positions) == 1:
+        axis_arg: ast.expr = ast.Constant(value=reduce_positions[0])
+    else:
+        axis_arg = ast.Tuple(
+            elts=[ast.Constant(value=p) for p in reduce_positions],
+            ctx=ast.Load(),
+        )
+    return ast.Call(
+        func=ast.Attribute(value=_name("np"), attr="sum", ctx=ast.Load()),
+        args=[body_ast],
+        keywords=[ast.keyword(arg="axis", value=axis_arg)],
+    )
+
+
+def _rebind_subscript_indices(  # noqa: PLR0911
+    expr: Expr, *, rebind: Mapping[str, str]
+) -> Expr:
+    """Rewrite Subscript ``AxisIndex(axis, coord=binding)`` slots to FREE.
+
+    Walks ``expr`` recursively; for every ``Subscript``, any index whose
+    ``coord`` matches a key of ``rebind`` (the per-binding coord name
+    chosen by the Reduce) is rewritten to a FREE wildcard on its declared
+    axis. Indices not matching are returned unchanged.
+
+    Returns:
+        A new IR expression with matching Subscript indices rewritten to
+        FREE, or ``expr`` itself when no rewrites apply.
+    """
+    if isinstance(expr, Subscript):
+        new_indices: list[AxisIndex] = []
+        changed = False
+        for idx in expr.indices:
+            if idx.coord and idx.coord in rebind and rebind[idx.coord] == idx.axis:
+                new_indices.append(AxisIndex(axis=idx.axis, kind=AxisKind.FREE))
+                changed = True
+            else:
+                new_indices.append(idx)
+        if changed:
+            return Subscript(name=expr.name, indices=tuple(new_indices))
+        return expr
+    if isinstance(expr, Apply):
+        new_args = tuple(_rebind_subscript_indices(a, rebind=rebind) for a in expr.args)
+        if any(na is not oa for na, oa in zip(new_args, expr.args, strict=True)):
+            return Apply(op=expr.op, args=new_args)
+        return expr
+    if isinstance(expr, Reduce):
+        # Inner Reduce shadows its own bindings: drop shadowed keys from
+        # the outer rebind map before recursing into the inner body.
+        inner_bindings = {b for _, b in expr.bindings}
+        inner_rebind = {k: v for k, v in rebind.items() if k not in inner_bindings}
+        new_body = _rebind_subscript_indices(expr.body, rebind=inner_rebind)
+        if new_body is not expr.body:
+            return Reduce(kind=expr.kind, bindings=expr.bindings, body=new_body)
+        return expr
+    return expr
 
 
 def _lower_apply(
@@ -296,6 +424,7 @@ def _lower_apply(
     target_axes: tuple[str, ...],
     buffer_axes: Mapping[str, tuple[str, ...]],
     axis_names: frozenset[str],
+    reducible_axes: frozenset[str] = frozenset(),
 ) -> ast.expr:
     def lower(child: Expr) -> ast.expr:
         return lower_to_vector_ast(
@@ -303,6 +432,7 @@ def _lower_apply(
             target_axes=target_axes,
             buffer_axes=buffer_axes,
             axis_names=axis_names,
+            reducible_axes=reducible_axes,
         )
 
     if expr.op == "neg" and len(expr.args) == 1:

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -586,6 +586,7 @@ def _try_ir_fast_path(
     target_axes: tuple[str, ...],
     name_to_template: Mapping[str, _BufferTemplate],
     axis_index: Mapping[str, Mapping[str, int]],
+    reducible_axes: frozenset[str] = frozenset(),
 ) -> ast.Expression | None:
     """Attempt to lower per-cell IR straight to a vector AST.
 
@@ -621,6 +622,7 @@ def _try_ir_fast_path(
             target_axes=target_axes,
             buffer_axes=buffer_axes,
             axis_names=frozenset(axis_index.keys()),
+            reducible_axes=reducible_axes,
         )
     except UnsupportedIRLoweringError:
         return None
@@ -633,11 +635,13 @@ def _rewrite_cell_to_vector(  # noqa: PLR0913
     *,
     expr: str,
     expr_ir: Expr | None = None,
+    expr_ir_reduce: Expr | None = None,
     target_axes: tuple[str, ...],
     cell_coords: Mapping[str, str],
     name_to_template: Mapping[str, _BufferTemplate],
     name_to_coords: Mapping[str, Mapping[str, str]],
     axis_index: Mapping[str, Mapping[str, int]],
+    reducible_axes: frozenset[str] = frozenset(),
     shaped_param_axes: Mapping[str, tuple[str, ...]] | None = None,
 ) -> ast.Expression:
     """Rewrite a per-cell expression string into a shaped buffer expression.
@@ -653,12 +657,27 @@ def _rewrite_cell_to_vector(  # noqa: PLR0913
     )
     ast.fix_missing_locations(tree)
     _validate_ast(tree, expr=expr)
+    # Prefer reduce-bearing IR (preserves helper structure as Reduce nodes)
+    # so the typed lowering can emit ``np.sum`` directly. On any v1-scope
+    # violation fall back to the post-expansion raw IR fast path, then to
+    # the legacy per-cell name rewriter.
+    if expr_ir_reduce is not None:
+        fast = _try_ir_fast_path(
+            expr_ir_reduce,
+            target_axes=target_axes,
+            name_to_template=name_to_template,
+            axis_index=axis_index,
+            reducible_axes=reducible_axes,
+        )
+        if fast is not None:
+            return fast
     if expr_ir is not None:
         fast = _try_ir_fast_path(
             expr_ir,
             target_axes=target_axes,
             name_to_template=name_to_template,
             axis_index=axis_index,
+            reducible_axes=reducible_axes,
         )
         if fast is not None:
             return fast
@@ -1200,9 +1219,11 @@ def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR
     template: _BufferTemplate,
     equations: tuple[str, ...],
     equations_ir: tuple[Expr | None, ...] | None = None,
+    equations_ir_reduce: tuple[Expr | None, ...] | None = None,
     name_to_template: Mapping[str, _BufferTemplate],
     name_to_coords: Mapping[str, Mapping[str, str]],
     axis_index: Mapping[str, Mapping[str, int]],
+    reducible_axes: frozenset[str] = frozenset(),
     shaped_param_axes: Mapping[str, tuple[str, ...]] | None = None,
 ) -> (
     tuple[
@@ -1237,6 +1258,12 @@ def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR
     cell_irs = (
         equations_ir[template.offset : template.offset + size]
         if equations_ir is not None and len(equations_ir) == len(equations)
+        else ()
+    )
+    cell_irs_reduce = (
+        equations_ir_reduce[template.offset : template.offset + size]
+        if equations_ir_reduce is not None
+        and len(equations_ir_reduce) == len(equations)
         else ()
     )
     n_axes = len(template.axes)
@@ -1298,11 +1325,15 @@ def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR
                 first_tree = _rewrite_cell_to_vector(
                     expr=cell_exprs[first_idx],
                     expr_ir=cell_irs[first_idx] if cell_irs else None,
+                    expr_ir_reduce=(
+                        cell_irs_reduce[first_idx] if cell_irs_reduce else None
+                    ),
                     target_axes=vec_axes,
                     cell_coords=template.coord_assignments[first_idx],
                     name_to_template=name_to_template,
                     name_to_coords=name_to_coords,
                     axis_index=axis_index,
+                    reducible_axes=reducible_axes,
                     shaped_param_axes=shaped_param_axes,
                 )
             except (ValueError, RuntimeError):
@@ -1313,11 +1344,15 @@ def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR
                     last_tree = _rewrite_cell_to_vector(
                         expr=cell_exprs[last_idx],
                         expr_ir=cell_irs[last_idx] if cell_irs else None,
+                        expr_ir_reduce=(
+                            cell_irs_reduce[last_idx] if cell_irs_reduce else None
+                        ),
                         target_axes=vec_axes,
                         cell_coords=template.coord_assignments[last_idx],
                         name_to_template=name_to_template,
                         name_to_coords=name_to_coords,
                         axis_index=axis_index,
+                        reducible_axes=reducible_axes,
                         shaped_param_axes=shaped_param_axes,
                     )
                 except (ValueError, RuntimeError):
@@ -1420,6 +1455,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
         return None
 
     axes_pairs: list[tuple[str, list[str]]] = []
+    reducible_axes_set: set[str] = set()
     for ax in axes_meta:
         if not isinstance(ax, Mapping):
             return None
@@ -1434,7 +1470,11 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
         # raw values would key ``axis_index`` by ``float`` while lookups use
         # ``str(float)``, causing ``KeyError`` in ``_build_access_ast``.
         axes_pairs.append((ax["name"], [str(c) for c in coords]))
+        ax_type = str(ax.get("type", "categorical")).strip().lower()
+        if ax_type in {"categorical", "ordinal"}:
+            reducible_axes_set.add(ax["name"])
     axis_index = {ax: {c: i for i, c in enumerate(coords)} for ax, coords in axes_pairs}
+    reducible_axes = frozenset(reducible_axes_set)
 
     state_buffers: list[_BufferTemplate] = []
     name_to_template: dict[str, _BufferTemplate] = {}
@@ -1516,22 +1556,28 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
                 tree = _rewrite_cell_to_vector(
                     expr=rhs.aliases[buf.expanded_names[0]],
                     expr_ir=rhs.aliases_ir.get(buf.expanded_names[0]),
+                    expr_ir_reduce=rhs.aliases_ir_reduce.get(buf.expanded_names[0]),
                     target_axes=buf.axes,
                     cell_coords=buf.coord_assignments[0],
                     name_to_template=name_to_template,
                     name_to_coords=name_to_coords,
                     axis_index=axis_index,
+                    reducible_axes=reducible_axes,
                     shaped_param_axes=shaped_param_axes,
                 )
                 if len(buf.expanded_names) > 1:
                     last_tree = _rewrite_cell_to_vector(
                         expr=rhs.aliases[buf.expanded_names[-1]],
                         expr_ir=rhs.aliases_ir.get(buf.expanded_names[-1]),
+                        expr_ir_reduce=rhs.aliases_ir_reduce.get(
+                            buf.expanded_names[-1]
+                        ),
                         target_axes=buf.axes,
                         cell_coords=buf.coord_assignments[-1],
                         name_to_template=name_to_template,
                         name_to_coords=name_to_coords,
                         axis_index=axis_index,
+                        reducible_axes=reducible_axes,
                         shaped_param_axes=shaped_param_axes,
                     )
                     if ast.dump(tree) != ast.dump(last_tree):
@@ -1542,11 +1588,13 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
                 tree = _rewrite_cell_to_vector(
                     expr=rhs.aliases[buf.expanded_names[0]],
                     expr_ir=rhs.aliases_ir.get(buf.expanded_names[0]),
+                    expr_ir_reduce=rhs.aliases_ir_reduce.get(buf.expanded_names[0]),
                     target_axes=(),
                     cell_coords={},
                     name_to_template=name_to_template,
                     name_to_coords=name_to_coords,
                     axis_index=axis_index,
+                    reducible_axes=reducible_axes,
                     shaped_param_axes=shaped_param_axes,
                 )
             tree = _distribute_const_over_add(tree)
@@ -1563,9 +1611,11 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
             template=buf,
             equations=rhs.equations,
             equations_ir=rhs.equations_ir_raw,
+            equations_ir_reduce=rhs.equations_ir_reduce,
             name_to_template=name_to_template,
             name_to_coords=name_to_coords,
             axis_index=axis_index,
+            reducible_axes=reducible_axes,
             shaped_param_axes=shaped_param_axes,
         )
         if result is None:

--- a/tests/op_system/test_op_system_vectorize.py
+++ b/tests/op_system/test_op_system_vectorize.py
@@ -648,3 +648,66 @@ def test_ir_fast_path_preserves_numerical_parity_with_scalar() -> None:
     # but kept distinct so a regression that disables the fast path is
     # caught by the structural test above without masking the parity check.
     _eval_equal(_sir_two_axis_spec(), beta=0.3, gamma=0.1)
+
+
+def _apply_along_categorical_spec() -> dict[str, object]:
+    """SIR over (pop,) with an ``apply_along(pop=j, I[pop=j])`` reduction.
+
+    Used to exercise Stage 1b: the reduce-bearing IR carries a
+    ``Reduce(kind='apply_along', ...)`` node that lowers directly to
+    ``np.sum`` over the bound axis, bypassing the post-expansion string
+    fallback.
+
+    Returns:
+        A spec dict suitable for passing to ``normalize_rhs``.
+    """
+    return {
+        "kind": "expr",
+        "axes": [{"name": "pop", "coords": ["p1", "p2", "p3"]}],
+        "state": ["S[pop]", "I[pop]", "R[pop]"],
+        "params": ["beta", "gamma"],
+        "equations": {
+            "S[pop]": "-beta * S[pop] * apply_along(pop=j, I[pop=j])",
+            "I[pop]": ("beta * S[pop] * apply_along(pop=j, I[pop=j]) - gamma * I[pop]"),
+            "R[pop]": "gamma * I[pop]",
+        },
+    }
+
+
+def test_reduce_ir_fast_path_emits_np_sum_for_apply_along() -> None:
+    """Reduce-bearing IR lowers apply_along directly to ``np.sum`` on the buffer.
+
+    Stage 1b: the IR fast path now consumes
+    ``NormalizedRhs.equations_ir_reduce`` (Reduce nodes preserved) and
+    emits a ``np.sum(I_buf, axis=...)`` reduction without falling back to
+    the string-expanded ``I__pop_p1 + I__pop_p2 + ...`` form. The compiled
+    code must therefore reference ``I_buf`` and ``sum`` once each, with no
+    per-cell ``I__pop_*`` names leaking through.
+    """
+    rhs = normalize_rhs(_apply_along_categorical_spec())
+    assert rhs.equations_ir_reduce, "Stage 1a should have populated reduce IR"
+    plan = build_vector_plan(rhs)
+    assert plan is not None
+    # Locate the S-equation code (it contains the reduction).
+    s_group = next(g for g in plan.eq_groups if g.base == "S")
+    code = s_group.codes[0]
+    names = set(code.co_names)
+    # No per-cell name leakage from string expansion.
+    assert not any("__" in n for n in names), (
+        f"per-cell names leaked into reduce-lowered code: "
+        f"{sorted(n for n in names if '__' in n)}"
+    )
+    assert "I_buf" in names, f"expected I_buf in {sorted(names)}"
+    assert "sum" in names, f"expected np.sum in {sorted(names)}"
+    # A direct np.sum(I_buf, axis=0) collapse loads I_buf exactly once.
+    i_buf_loads = sum(
+        1
+        for instr in dis.get_instructions(code)
+        if instr.opname.startswith("LOAD_") and instr.argval == "I_buf"
+    )
+    assert i_buf_loads == 1, f"expected single fused I_buf load, got {i_buf_loads}"
+
+
+def test_reduce_ir_fast_path_numerical_parity() -> None:
+    """Reduce-lowered apply_along eval matches the scalar reference."""
+    _eval_equal(_apply_along_categorical_spec(), beta=0.3, gamma=0.1)


### PR DESCRIPTION
## Summary

Stage 1b of the apply_along refactor (#112). Teaches the IR-fast-path
lowering to consume the reduce-bearing IR introduced in Stage 1a (#124),
so helper calls like `apply_along(pop=j, I[pop=j])` lower directly to a
single `np.sum(I_buf, axis=...)` call instead of falling back to the
post-expansion string `I__pop_p1 + I__pop_p2 + ...` rewriter path.

## Changes

- `src/op_system/_ir_lower.py`
  - `lower_to_vector_ast` gains a `reducible_axes: frozenset[str]`
    kwarg and now handles `Reduce` nodes via the new helper
    `_lower_reduce`.
  - `_lower_reduce` restricts v1 support to uniform-weight kinds
    (`apply_along`, `sum_over`) over axes the caller declares
    reducible (categorical / ordinal). It rewrites each bound
    `AxisIndex(axis, coord=binding)` slot in the body to a FREE
    wildcard, lowers the body with `target_axes` extended by the
    bound axes, then wraps the result in
    `np.sum(body, axis=(positions,))`. Continuous-axis bindings and
    `integrate_over` (weighted) raise `UnsupportedIRLoweringError`
    so the legacy string-expansion path still handles them.
  - New helper `_rebind_subscript_indices` performs the
    bound-axis → FREE substitution recursively, correctly shadowing
    inner-Reduce bindings.

- `src/op_system/_vectorize.py`
  - `_try_ir_fast_path` and `_rewrite_cell_to_vector` accept
    `reducible_axes`.
  - `_rewrite_cell_to_vector` now also accepts `expr_ir_reduce` and
    tries the reduce-bearing IR first; on
    `UnsupportedIRLoweringError` it falls back to the existing raw
    IR fast path, then to the legacy per-cell `_NameRewriter`.
  - `_vectorize_template_equations` plumbs `equations_ir_reduce` and
    `reducible_axes` to the rewrites.
  - `_build_vector_plan_inner` derives `reducible_axes` from the
    spec's axes meta (categorical+ordinal types) and forwards
    `rhs.aliases_ir_reduce` / `rhs.equations_ir_reduce` to the
    alias and state rewrite sites.

- `tests/op_system/test_op_system_vectorize.py`
  - `test_reduce_ir_fast_path_emits_np_sum_for_apply_along` asserts
    an `apply_along(pop=j, I[pop=j])` spec compiles to bytecode
    that loads `I_buf` exactly once and calls `sum` — i.e. it goes
    through the Reduce-lowering path, not the per-cell rewrite
    fallback.
  - `test_reduce_ir_fast_path_numerical_parity` confirms numerical
    equivalence with the scalar reference evaluator.

## Test plan

- `uv run pytest -q` — 354 passed (was 352; +2 new).
- `just ci` — green (ruff, basedpyright, pytest, docs).

## Next

Stage 2: drop `_expand_apply_along` from normalize and add runtime
helpers (`apply_along` / `sum_over` / `integrate_over`) to the
scalar `_make_eval_fn` env so the scalar engine no longer relies on
string expansion either.
