### PR TITLE
feat(#112): migrate DSL to valid-Python slice syntax

### DIFF
--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -219,10 +219,26 @@ def _axis_index_from_expr(node: ast.expr) -> AxisIndex:
     _invalid(detail=f"unsupported subscript index node: {type(node).__name__}")
 
 
+def _bound_axis_index_from_slice(node: ast.Slice) -> AxisIndex:
+    if node.step is not None:
+        _invalid(detail="bound-axis subscript axis:binding must not have a step")
+    if node.lower is None or node.upper is None:
+        _invalid(detail="bound-axis subscript requires axis:binding with both names")
+    if not isinstance(node.lower, ast.Name) or not isinstance(node.upper, ast.Name):
+        _invalid(detail="bound-axis subscript axis:binding requires bare identifiers")
+    return AxisIndex(axis=node.lower.id, coord=node.upper.id)
+
+
+def _parse_subscript_index_element(node: ast.expr) -> AxisIndex:
+    if isinstance(node, ast.Slice):
+        return _bound_axis_index_from_slice(node)
+    return _axis_index_from_expr(node)
+
+
 def _parse_subscript_indices(slc: ast.expr) -> tuple[AxisIndex, ...]:
     if isinstance(slc, ast.Tuple):
-        return tuple(_axis_index_from_expr(elt) for elt in slc.elts)
-    return (_axis_index_from_expr(slc),)
+        return tuple(_parse_subscript_index_element(elt) for elt in slc.elts)
+    return (_parse_subscript_index_element(slc),)
 
 
 def to_ir(node: ast.AST) -> Expr:  # noqa: C901, PLR0911, PLR0912

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -36,7 +36,7 @@ from op_system._helpers import (
     _ensure_str_list,
     _sorted_unique,
 )
-from op_system._ir import Apply, AxisIndex, Expr, Reduce, Subscript, parse_expr_to_ir
+from op_system._ir import Expr, parse_expr_to_ir
 from op_system._ir_templates import _detect_alias_cycle, inline_aliases
 from op_system._symbols import _collect_names, _parse_expr
 from op_system._templates import (
@@ -774,7 +774,8 @@ def _scan_shaped_param_refs(  # noqa: C901, PLR0912
     where ``name`` is not in ``name_blocklist`` (states, aliases, recognized
     built-ins) and every bracket entry is either:
     - A bare axis name (e.g., ``age``) registered in ``axis_lookup``
-    - An axis binding (e.g., ``age=ap``) where the axis name is registered
+    - An axis binding (e.g., ``age:ap`` or legacy ``age=ap``) where the
+      axis name is registered
 
     Each such ``name`` is recorded as shaped over the tuple of axes appearing
     in its first occurrence; subsequent occurrences must use the same axes in
@@ -806,8 +807,13 @@ def _scan_shaped_param_refs(  # noqa: C901, PLR0912
                 if not p:
                     valid = False
                     break
-                # Handle both bare axes (e.g., "age") and bindings (e.g., "age=ap")
-                if "=" in p:
+                # Handle bare axes (e.g., "age"), legacy bindings
+                # (``age=ap``), and the canonical slice-form bindings
+                # (``age:ap``).
+                if ":" in p:
+                    ax_name, _, _ = p.partition(":")
+                    ax_name = ax_name.strip()
+                elif "=" in p:
                     ax_name, _, _ = p.partition("=")
                     ax_name = ax_name.strip()
                 else:
@@ -1116,7 +1122,7 @@ def _expand_alias_templates(  # noqa: PLR0913
         if canonical_name in alias_template_map:
             # Defer ``_expand_helpers`` until the per-row LHS assignment is
             # known so that same-axis-twice references like
-            # ``K[age, age=ap]`` inside a templated alias (e.g. ``foi[age]``)
+            # ``K[age, age:ap]`` inside a templated alias (e.g. ``foi[age]``)
             # resolve the bare LHS-free position from the row assignment
             # rather than collapsing onto the bound ``apply_along`` coord.
             # Mirrors the equations path in ``_resolve_template_equation``.
@@ -1146,151 +1152,6 @@ def _expand_alias_templates(  # noqa: PLR0913
             )
 
     return aliases_out, alias_template_map
-
-
-# ``[axis=binding]`` subscript notation is used in pre-expansion spec strings
-# (e.g. ``I[pop=j]`` inside an ``apply_along(pop=j, ...)`` body) and is not
-# valid Python syntax, so ``parse_expr_to_ir`` cannot consume it directly.
-# When building helper-bearing (``Reduce``-node) IR for downstream consumers,
-# we rewrite each such bracket slot to a single marker identifier of the
-# form ``__op_bv__<axis>__<binding>__`` so the IR parser sees a bare name,
-# then post-process the resulting IR to restore ``AxisIndex(axis, coord)``.
-_BOUND_SUBSCRIPT_BRACKET_RE = re.compile(r"\[([^\[\]]*)\]")
-_BOUND_AX_MARKER_RE = re.compile(
-    r"^__op_bv__([A-Za-z_][A-Za-z0-9_]*)__([A-Za-z_][A-Za-z0-9_]*)__$"
-)
-
-
-def _preprocess_bound_subscripts(expr_s: str) -> str:
-    """Rewrite ``name[axis=binding, ...]`` slots to marker identifiers.
-
-    Only bracket slots that look like a simple ``axis=binding`` pair are
-    rewritten; list-literal contents (``in [c1, c2]`` filters, etc.) are
-    left alone. Nested brackets are not supported by this single-pass
-    regex and will simply be left unchanged — callers should treat the
-    second-pass IR build as best-effort.
-
-    Returns:
-        The input string with each ``axis=binding`` subscript slot
-        replaced by a single marker identifier.
-    """
-
-    def _repl(match: re.Match[str]) -> str:
-        inner = match.group(1)
-        parts = [p.strip() for p in inner.split(",")]
-        new_parts: list[str] = []
-        for p in parts:
-            if "=" in p and " in " not in p:
-                axis, binding = (s.strip() for s in p.split("=", 1))
-                if axis.isidentifier() and binding.isidentifier():
-                    new_parts.append(f"__op_bv__{axis}__{binding}__")
-                    continue
-            new_parts.append(p)
-        return "[" + ", ".join(new_parts) + "]"
-
-    return _BOUND_SUBSCRIPT_BRACKET_RE.sub(_repl, expr_s)
-
-
-_HELPER_CALL_NAMES: tuple[str, ...] = ("apply_along", "sum_over", "integrate_over")
-
-
-def _reorder_helper_call_args(expr_s: str) -> str:
-    """Move keyword arguments after positional arguments in helper calls.
-
-    Real-spec strings allow ``apply_along(pop=j, body)`` (kwargs before
-    positionals), which is rejected by Python's parser. The IR consumes a
-    canonical form with positionals first, so this helper rewrites each
-    occurrence by structurally splitting args and re-emitting them in
-    ``positional, *kwargs`` order. Nested helper calls are handled by
-    iterating until convergence.
-
-    Returns:
-        The input string with each helper call's argument list reordered
-        so that positional arguments precede keyword arguments.
-    """
-    for name in _HELPER_CALL_NAMES:
-        while True:
-            span = _find_call_span(expr_s, name)
-            if span is None:
-                break
-            start, end = span
-            inner = expr_s[start + len(name) + 1 : end - 1]
-            parts = _split_top_level_commas(inner)
-            positionals: list[str] = []
-            kwargs: list[str] = []
-            for p in parts:
-                ps = p.strip()
-                if not ps:
-                    continue
-                # An "=" at the top level marks a kwarg; bracket/paren contents
-                # were already skipped by ``_split_top_level_commas`` for
-                # commas, but ``=`` inside brackets is still possible.
-                if _is_top_level_kwarg(ps):
-                    kwargs.append(ps)
-                else:
-                    positionals.append(ps)
-            reordered = ", ".join(positionals + kwargs)
-            # Sentinel-rewrite the leading ``name(`` so the outer loop's next
-            # ``_find_call_span`` skips this already-processed occurrence;
-            # restore the name after the loop.
-            sentinel = f"__op_done__{name}__"
-            expr_s = expr_s[:start] + f"{sentinel}(" + reordered + ")" + expr_s[end:]
-        expr_s = expr_s.replace(f"__op_done__{name}__", name)
-    return expr_s
-
-
-def _is_top_level_kwarg(arg: str) -> bool:
-    """Return True if ``arg`` is a ``key=value`` pair at top bracket depth."""
-    depth = 0
-    for i, c in enumerate(arg):
-        if c in "([":
-            depth += 1
-        elif c in ")]":
-            depth -= 1
-        elif c == "=" and depth == 0:
-            next_eq = i + 1 < len(arg) and arg[i + 1] == "="
-            cmp_eq = i > 0 and arg[i - 1] in "<>!="
-            return not (next_eq or cmp_eq)
-    return False
-
-
-def _fixup_bound_axis_indices(expr: Expr) -> Expr:  # noqa: PLR0911
-    """Rewrite marker ``AxisIndex`` nodes produced by the preprocessor.
-
-    Walks ``expr`` recursively and replaces any ``AxisIndex`` whose ``axis``
-    matches the ``__op_bv__<axis>__<binding>__`` marker pattern with
-    ``AxisIndex(axis=<axis>, coord=<binding>)``. Other IR nodes are returned
-    unchanged when no descendant needed rewriting.
-
-    Returns:
-        A new IR expression with marker subscript indices restored to
-        ``AxisIndex(axis, coord)`` form, or ``expr`` itself if nothing
-        needed rewriting.
-    """
-    if isinstance(expr, Subscript):
-        new_indices: list[AxisIndex] = []
-        changed = False
-        for idx in expr.indices:
-            m = _BOUND_AX_MARKER_RE.match(idx.axis)
-            if m is not None:
-                new_indices.append(AxisIndex(axis=m.group(1), coord=m.group(2)))
-                changed = True
-            else:
-                new_indices.append(idx)
-        if changed:
-            return Subscript(name=expr.name, indices=tuple(new_indices))
-        return expr
-    if isinstance(expr, Apply):
-        new_args = tuple(_fixup_bound_axis_indices(a) for a in expr.args)
-        if any(na is not oa for na, oa in zip(new_args, expr.args, strict=True)):
-            return Apply(op=expr.op, args=new_args)
-        return expr
-    if isinstance(expr, Reduce):
-        new_body = _fixup_bound_axis_indices(expr.body)
-        if new_body is not expr.body:
-            return Reduce(kind=expr.kind, bindings=expr.bindings, body=new_body)
-        return expr
-    return expr
 
 
 def _build_aliases_ir(
@@ -1327,15 +1188,11 @@ def _build_aliases_ir(
             sys.setrecursionlimit(needed)
         parsed: dict[str, Expr] = {}
         for name, body in aliases.items():
-            if lower_helpers:
-                src = _preprocess_bound_subscripts(_reorder_helper_call_args(body))
-            else:
-                src = body
             try:
-                expr = parse_expr_to_ir(src, lower_helpers=lower_helpers)
+                expr = parse_expr_to_ir(body, lower_helpers=lower_helpers)
             except (ValueError, RecursionError):
                 continue
-            parsed[name] = _fixup_bound_axis_indices(expr) if lower_helpers else expr
+            parsed[name] = expr
         # Validate the alias graph once and share a free_symbols memo across
         # all per-alias inline_aliases calls: alias bodies are reused by
         # identity, so id-keyed caching turns the inner traversal cost from
@@ -1364,7 +1221,7 @@ def _build_aliases_ir(
             sys.setrecursionlimit(old_limit)
 
 
-def _build_equations_ir(  # noqa: C901
+def _build_equations_ir(
     equations: tuple[str, ...],
     aliases_ir: Mapping[str, Expr] | None = None,
     *,
@@ -1407,17 +1264,11 @@ def _build_equations_ir(  # noqa: C901
                 cycle_validated = False
         out: list[Expr | None] = []
         for eq in equations:
-            if lower_helpers:
-                src = _preprocess_bound_subscripts(_reorder_helper_call_args(eq))
-            else:
-                src = eq
             try:
-                expr = parse_expr_to_ir(src, lower_helpers=lower_helpers)
+                expr = parse_expr_to_ir(eq, lower_helpers=lower_helpers)
             except (ValueError, RecursionError):
                 out.append(None)
                 continue
-            if lower_helpers:
-                expr = _fixup_bound_axis_indices(expr)
             if aliases_ir is None:
                 out.append(expr)
                 continue
@@ -2086,9 +1937,9 @@ def _substitute_apply_along_brackets(  # noqa: C901, PLR0913, PLR0915
     ------------------------------
     For a shaped parameter declared on duplicate axes (e.g. a contact kernel
     ``K[age, age]``), the natural reference inside an ``apply_along`` is
-    ``K[age, age=ap]`` where the **bare** ``age`` token is the *free outer*
+    ``K[age, age:ap]`` where the **bare** ``age`` token is the *free outer*
     axis (taken from the LHS template assignment of the equation being
-    expanded) and the ``age=ap`` token is the *bound inner* axis (assigned
+    expanded) and the ``age:ap`` token is the *bound inner* axis (assigned
     by the surrounding ``apply_along``).  ``lhs_assignment`` carries the
     LHS-free axis bindings so this case can be lowered to per-row
     indexing/mangling rather than collapsing both positions onto the bound
@@ -2097,8 +1948,8 @@ def _substitute_apply_along_brackets(  # noqa: C901, PLR0913, PLR0915
     If ``shaped_params`` is provided and contains ``name`` with multiple axes
     (e.g., a contact kernel ``K[age, age]``), and all those axes are bound,
     the bracket assignments are converted to direct indexing instead of
-    name mangling. For example, ``K[age, age=ap]`` with bound ``age=c1`` is
-    converted to ``K[c1, ap]`` rather than ``K__age_<c1>[age=ap]``.
+    name mangling. For example, ``K[age, age:ap]`` with bound ``age=c1`` is
+    converted to ``K[c1, ap]`` rather than ``K__age_<c1>[age:ap]``.
 
     Returns:
         Expression string with bound bracket assignments folded into
@@ -2170,12 +2021,28 @@ def _substitute_apply_along_brackets(  # noqa: C901, PLR0913, PLR0915
         body = match.group(2)
         entries = [e.strip() for e in body.split(",") if e.strip()]
 
+        def _entry_parts(e: str) -> tuple[str, str | None]:
+            """Return (axis, coord) for one bracket entry.
+
+            Accepts both the canonical slice form ``axis:coord`` (valid
+            Python) and the legacy ``axis=coord`` form used by some
+            substitution outputs. Returns ``coord=None`` for bare
+            wildcard tokens.
+            """
+            for sep in (":", "="):
+                if sep in e:
+                    ax, _, c = e.partition(sep)
+                    return ax.strip(), c.strip()
+            return e, None
+
+        parsed_entries = [_entry_parts(e) for e in entries]
+
         # Same-axis-twice disambiguation: detect axes that appear in this
-        # bracket both as a bare token and as ``axis=coord``. The bare token
+        # bracket both as a bare token and as ``axis:coord``. The bare token
         # then refers to the LHS-free axis (taken from ``lhs_assignment``);
-        # the ``axis=coord`` token refers to the bound apply_along axis.
-        bare_axes = {e for e in entries if "=" not in e}
-        pinned_axes = {e.split("=", 1)[0].strip() for e in entries if "=" in e}
+        # the ``axis:coord`` token refers to the bound apply_along axis.
+        bare_axes = {ax for ax, c in parsed_entries if c is None}
+        pinned_axes = {ax for ax, c in parsed_entries if c is not None}
         same_axis_twice = bare_axes & pinned_axes
 
         # Resolve each entry positionally to (axis_name, coord, source) where
@@ -2183,11 +2050,8 @@ def _substitute_apply_along_brackets(  # noqa: C901, PLR0913, PLR0915
         resolved: list[tuple[str, str | None, str | None]] = []
         consumed: list[tuple[str, str]] = []
         remaining: list[str] = []
-        for entry in entries:
-            if "=" in entry:
-                ax, _, coord = entry.partition("=")
-                ax = ax.strip()
-                coord = coord.strip()
+        for entry, (ax, coord) in zip(entries, parsed_entries, strict=True):
+            if coord is not None:
                 if ax in bound and bound[ax] == coord:
                     consumed.append((ax, coord))
                     resolved.append((ax, coord, "bound"))
@@ -2202,9 +2066,9 @@ def _substitute_apply_along_brackets(  # noqa: C901, PLR0913, PLR0915
                 # equation), leave the token in the brackets for downstream
                 # template substitution.
                 if entry in lhs_assignment:
-                    coord = lhs_assignment[entry]
-                    consumed.append((entry, coord))
-                    resolved.append((entry, coord, "lhs"))
+                    lhs_coord = lhs_assignment[entry]
+                    consumed.append((entry, lhs_coord))
+                    resolved.append((entry, lhs_coord, "lhs"))
                     continue
                 resolved.append((entry, None, None))
                 remaining.append(entry)
@@ -2222,7 +2086,7 @@ def _substitute_apply_along_brackets(  # noqa: C901, PLR0913, PLR0915
 
         # Multi-axis shaped parameter → direct indexing when every position
         # is resolved. Use positional coords from ``resolved`` so that
-        # same-axis-twice references like ``K[age, age=ap]`` get distinct
+        # same-axis-twice references like ``K[age, age:ap]`` get distinct
         # row/column indices instead of collapsing onto the bound coord.
         if name in shaped_params and len(shaped_params[name]) > 1:
             param_axes = shaped_params[name]
@@ -2534,7 +2398,7 @@ def _expand_helpers(  # noqa: PLR0913
     ``lhs_assignment`` carries the LHS template assignment of the equation
     being expanded (e.g. ``{"age": "a0"}`` for the row ``foi__age_a0`` of
     ``foi[age]``). It is forwarded to :func:`_substitute_apply_along_brackets`
-    so that same-axis-twice references like ``K[age, age=ap]`` can resolve
+    so that same-axis-twice references like ``K[age, age:ap]`` can resolve
     the bare (free outer) axis position from the LHS row rather than
     collapsing it onto the bound apply_along coord.
 

--- a/tests/op_system/test_op_system_apply_along.py
+++ b/tests/op_system/test_op_system_apply_along.py
@@ -1,6 +1,6 @@
 """Unit tests for the ``apply_along`` expression primitive.
 
-``apply_along(axis1=var1, ..., inner_expr, [kernel=sum|integrate])``
+``apply_along(..., inner_expr, [kernel=sum|integrate], axis1=var1)``
 expands directly to weighted sums over the declared axes (categorical
 axes use uniform weights of 1; continuous axes use trapezoidal weights
 derived from the axis ``deltas``).  These tests cover:
@@ -27,8 +27,8 @@ def test_apply_along_single_axis_categorical_expands_to_sum() -> None:
         "axes": [{"name": "pop", "coords": ["p1", "p2"]}],
         "state": ["S[pop]", "I[pop]"],
         "equations": {
-            "S[pop]": "-beta * S[pop] * apply_along(pop=j, I[pop=j])",
-            "I[pop]": "beta * S[pop] * apply_along(pop=j, I[pop=j]) - gamma * I[pop]",
+            "S[pop]": "-beta * S[pop] * apply_along(I[pop:j], pop=j)",
+            "I[pop]": "beta * S[pop] * apply_along(I[pop:j], pop=j) - gamma * I[pop]",
         },
     }
     out = normalize_expr_rhs(spec)
@@ -48,7 +48,7 @@ def test_apply_along_multi_axis_categorical_expands_outer_product() -> None:
         "state": ["I[age, vax]", "N"],
         "equations": {
             "I[age, vax]": "0.0",
-            "N": "apply_along(age=a, vax=b, I[age=a, vax=b])",
+            "N": "apply_along(I[age:a, vax:b], age=a, vax=b)",
         },
     }
     out = normalize_expr_rhs(spec)
@@ -69,7 +69,7 @@ def test_apply_along_multi_axis_continuous_uses_trapezoidal_weights() -> None:
         "state": ["u[x, y]", "v"],
         "equations": {
             "u[x, y]": "0.0",
-            "v": "apply_along(x=i, y=j, u[x=i, y=j])",
+            "v": "apply_along(u[x:i, y:j], x=i, y=j)",
         },
     }
     out = normalize_expr_rhs(spec)
@@ -90,7 +90,7 @@ def test_apply_along_explicit_kernel_sum() -> None:
         "state": ["x[g]", "tot"],
         "equations": {
             "x[g]": "0.0",
-            "tot": "apply_along(g=i, x[g=i], kernel=sum)",
+            "tot": "apply_along(x[g:i], g=i, kernel=sum)",
         },
     }
     out = normalize_expr_rhs(spec)
@@ -107,7 +107,7 @@ def test_apply_along_explicit_kernel_integrate_on_categorical_axis_errors() -> N
         "state": ["x[g]", "tot"],
         "equations": {
             "x[g]": "0.0",
-            "tot": "apply_along(g=i, x[g=i], kernel=integrate)",
+            "tot": "apply_along(x[g:i], g=i, kernel=integrate)",
         },
     }
     with pytest.raises(ValueError, match=r"requires continuous axes"):
@@ -122,7 +122,7 @@ def test_apply_along_explicit_kernel_sum_on_continuous_axis_errors() -> None:
         "state": ["u[x]", "tot"],
         "equations": {
             "u[x]": "0.0",
-            "tot": "apply_along(x=i, u[x=i], kernel=sum)",
+            "tot": "apply_along(u[x:i], x=i, kernel=sum)",
         },
     }
     with pytest.raises(ValueError, match=r"requires categorical or ordinal axes"):
@@ -140,7 +140,7 @@ def test_apply_along_mixed_axis_types_without_kernel_errors() -> None:
         "state": ["u[g, x]", "tot"],
         "equations": {
             "u[g, x]": "0.0",
-            "tot": "apply_along(g=i, x=j, u[g=i, x=j])",
+            "tot": "apply_along(u[g:i, x:j], g=i, x=j)",
         },
     }
     with pytest.raises(ValueError, match=r"cannot infer kernel"):
@@ -165,7 +165,7 @@ def test_apply_along_requires_exactly_one_inner_expression() -> None:
         "kind": "expr",
         "axes": [{"name": "g", "coords": ["a", "b"]}],
         "state": ["x[g]"],
-        "equations": {"x[g]": "apply_along(g=i, x[g=i], x[g=i])"},
+        "equations": {"x[g]": "apply_along(x[g:i], x[g:i], g=i)"},
     }
     with pytest.raises(ValueError, match=r"exactly one inner expression"):
         normalize_expr_rhs(spec)
@@ -177,7 +177,7 @@ def test_apply_along_unknown_kernel_errors() -> None:
         "kind": "expr",
         "axes": [{"name": "g", "coords": ["a", "b"]}],
         "state": ["x[g]"],
-        "equations": {"x[g]": "apply_along(g=i, x[g=i], kernel=median)"},
+        "equations": {"x[g]": "apply_along(x[g:i], g=i, kernel=median)"},
     }
     with pytest.raises(ValueError, match=r"kernel must be one of"):
         normalize_expr_rhs(spec)
@@ -189,7 +189,7 @@ def test_apply_along_axis_binding_must_be_identifier() -> None:
         "kind": "expr",
         "axes": [{"name": "g", "coords": ["a", "b"]}],
         "state": ["x[g]"],
-        "equations": {"x[g]": "apply_along(g=1+2, x[g=i])"},
+        "equations": {"x[g]": "apply_along(x[g:i], g=1+2)"},
     }
     with pytest.raises(ValueError, match=r"must bind to an identifier"):
         normalize_expr_rhs(spec)
@@ -202,8 +202,8 @@ def test_apply_along_inside_arithmetic_expression() -> None:
         "axes": [{"name": "pop", "coords": ["p1", "p2"]}],
         "state": ["S[pop]", "I[pop]"],
         "equations": {
-            "S[pop]": "-beta * S[pop] * apply_along(pop=j, I[pop=j])",
-            "I[pop]": "beta * S[pop] * apply_along(pop=j, I[pop=j]) - gamma * I[pop]",
+            "S[pop]": "-beta * S[pop] * apply_along(I[pop:j], pop=j)",
+            "I[pop]": "beta * S[pop] * apply_along(I[pop:j], pop=j) - gamma * I[pop]",
         },
     }
     out = normalize_expr_rhs(spec)
@@ -227,7 +227,7 @@ def test_apply_along_nested_inside_apply_along() -> None:
         "state": ["I[age, vax]", "N"],
         "equations": {
             "I[age, vax]": "0.0",
-            "N": "apply_along(age=a, apply_along(vax=b, I[age=a, vax=b]))",
+            "N": "apply_along(apply_along(I[age:a, vax:b], vax=b), age=a)",
         },
     }
     out = normalize_expr_rhs(spec)
@@ -256,7 +256,7 @@ def test_apply_along_nested_three_axes_canonical_order() -> None:
             "N": (
                 "apply_along(age=a, "
                 "apply_along(vax=b, "
-                "apply_along(imm=k, X[age=a, vax=b, imm=k])))"
+                "apply_along(X[age:a, vax:b, imm:k], imm=k)))"
             ),
         },
     }
@@ -276,7 +276,7 @@ def test_apply_along_categorical_filter_subsets_coords() -> None:
         "state": ["pop[vax]", "covered"],
         "equations": {
             "pop[vax]": "0.0",
-            "covered": "apply_along(vax=j in [v, w], pop[vax=j])",
+            "covered": "apply_along(pop[vax:j], vax=j in [v, w])",
         },
     }
     out = normalize_expr_rhs(spec)
@@ -296,7 +296,7 @@ def test_apply_along_continuous_filter_recomputes_trapezoidal_deltas() -> None:
         "state": ["u[x]", "v"],
         "equations": {
             "u[x]": "0.0",
-            "v": "apply_along(x=i in [1.0, 4.0], u[x=i])",
+            "v": "apply_along(u[x:i], x=i in [1.0, 4.0])",
         },
     }
     out = normalize_expr_rhs(spec)
@@ -320,7 +320,7 @@ def test_apply_along_continuous_filter_requires_two_endpoints() -> None:
         "state": ["u[x]", "v"],
         "equations": {
             "u[x]": "0.0",
-            "v": "apply_along(x=i in [0.0, 1.0, 3.0], u[x=i])",
+            "v": "apply_along(u[x:i], x=i in [0.0, 1.0, 3.0])",
         },
     }
     with pytest.raises(Exception, match="2-element"):
@@ -337,7 +337,7 @@ def test_apply_along_continuous_filter_empty_subinterval_errors() -> None:
         "state": ["u[x]", "v"],
         "equations": {
             "u[x]": "0.0",
-            "v": "apply_along(x=i in [1.5, 2.5], u[x=i])",
+            "v": "apply_along(u[x:i], x=i in [1.5, 2.5])",
         },
     }
     with pytest.raises(Exception, match="selects no axis coords"):
@@ -352,7 +352,7 @@ def test_apply_along_filter_unknown_coord_errors() -> None:
         "state": ["pop[vax]", "covered"],
         "equations": {
             "pop[vax]": "0.0",
-            "covered": "apply_along(vax=j in [v, x], pop[vax=j])",
+            "covered": "apply_along(pop[vax:j], vax=j in [v, x])",
         },
     }
     with pytest.raises(Exception, match="unknown coords"):
@@ -370,7 +370,7 @@ def test_apply_along_filter_mixed_with_full_axis_in_multi_binding() -> None:
         "state": ["I[age, vax]", "N"],
         "equations": {
             "I[age, vax]": "0.0",
-            "N": "apply_along(age=a, vax=b in [v, w], I[age=a, vax=b])",
+            "N": "apply_along(I[age:a, vax:b], age=a, vax=b in [v, w])",
         },
     }
     out = normalize_expr_rhs(spec)
@@ -391,7 +391,7 @@ def test_apply_along_ordinal_axis_full_expansion_uses_uniform_weights() -> None:
         "state": ["pop[imm]", "total"],
         "equations": {
             "pop[imm]": "0.0",
-            "total": "apply_along(imm=k, pop[imm=k])",
+            "total": "apply_along(pop[imm:k], imm=k)",
         },
     }
     out = normalize_expr_rhs(spec)
@@ -414,7 +414,7 @@ def test_apply_along_ordinal_filter_inclusive_index_range() -> None:
         "state": ["pop[imm]", "covered"],
         "equations": {
             "pop[imm]": "0.0",
-            "covered": "apply_along(imm=k in [X1, X3], pop[imm=k])",
+            "covered": "apply_along(pop[imm:k], imm=k in [X1, X3])",
         },
     }
     out = normalize_expr_rhs(spec)
@@ -435,7 +435,7 @@ def test_apply_along_ordinal_filter_requires_two_endpoints() -> None:
         "state": ["pop[imm]", "covered"],
         "equations": {
             "pop[imm]": "0.0",
-            "covered": "apply_along(imm=k in [X0, X1, X2], pop[imm=k])",
+            "covered": "apply_along(pop[imm:k], imm=k in [X0, X1, X2])",
         },
     }
     with pytest.raises(Exception, match="2-element"):
@@ -452,7 +452,7 @@ def test_apply_along_ordinal_filter_unknown_endpoint_errors() -> None:
         "state": ["pop[imm]", "covered"],
         "equations": {
             "pop[imm]": "0.0",
-            "covered": "apply_along(imm=k in [X1, X9], pop[imm=k])",
+            "covered": "apply_along(pop[imm:k], imm=k in [X1, X9])",
         },
     }
     with pytest.raises(Exception, match="unknown coords"):
@@ -469,7 +469,7 @@ def test_apply_along_ordinal_filter_reversed_endpoints_errors() -> None:
         "state": ["pop[imm]", "covered"],
         "equations": {
             "pop[imm]": "0.0",
-            "covered": "apply_along(imm=k in [X3, X1], pop[imm=k])",
+            "covered": "apply_along(pop[imm:k], imm=k in [X3, X1])",
         },
     }
     with pytest.raises(Exception, match="index"):

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -228,8 +228,8 @@ def test_templates_and_apply_along_compile_and_eval() -> None:
         "axes": [{"name": "pop", "coords": ["p1", "p2"]}],
         "state": ["S[pop]", "I[pop]"],
         "equations": {
-            "S[pop]": "-beta * S[pop] * apply_along(pop=j, I[pop=j])",
-            "I[pop]": "beta * S[pop] * apply_along(pop=j, I[pop=j]) - gamma * I[pop]",
+            "S[pop]": "-beta * S[pop] * apply_along(I[pop:j], pop=j)",
+            "I[pop]": "beta * S[pop] * apply_along(I[pop:j], pop=j) - gamma * I[pop]",
         },
     }
     rhs = normalize_rhs(spec)

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -148,8 +148,8 @@ def test_expr_template_expansion_and_apply_along() -> None:
         "axes": [{"name": "pop", "coords": ["p1", "p2"]}],
         "state": ["S[pop]", "I[pop]"],
         "equations": {
-            "S[pop]": "-beta * S[pop] * apply_along(pop=j, I[pop=j])",
-            "I[pop]": "beta * S[pop] * apply_along(pop=j, I[pop=j]) - gamma * I[pop]",
+            "S[pop]": "-beta * S[pop] * apply_along(I[pop:j], pop=j)",
+            "I[pop]": "beta * S[pop] * apply_along(I[pop:j], pop=j) - gamma * I[pop]",
         },
     }
 
@@ -313,7 +313,7 @@ def test_same_axis_twice_apply_along_per_row_contraction() -> None:
         "state": ["I[age]", "foi[age]"],
         "equations": {
             "I[age]": "0.0",
-            "foi[age]": "apply_along(age=ap, K[age, age=ap] * I[age=ap])",
+            "foi[age]": "apply_along(K[age, age:ap] * I[age:ap], age=ap)",
         },
     }
     rhs = normalize_rhs(spec)
@@ -340,7 +340,7 @@ def test_same_axis_twice_apply_along_eval_end_to_end() -> None:
         "state": ["I[age]", "foi[age]"],
         "equations": {
             "I[age]": "0.0",
-            "foi[age]": "apply_along(age=ap, K[age, age=ap] * I[age=ap])",
+            "foi[age]": "apply_along(K[age, age:ap] * I[age:ap], age=ap)",
         },
     }
     rhs = normalize_rhs(spec)
@@ -377,7 +377,7 @@ def test_same_axis_twice_in_templated_alias_substituted_into_transition() -> Non
         "aliases": {
             "foi[age]": (
                 "apply_along(age=ap, K[age, age=ap]"
-                " * apply_along(vax=v, I[age=ap, vax=v]))"
+                " * apply_along(I[age:ap, vax:v], vax=v))"
             ),
         },
         "transitions": [
@@ -637,7 +637,7 @@ def test_apply_along_kernel_sum_rejects_continuous_axis() -> None:
             }
         ],
         "state": ["S[age]"],
-        "equations": {"S[age]": "-apply_along(age=i, S[age=i], kernel=sum)"},
+        "equations": {"S[age]": "-apply_along(S[age:i], age=i, kernel=sum)"},
     }
     with pytest.raises(ValueError, match=r"requires categorical or ordinal axes"):
         normalize_expr_rhs(spec)
@@ -657,7 +657,7 @@ def test_apply_along_integrate_expands_with_continuous_deltas() -> None:
         "state": ["u[x]", "v"],
         "equations": {
             "u[x]": "0.0",
-            "v": "apply_along(x=i, u[x=i])",
+            "v": "apply_along(u[x:i], x=i)",
         },
     }
 
@@ -685,7 +685,7 @@ def test_apply_along_kernel_integrate_rejects_categorical_axis() -> None:
             }
         ],
         "state": ["x[g]"],
-        "equations": {"x[g]": "apply_along(g=i, x[g=i], kernel=integrate)"},
+        "equations": {"x[g]": "apply_along(x[g:i], g=i, kernel=integrate)"},
     }
 
     with pytest.raises(ValueError, match=r"requires continuous axes"):
@@ -2148,8 +2148,8 @@ def test_equations_ir_reduce_is_positionally_aligned() -> None:
         "axes": [{"name": "pop", "coords": ["p1", "p2"]}],
         "state": ["S[pop]", "I[pop]"],
         "equations": {
-            "S[pop]": "-beta * S[pop] * apply_along(pop=j, I[pop=j])",
-            "I[pop]": ("beta * S[pop] * apply_along(pop=j, I[pop=j]) - gamma * I[pop]"),
+            "S[pop]": "-beta * S[pop] * apply_along(I[pop:j], pop=j)",
+            "I[pop]": ("beta * S[pop] * apply_along(I[pop:j], pop=j) - gamma * I[pop]"),
         },
     }
     out = normalize_expr_rhs(spec)
@@ -2163,8 +2163,8 @@ def test_equations_ir_reduce_contains_reduce_nodes_for_apply_along() -> None:
         "axes": [{"name": "pop", "coords": ["p1", "p2"]}],
         "state": ["S[pop]", "I[pop]"],
         "equations": {
-            "S[pop]": "-beta * S[pop] * apply_along(pop=j, I[pop=j])",
-            "I[pop]": ("beta * S[pop] * apply_along(pop=j, I[pop=j]) - gamma * I[pop]"),
+            "S[pop]": "-beta * S[pop] * apply_along(I[pop:j], pop=j)",
+            "I[pop]": ("beta * S[pop] * apply_along(I[pop:j], pop=j) - gamma * I[pop]"),
         },
     }
     out = normalize_expr_rhs(spec)
@@ -2183,7 +2183,7 @@ def test_aliases_ir_reduce_contains_reduce_for_aliased_apply_along() -> None:
         "kind": "expr",
         "axes": [{"name": "pop", "coords": ["p1", "p2"]}],
         "state": ["S[pop]", "I[pop]"],
-        "aliases": {"I_total": "apply_along(pop=j, I[pop=j])"},
+        "aliases": {"I_total": "apply_along(I[pop:j], pop=j)"},
         "equations": {
             "S[pop]": "-beta * S[pop] * I_total",
             "I[pop]": "beta * S[pop] * I_total - gamma * I[pop]",

--- a/tests/op_system/test_op_system_vectorize.py
+++ b/tests/op_system/test_op_system_vectorize.py
@@ -391,7 +391,7 @@ def _continuum_integrate_spec() -> dict[str, object]:
             # Integrate S over age, sum over loc → scalar.
             "S_total": (
                 "apply_along(age=a, "
-                "apply_along(loc=l, S[age=a, loc=l], kernel=sum), "
+                "apply_along(S[age:a, loc:l], loc=l, kernel=sum), "
                 "kernel=integrate)"
             ),
         },
@@ -487,7 +487,7 @@ def _network_outer_const_spec() -> dict[str, object]:
         "aliases": {
             "S_scaled": (
                 "0.25 * apply_along(age=a, "
-                "apply_along(loc=l, S[age=a, loc=l], kernel=sum), "
+                "apply_along(S[age:a, loc:l], loc=l, kernel=sum), "
                 "kernel=sum)"
             ),
         },
@@ -576,7 +576,7 @@ def _huge_chain_spec(n_loc: int) -> dict[str, object]:
         "state": ["S[loc]", "I[loc]"],
         "params": ["beta", "gamma"],
         "aliases": {
-            "S_scaled": "0.25 * apply_along(loc=l, S[loc=l], kernel=sum)",
+            "S_scaled": "0.25 * apply_along(S[loc:l], loc=l, kernel=sum)",
         },
         "equations": {
             "S[loc]": "-beta * S[loc] * S_scaled",
@@ -651,7 +651,7 @@ def test_ir_fast_path_preserves_numerical_parity_with_scalar() -> None:
 
 
 def _apply_along_categorical_spec() -> dict[str, object]:
-    """SIR over (pop,) with an ``apply_along(pop=j, I[pop=j])`` reduction.
+    """SIR over (pop,) with an ``apply_along(I[pop:j], pop=j)`` reduction.
 
     Used to exercise Stage 1b: the reduce-bearing IR carries a
     ``Reduce(kind='apply_along', ...)`` node that lowers directly to
@@ -667,8 +667,8 @@ def _apply_along_categorical_spec() -> dict[str, object]:
         "state": ["S[pop]", "I[pop]", "R[pop]"],
         "params": ["beta", "gamma"],
         "equations": {
-            "S[pop]": "-beta * S[pop] * apply_along(pop=j, I[pop=j])",
-            "I[pop]": ("beta * S[pop] * apply_along(pop=j, I[pop=j]) - gamma * I[pop]"),
+            "S[pop]": "-beta * S[pop] * apply_along(I[pop:j], pop=j)",
+            "I[pop]": ("beta * S[pop] * apply_along(I[pop:j], pop=j) - gamma * I[pop]"),
             "R[pop]": "gamma * I[pop]",
         },
     }


### PR DESCRIPTION
Part of #112 (Stage 2, Phase 1).

## Summary

Migrates the canonical `apply_along` / `sum_over` / `integrate_over`
RHS surface syntax so that every RHS expression is **valid Python**:

1. Bound axis bindings inside subscripts now use **slice notation**:
   `I[pop:j]` instead of `I[pop=j]`.
2. Helper calls are **body-first**: `apply_along(body, axis=binding)`
   instead of `apply_along(axis=binding, body)`. Python requires
   kwargs to follow positionals, so this ordering also makes the
   surface syntax legal Python.

Pinned-coord selectors in LHS templates, state lists, and transition
`from`/`to` (`S[imm=X99]`, `S[age=y, vax]`) keep the `=` form
since they're parsed by the selector regex, not the Python AST.

## Why

This is a prerequisite for the upcoming runtime-helpers work (Phase 2):
once every RHS is valid Python, the eval-fn environment can host real
`apply_along` / `sum_over` / `integrate_over` callables and we can
retire the string-rewriting expansion path.

## Implementation

- Teach the AST parser in `_ir.py` to recognize `Slice(Name, Name)`
  inside subscripts as a bound `AxisIndex`.
- Delete the legacy `_preprocess_bound_subscripts` /
  `_reorder_helper_call_args` / `_fixup_bound_axis_indices`
  scaffolding from `_normalize.py`; the AST-based parser now handles
  the new form natively. (`-228, +112` net.)
- Extend `_scan_shaped_param_refs` and the bracket-folder entry
  parser to accept both `axis:coord` (canonical) and `axis=coord`
  (legacy, for internal substitution output).
- Migrate all test fixtures and the relevant docstring examples in
  bulk to the new form.

## Validation

- `uv run pytest tests/ -q` → **354 passed**
- `just ci` → **all checks passed**