### PR TITLE
Feat/112 stage2 runtime helpers

### DIFF
--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -166,16 +166,17 @@ def _extract_filter_from_value(value: Expr) -> tuple[str, tuple[str, ...]] | Non
     ``Literal`` (numeric / string coords for continuous filters). All
     other shapes return ``None`` so the caller falls back to plain
     binding interpretation.
+
+    Returns:
+        ``(var_name, coord_strs)`` when the value matches the ``var in
+        [...]`` filter shape, otherwise ``None``.
     """
     if not (isinstance(value, Apply) and value.op == "in" and len(value.args) == 2):
         return None
     var_node, list_node = value.args
     if not isinstance(var_node, Sym):
         return None
-    if not (
-        isinstance(list_node, Apply)
-        and list_node.op == "list"
-    ):
+    if not (isinstance(list_node, Apply) and list_node.op == "list"):
         return None
     coords: list[str] = []
     for elt in list_node.args:
@@ -188,7 +189,7 @@ def _extract_filter_from_value(value: Expr) -> tuple[str, tuple[str, ...]] | Non
     return var_node.name, tuple(coords)
 
 
-def _lower_single_helper(node: Apply) -> Expr:
+def _lower_single_helper(node: Apply) -> Expr:  # noqa: C901, PLR0912
     if node.op not in _HELPER_REDUCE_OPS:
         return node
 
@@ -220,9 +221,7 @@ def _lower_single_helper(node: Apply) -> Expr:
             elif isinstance(value, Literal):
                 kernel_name = str(value.value)
             else:
-                _invalid(
-                    detail=f"{node.op} kernel= must be 'sum' or 'integrate'"
-                )
+                _invalid(detail=f"{node.op} kernel= must be 'sum' or 'integrate'")
             if kernel_name not in _APPLY_ALONG_KERNELS_IR:
                 _invalid(
                     detail=(

--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -72,11 +72,26 @@ class Apply:
 
 @dataclass(frozen=True, slots=True)
 class Reduce:
-    """Reduction primitive placeholder for future helper-lowering passes."""
+    """Reduction primitive placeholder for future helper-lowering passes.
+
+    ``filters`` records optional per-axis coord subsets from helper
+    invocations of the form ``axis=var in [c1, c2, ...]``. Each entry is
+    ``(axis_name, (coord1, coord2, ...))``; absence of an entry for an
+    axis means the reduction spans the full axis. For continuous axes
+    with two numeric coords ``[lo, hi]`` the filter is interpreted as a
+    sub-interval to integrate over.
+
+    ``kernel`` records an explicit ``kernel=`` kwarg from
+    ``apply_along(..., kernel=sum|integrate)``. ``None`` means auto-select
+    based on the bound axis types (the same behavior as the string
+    expander).
+    """
 
     kind: str
     bindings: tuple[tuple[str, str], ...]
     body: Expr
+    filters: tuple[tuple[str, tuple[str, ...]], ...] = ()
+    kernel: str | None = None
 
 
 Expr = Literal | Sym | Subscript | Apply | Reduce
@@ -141,6 +156,38 @@ def _kwarg_value_as_binding(value: Expr, *, key: str) -> str:
     _invalid(detail=f"helper binding {key!r} must be a symbol or literal")
 
 
+_APPLY_ALONG_KERNELS_IR: frozenset[str] = frozenset({"sum", "integrate"})
+
+
+def _extract_filter_from_value(value: Expr) -> tuple[str, tuple[str, ...]] | None:
+    """If ``value`` is ``var in [c1, c2, ...]``, return ``(var, coords)``.
+
+    The coord list elements may be ``Sym`` (categorical/ordinal labels) or
+    ``Literal`` (numeric / string coords for continuous filters). All
+    other shapes return ``None`` so the caller falls back to plain
+    binding interpretation.
+    """
+    if not (isinstance(value, Apply) and value.op == "in" and len(value.args) == 2):
+        return None
+    var_node, list_node = value.args
+    if not isinstance(var_node, Sym):
+        return None
+    if not (
+        isinstance(list_node, Apply)
+        and list_node.op == "list"
+    ):
+        return None
+    coords: list[str] = []
+    for elt in list_node.args:
+        if isinstance(elt, Sym):
+            coords.append(elt.name)
+        elif isinstance(elt, Literal):
+            coords.append(str(elt.value))
+        else:
+            return None
+    return var_node.name, tuple(coords)
+
+
 def _lower_single_helper(node: Apply) -> Expr:
     if node.op not in _HELPER_REDUCE_OPS:
         return node
@@ -157,14 +204,50 @@ def _lower_single_helper(node: Apply) -> Expr:
         _invalid(detail=f"{node.op} helper requires exactly one body expression")
 
     bindings: list[tuple[str, str]] = []
+    filters: list[tuple[str, tuple[str, ...]]] = []
+    kernel: str | None = None
     for kw_node in kw_nodes:
         if len(kw_node.args) != 2:
             _invalid(detail="kwarg marker must contain (key, value)")
         key = _kwarg_name(kw_node.args[0])
-        val = _kwarg_value_as_binding(kw_node.args[1], key=key)
+        value = kw_node.args[1]
+        if key == "kernel":
+            # ``kernel=sum`` / ``kernel=integrate`` selects the per-axis form
+            # explicitly; recognize it specially so it doesn't get mistaken
+            # for an axis binding.
+            if isinstance(value, Sym):
+                kernel_name = value.name
+            elif isinstance(value, Literal):
+                kernel_name = str(value.value)
+            else:
+                _invalid(
+                    detail=f"{node.op} kernel= must be 'sum' or 'integrate'"
+                )
+            if kernel_name not in _APPLY_ALONG_KERNELS_IR:
+                _invalid(
+                    detail=(
+                        f"{node.op} kernel must be one of "
+                        f"{sorted(_APPLY_ALONG_KERNELS_IR)}, got {kernel_name!r}"
+                    )
+                )
+            kernel = kernel_name
+            continue
+        flt = _extract_filter_from_value(value)
+        if flt is not None:
+            var_name, coords = flt
+            bindings.append((key, var_name))
+            filters.append((key, coords))
+            continue
+        val = _kwarg_value_as_binding(value, key=key)
         bindings.append((key, val))
 
-    return Reduce(kind=node.op, bindings=tuple(bindings), body=positional[0])
+    return Reduce(
+        kind=node.op,
+        bindings=tuple(bindings),
+        body=positional[0],
+        filters=tuple(filters),
+        kernel=kernel,
+    )
 
 
 def lower_helper_calls(expr: Expr) -> Expr:
@@ -186,6 +269,8 @@ def lower_helper_calls(expr: Expr) -> Expr:
             kind=expr.kind,
             bindings=expr.bindings,
             body=lower_helper_calls(expr.body),
+            filters=expr.filters,
+            kernel=expr.kernel,
         )
 
     return expr
@@ -282,6 +367,25 @@ def to_ir(node: ast.AST) -> Expr:  # noqa: C901, PLR0911, PLR0912
     if isinstance(node, ast.Compare):
         if len(node.ops) != len(node.comparators):
             _invalid(detail="malformed comparison node")
+        # Special-case ``x in [c1, c2, ...]`` (single ``In`` op) so helper
+        # kwarg values like ``axis=var in [c1, c2]`` survive parsing and
+        # can be recognized as filter specifications by
+        # :func:`_lower_single_helper`.
+        if (
+            len(node.ops) == 1
+            and isinstance(node.ops[0], ast.In)
+            and isinstance(node.comparators[0], ast.List)
+        ):
+            return Apply(
+                op="in",
+                args=(
+                    to_ir(node.left),
+                    Apply(
+                        op="list",
+                        args=tuple(to_ir(e) for e in node.comparators[0].elts),
+                    ),
+                ),
+            )
         left = node.left
         parts: list[Expr] = []
         for op_node, right in zip(node.ops, node.comparators, strict=True):
@@ -712,6 +816,8 @@ def substitute(
             kind=expr.kind,
             bindings=expr.bindings,
             body=substitute(expr.body, inner, memo),
+            filters=expr.filters,
+            kernel=expr.kernel,
         )
     _invalid(detail=f"unsupported IR node in substitute: {type(expr).__name__}")
 
@@ -726,7 +832,13 @@ def _map_children(expr: Expr, fn: Callable[[Expr], Expr]) -> Expr:
         new_body = fn(expr.body)
         if new_body == expr.body:
             return expr
-        return Reduce(kind=expr.kind, bindings=expr.bindings, body=new_body)
+        return Reduce(
+            kind=expr.kind,
+            bindings=expr.bindings,
+            body=new_body,
+            filters=expr.filters,
+            kernel=expr.kernel,
+        )
     return expr
 
 
@@ -871,7 +983,13 @@ def resolve_axis_kinds(expr: Expr, *, axis_names: frozenset[str]) -> Expr:  # no
         new_body = resolve_axis_kinds(expr.body, axis_names=axis_names)
         if new_body is expr.body:
             return expr
-        return Reduce(kind=expr.kind, bindings=expr.bindings, body=new_body)
+        return Reduce(
+            kind=expr.kind,
+            bindings=expr.bindings,
+            body=new_body,
+            filters=expr.filters,
+            kernel=expr.kernel,
+        )
     _invalid(detail=f"unsupported IR node in resolve_axis_kinds: {type(expr).__name__}")
 
 

--- a/src/op_system/_ir_lower.py
+++ b/src/op_system/_ir_lower.py
@@ -228,6 +228,7 @@ def lower_to_vector_ast(  # noqa: PLR0913
     reducible_axes: frozenset[str] = frozenset(),
     axis_weights: Mapping[str, tuple[float, ...]] | None = None,
     axis_coords: Mapping[str, tuple[str, ...]] | None = None,
+    axis_types: Mapping[str, str] | None = None,
 ) -> ast.expr:
     """Lower an IR expression to a vector-shape AST.
 
@@ -258,6 +259,13 @@ def lower_to_vector_ast(  # noqa: PLR0913
             coord labels (as strings). Required when a :class:`Reduce`
             carries non-empty ``filters`` so coord labels can be
             resolved to integer indices for ``np.take`` slicing.
+        axis_types: Optional mapping from axis name to its declared type
+            (``"categorical"``, ``"ordinal"``, or ``"continuous"``).
+            Controls how :class:`Reduce` filter coord lists are
+            interpreted: categorical → exact-label subset, ordinal →
+            inclusive ``[lo_label, hi_label]`` index range, continuous →
+            closed ``[lo, hi]`` numeric sub-interval (with trapezoidal
+            weight recomputation for the integrate kernel).
 
     Returns:
         An ``ast.expr`` suitable for ``compile(ast.Expression(body=...))``
@@ -297,6 +305,7 @@ def lower_to_vector_ast(  # noqa: PLR0913
             reducible_axes=reducible_axes,
             axis_weights=axis_weights,
             axis_coords=axis_coords,
+            axis_types=axis_types,
         )
 
     return _lower_reduce(
@@ -307,6 +316,7 @@ def lower_to_vector_ast(  # noqa: PLR0913
         reducible_axes=reducible_axes,
         axis_weights=axis_weights,
         axis_coords=axis_coords,
+        axis_types=axis_types,
     )
 
 
@@ -318,6 +328,132 @@ _REDUCE_SUM_KINDS: frozenset[str] = frozenset({
 _REDUCE_UNIFORM_KINDS: frozenset[str] = frozenset({"apply_along", "sum_over"})
 
 
+def _resolve_ordinal_range_filter(
+    axis: str, declared: tuple[str, ...], filt: tuple[str, ...]
+) -> tuple[int, ...]:
+    """Resolve an ordinal-axis ``[lo_label, hi_label]`` filter to indices.
+
+    Returns:
+        Tuple of declared-coord indices spanning the inclusive index
+        range ``declared.index(lo)..declared.index(hi)``.
+
+    Raises:
+        UnsupportedIRLoweringError: If ``filt`` is not a 2-element list,
+            either endpoint is not a declared coord label, or
+            ``index(lo) > index(hi)``.
+    """
+    if len(filt) != 2:
+        msg = (
+            f"Reduce filter for ordinal axis {axis!r} must be a 2-element "
+            f"[lo_label, hi_label] range (got {len(filt)} entries)"
+        )
+        raise UnsupportedIRLoweringError(msg)
+    lo_label, hi_label = filt
+    unknown = [c for c in (lo_label, hi_label) if c not in declared]
+    if unknown:
+        msg = f"Reduce filter for ordinal axis {axis!r} has unknown coords: {unknown}"
+        raise UnsupportedIRLoweringError(msg)
+    lo_idx = declared.index(lo_label)
+    hi_idx = declared.index(hi_label)
+    if lo_idx > hi_idx:
+        msg = (
+            f"Reduce filter for ordinal axis {axis!r} endpoints must satisfy "
+            f"index(lo) <= index(hi) (got [{lo_label!r}, {hi_label!r}] at "
+            f"indices [{lo_idx}, {hi_idx}])"
+        )
+        raise UnsupportedIRLoweringError(msg)
+    return tuple(range(lo_idx, hi_idx + 1))
+
+
+def _resolve_continuous_range_filter(  # noqa: C901
+    axis: str,
+    declared: tuple[str, ...],
+    filt: tuple[str, ...],
+    *,
+    recompute_trapezoidal: bool,
+) -> tuple[tuple[int, ...], tuple[float, ...] | None]:
+    """Resolve a continuous-axis ``[lo, hi]`` filter to indices (+ weights).
+
+    Selects declared coord positions ``i`` for which ``lo <= float(c) <= hi``.
+    When ``recompute_trapezoidal`` is true (axis is integrated over), the
+    selected coords are parsed as floats and trapezoidal weights are
+    computed for the sub-interval; otherwise the second element is
+    ``None``.
+
+    Returns:
+        ``(indices, sub_interval_weights_or_None)``.
+
+    Raises:
+        UnsupportedIRLoweringError: If ``filt`` is not a 2-element list,
+            the endpoints aren't numeric, ``lo > hi``, the sub-interval
+            selects no axis coords, or trapezoidal weight recomputation
+            requires fewer than two coords / non-strictly-increasing
+            coords.
+    """
+    if len(filt) != 2:
+        msg = (
+            f"Reduce filter for continuous axis {axis!r} must be a 2-element "
+            f"[lo, hi] interval (got {len(filt)} entries)"
+        )
+        raise UnsupportedIRLoweringError(msg)
+    try:
+        lo = float(filt[0])
+        hi = float(filt[1])
+    except ValueError as exc:
+        msg = (
+            f"Reduce filter for continuous axis {axis!r} endpoints must be "
+            f"numeric (got {list(filt)!r})"
+        )
+        raise UnsupportedIRLoweringError(msg) from exc
+    if lo > hi:
+        msg = (
+            f"Reduce filter for continuous axis {axis!r} endpoints must "
+            f"satisfy lo <= hi (got [{lo}, {hi}])"
+        )
+        raise UnsupportedIRLoweringError(msg)
+    try:
+        coord_floats = [float(c) for c in declared]
+    except ValueError as exc:
+        msg = (
+            f"Reduce filter for continuous axis {axis!r} requires numeric "
+            f"declared coords (got {list(declared)!r})"
+        )
+        raise UnsupportedIRLoweringError(msg) from exc
+    indices = tuple(i for i, c in enumerate(coord_floats) if lo <= c <= hi)
+    if not indices:
+        msg = (
+            f"Reduce filter for continuous axis {axis!r} interval [{lo}, "
+            f"{hi}] selects no axis coords"
+        )
+        raise UnsupportedIRLoweringError(msg)
+    if not recompute_trapezoidal:
+        return indices, None
+    sub_floats = [coord_floats[i] for i in indices]
+    if len(sub_floats) < 2:
+        msg = (
+            f"Reduce filter for continuous axis {axis!r} sub-interval needs "
+            "at least 2 coords for trapezoidal integration"
+        )
+        raise UnsupportedIRLoweringError(msg)
+    sub_weights: list[float] = []
+    for i in range(len(sub_floats)):
+        if i == 0:
+            width = (sub_floats[1] - sub_floats[0]) / 2.0
+        elif i == len(sub_floats) - 1:
+            width = (sub_floats[-1] - sub_floats[-2]) / 2.0
+        else:
+            width = (sub_floats[i + 1] - sub_floats[i - 1]) / 2.0
+        if width <= 0.0:
+            msg = (
+                f"Reduce filter for continuous axis {axis!r} sub-interval "
+                "coords must be strictly increasing for trapezoidal "
+                "integration"
+            )
+            raise UnsupportedIRLoweringError(msg)
+        sub_weights.append(width)
+    return indices, tuple(sub_weights)
+
+
 def _lower_reduce(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915
     expr: Reduce,
     *,
@@ -327,6 +463,7 @@ def _lower_reduce(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915
     reducible_axes: frozenset[str],
     axis_weights: Mapping[str, tuple[float, ...]] | None = None,
     axis_coords: Mapping[str, tuple[str, ...]] | None = None,
+    axis_types: Mapping[str, str] | None = None,
 ) -> ast.expr:
     """Lower a :class:`Reduce` node to ``np.sum(body, axis=...)``.
 
@@ -364,6 +501,7 @@ def _lower_reduce(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915
 
     weights_map: Mapping[str, tuple[float, ...]] = axis_weights or {}
     coords_map: Mapping[str, tuple[str, ...]] = axis_coords or {}
+    types_map: Mapping[str, str] = axis_types or {}
     filter_map: dict[str, tuple[str, ...]] = dict(expr.filters)
     force_integrate = expr.kind == "integrate_over" or expr.kernel == "integrate"
     force_sum = expr.kernel == "sum"
@@ -399,14 +537,25 @@ def _lower_reduce(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915
         reducible_axes=reducible_axes,
         axis_weights=axis_weights,
         axis_coords=axis_coords,
+        axis_types=axis_types,
     )
 
-    # Resolve per-axis filter coord lists to integer indices. v1 lowering
-    # supports the categorical/ordinal-subset case where every filter coord
-    # is an exact label in the axis's declared coords. Continuous-range
-    # filters (numeric ``[lo, hi]`` re-grid) and ordinal label-range
-    # filters fall back to the legacy string-expansion path.
+    # Resolve per-axis filter coord lists to integer indices. The
+    # interpretation depends on the axis type carried in ``axis_types``
+    # (mirroring :func:`_normalize._build_apply_along_axis_options`):
+    #
+    # * ``categorical`` (or unknown type): exact-label subset \u2014 every
+    #   filter coord must appear in the axis's declared coord list.
+    # * ``ordinal``: filter must be exactly ``[lo_label, hi_label]``;
+    #   resolves to the inclusive index range ``index(lo)..index(hi)``.
+    # * ``continuous``: filter must be exactly ``[lo, hi]`` numeric
+    #   endpoints; resolves to declared coords ``c`` with
+    #   ``lo <= float(c) <= hi``. When the axis is also weighted, the
+    #   integration weights for the sub-interval are recomputed via the
+    #   trapezoidal rule on the selected coords (not sub-selected from
+    #   the original axis weights).
     filter_indices: dict[str, tuple[int, ...]] = {}
+    filter_subinterval_weights: dict[str, tuple[float, ...]] = {}
     for ax, coords in filter_map.items():
         if ax not in bound_axes:
             msg = f"Reduce filter for axis {ax!r} has no matching binding"
@@ -418,15 +567,28 @@ def _lower_reduce(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915
             )
             raise UnsupportedIRLoweringError(msg)
         declared = coords_map[ax]
-        try:
-            indices = tuple(declared.index(c) for c in coords)
-        except ValueError:
-            msg = (
-                f"Reduce filter {ax}={list(coords)} contains coord(s) not "
-                f"declared on axis {ax!r}; v1 lowering only supports exact "
-                "subsets of the declared coords"
+        ax_type = types_map.get(ax, "categorical")
+        if ax_type == "ordinal":
+            indices = _resolve_ordinal_range_filter(ax, declared, coords)
+        elif ax_type == "continuous":
+            indices, sub_weights = _resolve_continuous_range_filter(
+                ax,
+                declared,
+                coords,
+                recompute_trapezoidal=ax in weighted_axes,
             )
-            raise UnsupportedIRLoweringError(msg) from None
+            if sub_weights is not None:
+                filter_subinterval_weights[ax] = sub_weights
+        else:
+            try:
+                indices = tuple(declared.index(c) for c in coords)
+            except ValueError:
+                msg = (
+                    f"Reduce filter {ax}={list(coords)} contains coord(s) "
+                    f"not declared on axis {ax!r}; categorical filters "
+                    "require an exact subset of the declared coords"
+                )
+                raise UnsupportedIRLoweringError(msg) from None
         filter_indices[ax] = indices
 
     for ax, indices in filter_indices.items():
@@ -445,8 +607,14 @@ def _lower_reduce(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915
 
     for ax in weighted_axes:
         weights = weights_map[ax]
-        if ax in filter_indices:
-            # Sub-select weights to match the filtered slice.
+        if ax in filter_subinterval_weights:
+            # Continuous-axis sub-interval integration uses freshly
+            # recomputed trapezoidal weights, not the original axis
+            # weights indexed by position.
+            weights = filter_subinterval_weights[ax]
+        elif ax in filter_indices:
+            # Categorical / ordinal filter: sub-select the original
+            # uniform-or-weighted vector to match the slice.
             weights = tuple(weights[i] for i in filter_indices[ax])
         body_ast = ast.BinOp(
             left=_weight_constant_for_axis(
@@ -573,6 +741,7 @@ def _lower_apply(  # noqa: PLR0913
     reducible_axes: frozenset[str] = frozenset(),
     axis_weights: Mapping[str, tuple[float, ...]] | None = None,
     axis_coords: Mapping[str, tuple[str, ...]] | None = None,
+    axis_types: Mapping[str, str] | None = None,
 ) -> ast.expr:
     def lower(child: Expr) -> ast.expr:
         return lower_to_vector_ast(
@@ -583,6 +752,7 @@ def _lower_apply(  # noqa: PLR0913
             reducible_axes=reducible_axes,
             axis_weights=axis_weights,
             axis_coords=axis_coords,
+            axis_types=axis_types,
         )
 
     if expr.op == "neg" and len(expr.args) == 1:

--- a/src/op_system/_ir_lower.py
+++ b/src/op_system/_ir_lower.py
@@ -219,7 +219,7 @@ def _transpose(node: ast.expr, perm: tuple[int, ...]) -> ast.expr:
 # ---------------------------------------------------------------------------
 
 
-def lower_to_vector_ast(
+def lower_to_vector_ast(  # noqa: PLR0913
     expr: Expr,
     *,
     target_axes: tuple[str, ...],
@@ -227,6 +227,7 @@ def lower_to_vector_ast(
     axis_names: frozenset[str],
     reducible_axes: frozenset[str] = frozenset(),
     axis_weights: Mapping[str, tuple[float, ...]] | None = None,
+    axis_coords: Mapping[str, tuple[str, ...]] | None = None,
 ) -> ast.expr:
     """Lower an IR expression to a vector-shape AST.
 
@@ -253,6 +254,10 @@ def lower_to_vector_ast(
             for any bound axis not in ``reducible_axes``. When supplied,
             the reduction emits ``np.sum(weights * body, axis=...)``
             instead of a plain ``np.sum``.
+        axis_coords: Optional mapping from axis name to its declared
+            coord labels (as strings). Required when a :class:`Reduce`
+            carries non-empty ``filters`` so coord labels can be
+            resolved to integer indices for ``np.take`` slicing.
 
     Returns:
         An ``ast.expr`` suitable for ``compile(ast.Expression(body=...))``
@@ -291,6 +296,7 @@ def lower_to_vector_ast(
             axis_names=axis_names,
             reducible_axes=reducible_axes,
             axis_weights=axis_weights,
+            axis_coords=axis_coords,
         )
 
     return _lower_reduce(
@@ -300,16 +306,19 @@ def lower_to_vector_ast(
         axis_names=axis_names,
         reducible_axes=reducible_axes,
         axis_weights=axis_weights,
+        axis_coords=axis_coords,
     )
 
 
-_REDUCE_SUM_KINDS: frozenset[str] = frozenset(
-    {"apply_along", "sum_over", "integrate_over"}
-)
+_REDUCE_SUM_KINDS: frozenset[str] = frozenset({
+    "apply_along",
+    "sum_over",
+    "integrate_over",
+})
 _REDUCE_UNIFORM_KINDS: frozenset[str] = frozenset({"apply_along", "sum_over"})
 
 
-def _lower_reduce(
+def _lower_reduce(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915
     expr: Reduce,
     *,
     target_axes: tuple[str, ...],
@@ -317,6 +326,7 @@ def _lower_reduce(
     axis_names: frozenset[str],
     reducible_axes: frozenset[str],
     axis_weights: Mapping[str, tuple[float, ...]] | None = None,
+    axis_coords: Mapping[str, tuple[str, ...]] | None = None,
 ) -> ast.expr:
     """Lower a :class:`Reduce` node to ``np.sum(body, axis=...)``.
 
@@ -345,7 +355,18 @@ def _lower_reduce(
         )
         raise UnsupportedIRLoweringError(msg)
 
+    if expr.kernel is not None and expr.kernel not in {"sum", "integrate"}:
+        msg = (
+            f"Reduce kernel {expr.kernel!r} is not recognized; v1 lowering "
+            "supports kernel='sum' or kernel='integrate'"
+        )
+        raise UnsupportedIRLoweringError(msg)
+
     weights_map: Mapping[str, tuple[float, ...]] = axis_weights or {}
+    coords_map: Mapping[str, tuple[str, ...]] = axis_coords or {}
+    filter_map: dict[str, tuple[str, ...]] = dict(expr.filters)
+    force_integrate = expr.kind == "integrate_over" or expr.kernel == "integrate"
+    force_sum = expr.kernel == "sum"
     bound_axes: list[str] = []
     weighted_axes: list[str] = []
     rebind: dict[str, str] = {}
@@ -353,12 +374,12 @@ def _lower_reduce(
         if axis in bound_axes:
             msg = f"Reduce has duplicate axis binding {axis!r}"
             raise UnsupportedIRLoweringError(msg)
-        if expr.kind == "integrate_over" or axis not in reducible_axes:
+        if force_integrate or (not force_sum and axis not in reducible_axes):
             if axis not in weights_map:
                 msg = (
-                    f"Reduce binding {axis}={binding} (kind {expr.kind!r}) "
-                    f"requires integration weights for axis {axis!r}, but "
-                    "none were provided"
+                    f"Reduce binding {axis}={binding} (kind {expr.kind!r}, "
+                    f"kernel {expr.kernel!r}) requires integration weights "
+                    f"for axis {axis!r}, but none were provided"
                 )
                 raise UnsupportedIRLoweringError(msg)
             weighted_axes.append(axis)
@@ -377,13 +398,60 @@ def _lower_reduce(
         axis_names=axis_names,
         reducible_axes=reducible_axes,
         axis_weights=axis_weights,
+        axis_coords=axis_coords,
     )
 
+    # Resolve per-axis filter coord lists to integer indices. v1 lowering
+    # supports the categorical/ordinal-subset case where every filter coord
+    # is an exact label in the axis's declared coords. Continuous-range
+    # filters (numeric ``[lo, hi]`` re-grid) and ordinal label-range
+    # filters fall back to the legacy string-expansion path.
+    filter_indices: dict[str, tuple[int, ...]] = {}
+    for ax, coords in filter_map.items():
+        if ax not in bound_axes:
+            msg = f"Reduce filter for axis {ax!r} has no matching binding"
+            raise UnsupportedIRLoweringError(msg)
+        if ax not in coords_map:
+            msg = (
+                f"Reduce filter for axis {ax!r} requires axis_coords, but "
+                "none were provided"
+            )
+            raise UnsupportedIRLoweringError(msg)
+        declared = coords_map[ax]
+        try:
+            indices = tuple(declared.index(c) for c in coords)
+        except ValueError:
+            msg = (
+                f"Reduce filter {ax}={list(coords)} contains coord(s) not "
+                f"declared on axis {ax!r}; v1 lowering only supports exact "
+                "subsets of the declared coords"
+            )
+            raise UnsupportedIRLoweringError(msg) from None
+        filter_indices[ax] = indices
+
+    for ax, indices in filter_indices.items():
+        pos = extended_target.index(ax)
+        body_ast = ast.Call(
+            func=ast.Attribute(value=_name("np"), attr="take", ctx=ast.Load()),
+            args=[
+                body_ast,
+                ast.List(
+                    elts=[ast.Constant(value=i) for i in indices],
+                    ctx=ast.Load(),
+                ),
+            ],
+            keywords=[ast.keyword(arg="axis", value=ast.Constant(value=pos))],
+        )
+
     for ax in weighted_axes:
+        weights = weights_map[ax]
+        if ax in filter_indices:
+            # Sub-select weights to match the filtered slice.
+            weights = tuple(weights[i] for i in filter_indices[ax])
         body_ast = ast.BinOp(
             left=_weight_constant_for_axis(
                 ax,
-                weights=weights_map[ax],
+                weights=weights,
                 extended_target=extended_target,
             ),
             op=ast.Mult(),
@@ -415,6 +483,10 @@ def _weight_constant_for_axis(
 
     Returns a constant 1-D weights vector reshaped to broadcast along the
     position of ``axis`` within ``extended_target``.
+
+    Returns:
+        An AST expression that evaluates to the broadcast-shaped weights
+        constant.
     """
     pos = extended_target.index(axis)
     arr: ast.expr = ast.Call(
@@ -481,12 +553,18 @@ def _rebind_subscript_indices(  # noqa: PLR0911
         inner_rebind = {k: v for k, v in rebind.items() if k not in inner_bindings}
         new_body = _rebind_subscript_indices(expr.body, rebind=inner_rebind)
         if new_body is not expr.body:
-            return Reduce(kind=expr.kind, bindings=expr.bindings, body=new_body)
+            return Reduce(
+                kind=expr.kind,
+                bindings=expr.bindings,
+                body=new_body,
+                filters=expr.filters,
+                kernel=expr.kernel,
+            )
         return expr
     return expr
 
 
-def _lower_apply(
+def _lower_apply(  # noqa: PLR0913
     expr: Apply,
     *,
     target_axes: tuple[str, ...],
@@ -494,6 +572,7 @@ def _lower_apply(
     axis_names: frozenset[str],
     reducible_axes: frozenset[str] = frozenset(),
     axis_weights: Mapping[str, tuple[float, ...]] | None = None,
+    axis_coords: Mapping[str, tuple[str, ...]] | None = None,
 ) -> ast.expr:
     def lower(child: Expr) -> ast.expr:
         return lower_to_vector_ast(
@@ -503,6 +582,7 @@ def _lower_apply(
             axis_names=axis_names,
             reducible_axes=reducible_axes,
             axis_weights=axis_weights,
+            axis_coords=axis_coords,
         )
 
     if expr.op == "neg" and len(expr.args) == 1:

--- a/src/op_system/_ir_lower.py
+++ b/src/op_system/_ir_lower.py
@@ -226,6 +226,7 @@ def lower_to_vector_ast(
     buffer_axes: Mapping[str, tuple[str, ...]],
     axis_names: frozenset[str],
     reducible_axes: frozenset[str] = frozenset(),
+    axis_weights: Mapping[str, tuple[float, ...]] | None = None,
 ) -> ast.expr:
     """Lower an IR expression to a vector-shape AST.
 
@@ -246,6 +247,12 @@ def lower_to_vector_ast(
             :class:`Reduce` node. Typically the set of categorical/ordinal
             axes (uniform-weight kernel). Empty by default — when empty,
             any :class:`Reduce` raises :class:`UnsupportedIRLoweringError`.
+        axis_weights: Optional mapping from axis name to per-coordinate
+            integration weights (e.g. trapezoidal deltas) for continuous
+            axes. Required for ``Reduce(kind="integrate_over", ...)`` and
+            for any bound axis not in ``reducible_axes``. When supplied,
+            the reduction emits ``np.sum(weights * body, axis=...)``
+            instead of a plain ``np.sum``.
 
     Returns:
         An ``ast.expr`` suitable for ``compile(ast.Expression(body=...))``
@@ -283,6 +290,7 @@ def lower_to_vector_ast(
             buffer_axes=buffer_axes,
             axis_names=axis_names,
             reducible_axes=reducible_axes,
+            axis_weights=axis_weights,
         )
 
     return _lower_reduce(
@@ -291,10 +299,14 @@ def lower_to_vector_ast(
         buffer_axes=buffer_axes,
         axis_names=axis_names,
         reducible_axes=reducible_axes,
+        axis_weights=axis_weights,
     )
 
 
-_REDUCE_SUM_KINDS: frozenset[str] = frozenset({"apply_along", "sum_over"})
+_REDUCE_SUM_KINDS: frozenset[str] = frozenset(
+    {"apply_along", "sum_over", "integrate_over"}
+)
+_REDUCE_UNIFORM_KINDS: frozenset[str] = frozenset({"apply_along", "sum_over"})
 
 
 def _lower_reduce(
@@ -304,46 +316,52 @@ def _lower_reduce(
     buffer_axes: Mapping[str, tuple[str, ...]],
     axis_names: frozenset[str],
     reducible_axes: frozenset[str],
+    axis_weights: Mapping[str, tuple[float, ...]] | None = None,
 ) -> ast.expr:
     """Lower a :class:`Reduce` node to ``np.sum(body, axis=...)``.
 
-    Restricted to uniform-weight kernels (``apply_along`` / ``sum_over``)
-    over axes that appear in ``reducible_axes`` — i.e. categorical or
-    ordinal axes where the reduction collapses to a plain sum. The
-    ``integrate_over`` kind and any continuous-axis binding raise
-    :class:`UnsupportedIRLoweringError` so callers fall back to the
-    legacy string-expansion path.
+    Supports uniform-weight kernels (``apply_along`` / ``sum_over``) over
+    axes in ``reducible_axes`` and shaped-weight kernels
+    (``integrate_over``, or any binding whose axis appears in
+    ``axis_weights``). For weighted bindings, emits
+    ``np.sum(weights * body, axis=...)`` with per-axis weight constants
+    baked into the AST as ``np.array([...])`` factors broadcast into
+    position.
 
     Returns:
-        An ``ast.expr`` invoking ``np.sum`` on the lowered body, with the
-        bound axes collapsed.
+        An ``ast.expr`` invoking ``np.sum`` on the (possibly
+        weight-scaled) lowered body, with the bound axes collapsed.
 
     Raises:
-        UnsupportedIRLoweringError: If ``expr.kind`` is not a uniform-sum
-            kind, if any bound axis is not in ``reducible_axes``, or if
-            the body itself violates the v1 lowering subset.
+        UnsupportedIRLoweringError: If ``expr.kind`` is not a recognized
+            sum kind, if a binding requires weights but none were
+            provided, if a uniform binding targets a non-reducible axis,
+            or if the body itself violates the v1 lowering subset.
     """
     if expr.kind not in _REDUCE_SUM_KINDS:
         msg = (
-            f"Reduce kind {expr.kind!r} requires shaped weights; v1 "
-            "lowering supports only uniform-weight reductions "
-            f"({sorted(_REDUCE_SUM_KINDS)})"
+            f"Reduce kind {expr.kind!r} is not a recognized sum kind; v1 "
+            f"lowering supports {sorted(_REDUCE_SUM_KINDS)}"
         )
         raise UnsupportedIRLoweringError(msg)
 
+    weights_map: Mapping[str, tuple[float, ...]] = axis_weights or {}
     bound_axes: list[str] = []
+    weighted_axes: list[str] = []
     rebind: dict[str, str] = {}
     for axis, binding in expr.bindings:
-        if axis not in reducible_axes:
-            msg = (
-                f"Reduce binding {axis}={binding} targets a non-reducible "
-                "axis (likely continuous) — v1 lowering supports "
-                "uniform-weight categorical reductions only"
-            )
-            raise UnsupportedIRLoweringError(msg)
         if axis in bound_axes:
             msg = f"Reduce has duplicate axis binding {axis!r}"
             raise UnsupportedIRLoweringError(msg)
+        if expr.kind == "integrate_over" or axis not in reducible_axes:
+            if axis not in weights_map:
+                msg = (
+                    f"Reduce binding {axis}={binding} (kind {expr.kind!r}) "
+                    f"requires integration weights for axis {axis!r}, but "
+                    "none were provided"
+                )
+                raise UnsupportedIRLoweringError(msg)
+            weighted_axes.append(axis)
         bound_axes.append(axis)
         rebind[binding] = axis
 
@@ -358,7 +376,19 @@ def _lower_reduce(
         buffer_axes=buffer_axes,
         axis_names=axis_names,
         reducible_axes=reducible_axes,
+        axis_weights=axis_weights,
     )
+
+    for ax in weighted_axes:
+        body_ast = ast.BinOp(
+            left=_weight_constant_for_axis(
+                ax,
+                weights=weights_map[ax],
+                extended_target=extended_target,
+            ),
+            op=ast.Mult(),
+            right=body_ast,
+        )
 
     reduce_positions = tuple(extended_target.index(ax) for ax in bound_axes)
     if len(reduce_positions) == 1:
@@ -372,6 +402,44 @@ def _lower_reduce(
         func=ast.Attribute(value=_name("np"), attr="sum", ctx=ast.Load()),
         args=[body_ast],
         keywords=[ast.keyword(arg="axis", value=axis_arg)],
+    )
+
+
+def _weight_constant_for_axis(
+    axis: str,
+    *,
+    weights: tuple[float, ...],
+    extended_target: tuple[str, ...],
+) -> ast.expr:
+    """Build ``np.array([w0, w1, ...])[None, ..., :, ..., None]`` for ``axis``.
+
+    Returns a constant 1-D weights vector reshaped to broadcast along the
+    position of ``axis`` within ``extended_target``.
+    """
+    pos = extended_target.index(axis)
+    arr: ast.expr = ast.Call(
+        func=ast.Attribute(value=_name("np"), attr="array", ctx=ast.Load()),
+        args=[
+            ast.List(
+                elts=[ast.Constant(value=float(w)) for w in weights],
+                ctx=ast.Load(),
+            )
+        ],
+        keywords=[],
+    )
+    n = len(extended_target)
+    if n == 1:
+        return arr
+    elts: list[ast.expr] = []
+    for i in range(n):
+        if i == pos:
+            elts.append(ast.Slice(lower=None, upper=None, step=None))
+        else:
+            elts.append(ast.Constant(value=None))
+    return ast.Subscript(
+        value=arr,
+        slice=ast.Tuple(elts=elts, ctx=ast.Load()),
+        ctx=ast.Load(),
     )
 
 
@@ -425,6 +493,7 @@ def _lower_apply(
     buffer_axes: Mapping[str, tuple[str, ...]],
     axis_names: frozenset[str],
     reducible_axes: frozenset[str] = frozenset(),
+    axis_weights: Mapping[str, tuple[float, ...]] | None = None,
 ) -> ast.expr:
     def lower(child: Expr) -> ast.expr:
         return lower_to_vector_ast(
@@ -433,6 +502,7 @@ def _lower_apply(
             buffer_axes=buffer_axes,
             axis_names=axis_names,
             reducible_axes=reducible_axes,
+            axis_weights=axis_weights,
         )
 
     if expr.op == "neg" and len(expr.args) == 1:

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -587,6 +587,7 @@ def _try_ir_fast_path(
     name_to_template: Mapping[str, _BufferTemplate],
     axis_index: Mapping[str, Mapping[str, int]],
     reducible_axes: frozenset[str] = frozenset(),
+    axis_weights: Mapping[str, tuple[float, ...]] | None = None,
 ) -> ast.Expression | None:
     """Attempt to lower per-cell IR straight to a vector AST.
 
@@ -623,6 +624,7 @@ def _try_ir_fast_path(
             buffer_axes=buffer_axes,
             axis_names=frozenset(axis_index.keys()),
             reducible_axes=reducible_axes,
+            axis_weights=axis_weights,
         )
     except UnsupportedIRLoweringError:
         return None
@@ -642,6 +644,7 @@ def _rewrite_cell_to_vector(  # noqa: PLR0913
     name_to_coords: Mapping[str, Mapping[str, str]],
     axis_index: Mapping[str, Mapping[str, int]],
     reducible_axes: frozenset[str] = frozenset(),
+    axis_weights: Mapping[str, tuple[float, ...]] | None = None,
     shaped_param_axes: Mapping[str, tuple[str, ...]] | None = None,
 ) -> ast.Expression:
     """Rewrite a per-cell expression string into a shaped buffer expression.
@@ -668,6 +671,7 @@ def _rewrite_cell_to_vector(  # noqa: PLR0913
             name_to_template=name_to_template,
             axis_index=axis_index,
             reducible_axes=reducible_axes,
+            axis_weights=axis_weights,
         )
         if fast is not None:
             return fast
@@ -678,6 +682,7 @@ def _rewrite_cell_to_vector(  # noqa: PLR0913
             name_to_template=name_to_template,
             axis_index=axis_index,
             reducible_axes=reducible_axes,
+            axis_weights=axis_weights,
         )
         if fast is not None:
             return fast
@@ -1224,6 +1229,7 @@ def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR
     name_to_coords: Mapping[str, Mapping[str, str]],
     axis_index: Mapping[str, Mapping[str, int]],
     reducible_axes: frozenset[str] = frozenset(),
+    axis_weights: Mapping[str, tuple[float, ...]] | None = None,
     shaped_param_axes: Mapping[str, tuple[str, ...]] | None = None,
 ) -> (
     tuple[
@@ -1334,6 +1340,7 @@ def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR
                     name_to_coords=name_to_coords,
                     axis_index=axis_index,
                     reducible_axes=reducible_axes,
+                    axis_weights=axis_weights,
                     shaped_param_axes=shaped_param_axes,
                 )
             except (ValueError, RuntimeError):
@@ -1353,6 +1360,7 @@ def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR
                         name_to_coords=name_to_coords,
                         axis_index=axis_index,
                         reducible_axes=reducible_axes,
+                        axis_weights=axis_weights,
                         shaped_param_axes=shaped_param_axes,
                     )
                 except (ValueError, RuntimeError):
@@ -1456,6 +1464,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
 
     axes_pairs: list[tuple[str, list[str]]] = []
     reducible_axes_set: set[str] = set()
+    axis_weights: dict[str, tuple[float, ...]] = {}
     for ax in axes_meta:
         if not isinstance(ax, Mapping):
             return None
@@ -1473,6 +1482,9 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
         ax_type = str(ax.get("type", "categorical")).strip().lower()
         if ax_type in {"categorical", "ordinal"}:
             reducible_axes_set.add(ax["name"])
+        deltas = ax.get("deltas")
+        if deltas:
+            axis_weights[ax["name"]] = tuple(float(d) for d in deltas)
     axis_index = {ax: {c: i for i, c in enumerate(coords)} for ax, coords in axes_pairs}
     reducible_axes = frozenset(reducible_axes_set)
 
@@ -1563,6 +1575,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
                     name_to_coords=name_to_coords,
                     axis_index=axis_index,
                     reducible_axes=reducible_axes,
+                    axis_weights=axis_weights,
                     shaped_param_axes=shaped_param_axes,
                 )
                 if len(buf.expanded_names) > 1:
@@ -1578,6 +1591,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
                         name_to_coords=name_to_coords,
                         axis_index=axis_index,
                         reducible_axes=reducible_axes,
+                        axis_weights=axis_weights,
                         shaped_param_axes=shaped_param_axes,
                     )
                     if ast.dump(tree) != ast.dump(last_tree):
@@ -1595,6 +1609,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
                     name_to_coords=name_to_coords,
                     axis_index=axis_index,
                     reducible_axes=reducible_axes,
+                    axis_weights=axis_weights,
                     shaped_param_axes=shaped_param_axes,
                 )
             tree = _distribute_const_over_add(tree)
@@ -1616,6 +1631,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
             name_to_coords=name_to_coords,
             axis_index=axis_index,
             reducible_axes=reducible_axes,
+            axis_weights=axis_weights,
             shaped_param_axes=shaped_param_axes,
         )
         if result is None:

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -589,6 +589,7 @@ def _try_ir_fast_path(  # noqa: PLR0913
     reducible_axes: frozenset[str] = frozenset(),
     axis_weights: Mapping[str, tuple[float, ...]] | None = None,
     axis_coords: Mapping[str, tuple[str, ...]] | None = None,
+    axis_types: Mapping[str, str] | None = None,
 ) -> ast.Expression | None:
     """Attempt to lower per-cell IR straight to a vector AST.
 
@@ -627,6 +628,7 @@ def _try_ir_fast_path(  # noqa: PLR0913
             reducible_axes=reducible_axes,
             axis_weights=axis_weights,
             axis_coords=axis_coords,
+            axis_types=axis_types,
         )
     except UnsupportedIRLoweringError:
         return None
@@ -648,6 +650,7 @@ def _rewrite_cell_to_vector(  # noqa: PLR0913
     reducible_axes: frozenset[str] = frozenset(),
     axis_weights: Mapping[str, tuple[float, ...]] | None = None,
     axis_coords: Mapping[str, tuple[str, ...]] | None = None,
+    axis_types: Mapping[str, str] | None = None,
     shaped_param_axes: Mapping[str, tuple[str, ...]] | None = None,
 ) -> ast.Expression:
     """Rewrite a per-cell expression string into a shaped buffer expression.
@@ -676,6 +679,7 @@ def _rewrite_cell_to_vector(  # noqa: PLR0913
             reducible_axes=reducible_axes,
             axis_weights=axis_weights,
             axis_coords=axis_coords,
+            axis_types=axis_types,
         )
         if fast is not None:
             return fast
@@ -688,6 +692,7 @@ def _rewrite_cell_to_vector(  # noqa: PLR0913
             reducible_axes=reducible_axes,
             axis_weights=axis_weights,
             axis_coords=axis_coords,
+            axis_types=axis_types,
         )
         if fast is not None:
             return fast
@@ -1236,6 +1241,7 @@ def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR
     reducible_axes: frozenset[str] = frozenset(),
     axis_weights: Mapping[str, tuple[float, ...]] | None = None,
     axis_coords: Mapping[str, tuple[str, ...]] | None = None,
+    axis_types: Mapping[str, str] | None = None,
     shaped_param_axes: Mapping[str, tuple[str, ...]] | None = None,
 ) -> (
     tuple[
@@ -1348,6 +1354,7 @@ def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR
                     reducible_axes=reducible_axes,
                     axis_weights=axis_weights,
                     axis_coords=axis_coords,
+                    axis_types=axis_types,
                     shaped_param_axes=shaped_param_axes,
                 )
             except (ValueError, RuntimeError):
@@ -1369,6 +1376,7 @@ def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR
                         reducible_axes=reducible_axes,
                         axis_weights=axis_weights,
                         axis_coords=axis_coords,
+                        axis_types=axis_types,
                         shaped_param_axes=shaped_param_axes,
                     )
                 except (ValueError, RuntimeError):
@@ -1473,6 +1481,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
     axes_pairs: list[tuple[str, list[str]]] = []
     reducible_axes_set: set[str] = set()
     axis_weights: dict[str, tuple[float, ...]] = {}
+    axis_types: dict[str, str] = {}
     for ax in axes_meta:
         if not isinstance(ax, Mapping):
             return None
@@ -1488,6 +1497,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
         # ``str(float)``, causing ``KeyError`` in ``_build_access_ast``.
         axes_pairs.append((ax["name"], [str(c) for c in coords]))
         ax_type = str(ax.get("type", "categorical")).strip().lower()
+        axis_types[ax["name"]] = ax_type
         if ax_type in {"categorical", "ordinal"}:
             reducible_axes_set.add(ax["name"])
         deltas = ax.get("deltas")
@@ -1588,6 +1598,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
                     reducible_axes=reducible_axes,
                     axis_weights=axis_weights,
                     axis_coords=axis_coords,
+                    axis_types=axis_types,
                     shaped_param_axes=shaped_param_axes,
                 )
                 if len(buf.expanded_names) > 1:
@@ -1605,6 +1616,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
                         reducible_axes=reducible_axes,
                         axis_weights=axis_weights,
                         axis_coords=axis_coords,
+                        axis_types=axis_types,
                         shaped_param_axes=shaped_param_axes,
                     )
                     if ast.dump(tree) != ast.dump(last_tree):
@@ -1624,6 +1636,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
                     reducible_axes=reducible_axes,
                     axis_weights=axis_weights,
                     axis_coords=axis_coords,
+                    axis_types=axis_types,
                     shaped_param_axes=shaped_param_axes,
                 )
             tree = _distribute_const_over_add(tree)
@@ -1647,6 +1660,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
             reducible_axes=reducible_axes,
             axis_weights=axis_weights,
             axis_coords=axis_coords,
+            axis_types=axis_types,
             shaped_param_axes=shaped_param_axes,
         )
         if result is None:

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -580,7 +580,7 @@ class _NameRewriter(ast.NodeTransformer):
         )
 
 
-def _try_ir_fast_path(
+def _try_ir_fast_path(  # noqa: PLR0913
     expr_ir: Expr,
     *,
     target_axes: tuple[str, ...],
@@ -588,6 +588,7 @@ def _try_ir_fast_path(
     axis_index: Mapping[str, Mapping[str, int]],
     reducible_axes: frozenset[str] = frozenset(),
     axis_weights: Mapping[str, tuple[float, ...]] | None = None,
+    axis_coords: Mapping[str, tuple[str, ...]] | None = None,
 ) -> ast.Expression | None:
     """Attempt to lower per-cell IR straight to a vector AST.
 
@@ -625,6 +626,7 @@ def _try_ir_fast_path(
             axis_names=frozenset(axis_index.keys()),
             reducible_axes=reducible_axes,
             axis_weights=axis_weights,
+            axis_coords=axis_coords,
         )
     except UnsupportedIRLoweringError:
         return None
@@ -645,6 +647,7 @@ def _rewrite_cell_to_vector(  # noqa: PLR0913
     axis_index: Mapping[str, Mapping[str, int]],
     reducible_axes: frozenset[str] = frozenset(),
     axis_weights: Mapping[str, tuple[float, ...]] | None = None,
+    axis_coords: Mapping[str, tuple[str, ...]] | None = None,
     shaped_param_axes: Mapping[str, tuple[str, ...]] | None = None,
 ) -> ast.Expression:
     """Rewrite a per-cell expression string into a shaped buffer expression.
@@ -672,6 +675,7 @@ def _rewrite_cell_to_vector(  # noqa: PLR0913
             axis_index=axis_index,
             reducible_axes=reducible_axes,
             axis_weights=axis_weights,
+            axis_coords=axis_coords,
         )
         if fast is not None:
             return fast
@@ -683,6 +687,7 @@ def _rewrite_cell_to_vector(  # noqa: PLR0913
             axis_index=axis_index,
             reducible_axes=reducible_axes,
             axis_weights=axis_weights,
+            axis_coords=axis_coords,
         )
         if fast is not None:
             return fast
@@ -1230,6 +1235,7 @@ def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR
     axis_index: Mapping[str, Mapping[str, int]],
     reducible_axes: frozenset[str] = frozenset(),
     axis_weights: Mapping[str, tuple[float, ...]] | None = None,
+    axis_coords: Mapping[str, tuple[str, ...]] | None = None,
     shaped_param_axes: Mapping[str, tuple[str, ...]] | None = None,
 ) -> (
     tuple[
@@ -1341,6 +1347,7 @@ def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR
                     axis_index=axis_index,
                     reducible_axes=reducible_axes,
                     axis_weights=axis_weights,
+                    axis_coords=axis_coords,
                     shaped_param_axes=shaped_param_axes,
                 )
             except (ValueError, RuntimeError):
@@ -1361,6 +1368,7 @@ def _vectorize_template_equations(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR
                         axis_index=axis_index,
                         reducible_axes=reducible_axes,
                         axis_weights=axis_weights,
+                        axis_coords=axis_coords,
                         shaped_param_axes=shaped_param_axes,
                     )
                 except (ValueError, RuntimeError):
@@ -1486,6 +1494,9 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
         if deltas:
             axis_weights[ax["name"]] = tuple(float(d) for d in deltas)
     axis_index = {ax: {c: i for i, c in enumerate(coords)} for ax, coords in axes_pairs}
+    axis_coords: dict[str, tuple[str, ...]] = {
+        ax: tuple(coords) for ax, coords in axes_pairs
+    }
     reducible_axes = frozenset(reducible_axes_set)
 
     state_buffers: list[_BufferTemplate] = []
@@ -1576,6 +1587,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
                     axis_index=axis_index,
                     reducible_axes=reducible_axes,
                     axis_weights=axis_weights,
+                    axis_coords=axis_coords,
                     shaped_param_axes=shaped_param_axes,
                 )
                 if len(buf.expanded_names) > 1:
@@ -1592,6 +1604,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
                         axis_index=axis_index,
                         reducible_axes=reducible_axes,
                         axis_weights=axis_weights,
+                        axis_coords=axis_coords,
                         shaped_param_axes=shaped_param_axes,
                     )
                     if ast.dump(tree) != ast.dump(last_tree):
@@ -1610,6 +1623,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
                     axis_index=axis_index,
                     reducible_axes=reducible_axes,
                     axis_weights=axis_weights,
+                    axis_coords=axis_coords,
                     shaped_param_axes=shaped_param_axes,
                 )
             tree = _distribute_const_over_add(tree)
@@ -1632,6 +1646,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
             axis_index=axis_index,
             reducible_axes=reducible_axes,
             axis_weights=axis_weights,
+            axis_coords=axis_coords,
             shaped_param_axes=shaped_param_axes,
         )
         if result is None:

--- a/tests/op_system/test_op_system_ir.py
+++ b/tests/op_system/test_op_system_ir.py
@@ -201,9 +201,7 @@ def test_lower_helper_recognizes_categorical_filter() -> None:
 
 def test_lower_helper_recognizes_continuous_range_filter() -> None:
     """Numeric coord lists are preserved as string filter coords."""
-    ir = parse_expr_to_ir(
-        "apply_along(u[x:i], x=i in [1.0, 4.0])", lower_helpers=True
-    )
+    ir = parse_expr_to_ir("apply_along(u[x:i], x=i in [1.0, 4.0])", lower_helpers=True)
 
     assert isinstance(ir, Reduce)
     assert ir.bindings == (("x", "i"),)
@@ -225,9 +223,7 @@ def test_lower_helper_recognizes_kernel_kwarg() -> None:
 def test_lower_helper_rejects_unknown_kernel() -> None:
     """``kernel=`` only accepts ``sum`` or ``integrate``."""
     with pytest.raises(InvalidExpressionError):
-        parse_expr_to_ir(
-            "apply_along(u[x:i], x=i, kernel=median)", lower_helpers=True
-        )
+        parse_expr_to_ir("apply_along(u[x:i], x=i, kernel=median)", lower_helpers=True)
 
 
 def test_lower_helper_combines_binding_and_filter_across_axes() -> None:

--- a/tests/op_system/test_op_system_ir.py
+++ b/tests/op_system/test_op_system_ir.py
@@ -184,3 +184,59 @@ def test_extract_common_subexpressions_skips_reserved_names() -> None:
 
     assert bindings == (("_cse1", parse_expr_to_ir("a + b")),)
     assert rewritten == (parse_expr_to_ir("_cse1 * _cse1"),)
+
+
+def test_lower_helper_recognizes_categorical_filter() -> None:
+    """``axis=var in [c1, c2, ...]`` lowers into ``Reduce.filters``."""
+    ir = parse_expr_to_ir(
+        "apply_along(pop[vax:j], vax=j in [v, w])", lower_helpers=True
+    )
+
+    assert isinstance(ir, Reduce)
+    assert ir.kind == "apply_along"
+    assert ir.bindings == (("vax", "j"),)
+    assert ir.filters == (("vax", ("v", "w")),)
+    assert ir.kernel is None
+
+
+def test_lower_helper_recognizes_continuous_range_filter() -> None:
+    """Numeric coord lists are preserved as string filter coords."""
+    ir = parse_expr_to_ir(
+        "apply_along(u[x:i], x=i in [1.0, 4.0])", lower_helpers=True
+    )
+
+    assert isinstance(ir, Reduce)
+    assert ir.bindings == (("x", "i"),)
+    assert ir.filters == (("x", ("1.0", "4.0")),)
+
+
+def test_lower_helper_recognizes_kernel_kwarg() -> None:
+    """``kernel=sum|integrate`` sets ``Reduce.kernel`` without a binding."""
+    ir = parse_expr_to_ir(
+        "apply_along(u[x:i], x=i, kernel=integrate)", lower_helpers=True
+    )
+
+    assert isinstance(ir, Reduce)
+    assert ir.bindings == (("x", "i"),)
+    assert ir.filters == ()
+    assert ir.kernel == "integrate"
+
+
+def test_lower_helper_rejects_unknown_kernel() -> None:
+    """``kernel=`` only accepts ``sum`` or ``integrate``."""
+    with pytest.raises(InvalidExpressionError):
+        parse_expr_to_ir(
+            "apply_along(u[x:i], x=i, kernel=median)", lower_helpers=True
+        )
+
+
+def test_lower_helper_combines_binding_and_filter_across_axes() -> None:
+    """Multi-axis helpers can mix plain bindings and filtered ones."""
+    ir = parse_expr_to_ir(
+        "apply_along(I[age:a, vax:b], age=a, vax=b in [v, w])",
+        lower_helpers=True,
+    )
+
+    assert isinstance(ir, Reduce)
+    assert ir.bindings == (("age", "a"), ("vax", "b"))
+    assert ir.filters == (("vax", ("v", "w")),)

--- a/tests/op_system/test_op_system_ir_lower.py
+++ b/tests/op_system/test_op_system_ir_lower.py
@@ -584,3 +584,192 @@ def test_lower_apply_along_categorical_filter_with_continuous_weighted_axis() ->
     got = _eval(node, {"f_buf": f_buf, "np": np})
     # Take indices [0, 2]; weights become (1.0, 3.0); sum = 1*10 + 3*30 = 100
     assert got == pytest.approx(100.0)
+
+
+def test_lower_apply_along_ordinal_range_filter() -> None:
+    """Ordinal axis_types maps ``[lo, hi]`` to an inclusive index range."""
+    body = Subscript(
+        name="pop",
+        indices=(AxisIndex(axis="imm", kind=AxisKind.FREE),),
+    )
+    expr = Reduce(
+        kind="apply_along",
+        bindings=(("imm", "k"),),
+        body=body,
+        filters=(("imm", ("X1", "X3")),),
+    )
+    node = lower_to_vector_ast(
+        expr,
+        target_axes=(),
+        buffer_axes={"pop": ("imm",)},
+        axis_names=frozenset({"imm"}),
+        reducible_axes=frozenset({"imm"}),
+        axis_coords={"imm": ("X0", "X1", "X2", "X3", "X4")},
+        axis_types={"imm": "ordinal"},
+    )
+    pop_buf = np.array([1.0, 2.0, 4.0, 8.0, 16.0])
+    got = _eval(node, {"pop_buf": pop_buf, "np": np})
+    # Inclusive index range [1, 3] -> 2.0 + 4.0 + 8.0
+    assert got == pytest.approx(14.0)
+
+
+def test_lower_apply_along_ordinal_range_filter_rejects_non_pair() -> None:
+    """An ordinal-axis filter must be exactly ``[lo, hi]``."""
+    body = Subscript(
+        name="pop",
+        indices=(AxisIndex(axis="imm", kind=AxisKind.FREE),),
+    )
+    expr = Reduce(
+        kind="apply_along",
+        bindings=(("imm", "k"),),
+        body=body,
+        filters=(("imm", ("X0", "X1", "X2")),),
+    )
+    with pytest.raises(UnsupportedIRLoweringError, match="2-element"):
+        lower_to_vector_ast(
+            expr,
+            target_axes=(),
+            buffer_axes={"pop": ("imm",)},
+            axis_names=frozenset({"imm"}),
+            reducible_axes=frozenset({"imm"}),
+            axis_coords={"imm": ("X0", "X1", "X2", "X3")},
+            axis_types={"imm": "ordinal"},
+        )
+
+
+def test_lower_apply_along_ordinal_range_filter_rejects_reversed() -> None:
+    """An ordinal-axis filter with ``index(lo) > index(hi)`` is rejected."""
+    body = Subscript(
+        name="pop",
+        indices=(AxisIndex(axis="imm", kind=AxisKind.FREE),),
+    )
+    expr = Reduce(
+        kind="apply_along",
+        bindings=(("imm", "k"),),
+        body=body,
+        filters=(("imm", ("X3", "X1")),),
+    )
+    with pytest.raises(UnsupportedIRLoweringError, match="index"):
+        lower_to_vector_ast(
+            expr,
+            target_axes=(),
+            buffer_axes={"pop": ("imm",)},
+            axis_names=frozenset({"imm"}),
+            reducible_axes=frozenset({"imm"}),
+            axis_coords={"imm": ("X0", "X1", "X2", "X3")},
+            axis_types={"imm": "ordinal"},
+        )
+
+
+def test_lower_apply_along_continuous_range_filter_uniform_sum() -> None:
+    """Continuous ``[lo, hi]`` filter with kernel='sum' selects coords unweighted."""
+    body = Subscript(
+        name="f",
+        indices=(AxisIndex(axis="x", kind=AxisKind.FREE),),
+    )
+    expr = Reduce(
+        kind="apply_along",
+        bindings=(("x", "i"),),
+        body=body,
+        filters=(("x", ("1.0", "3.0")),),
+        kernel="sum",
+    )
+    node = lower_to_vector_ast(
+        expr,
+        target_axes=(),
+        buffer_axes={"f": ("x",)},
+        axis_names=frozenset({"x"}),
+        reducible_axes=frozenset(),
+        axis_weights={"x": (0.5, 1.5, 1.0, 0.5)},  # ignored due to kernel='sum'
+        axis_coords={"x": ("0.0", "1.0", "3.0", "4.0")},
+        axis_types={"x": "continuous"},
+    )
+    f_buf = np.array([1.0, 2.0, 4.0, 8.0])
+    got = _eval(node, {"f_buf": f_buf, "np": np})
+    # Coords 1.0 and 3.0 are in [1.0, 3.0] -> 2.0 + 4.0 = 6.0
+    assert got == pytest.approx(6.0)
+
+
+def test_lower_apply_along_continuous_range_filter_integrate_recomputes_weights() -> (
+    None
+):
+    """Continuous-axis filter under integrate kernel recomputes trapezoidal weights."""
+    body = Subscript(
+        name="f",
+        indices=(AxisIndex(axis="x", kind=AxisKind.FREE),),
+    )
+    # Mirrors test_apply_along_continuous_filter_recomputes_trapezoidal_deltas:
+    # declared coords [0.0, 1.0, 3.0, 4.0], filter [1.0, 4.0] -> sub-coords
+    # [1.0, 3.0, 4.0], trapezoidal weights [1.0, 1.5, 0.5].
+    expr = Reduce(
+        kind="integrate_over",
+        bindings=(("x", "i"),),
+        body=body,
+        filters=(("x", ("1.0", "4.0")),),
+    )
+    node = lower_to_vector_ast(
+        expr,
+        target_axes=(),
+        buffer_axes={"f": ("x",)},
+        axis_names=frozenset({"x"}),
+        reducible_axes=frozenset(),
+        axis_weights={"x": (0.5, 1.5, 1.5, 0.5)},
+        axis_coords={"x": ("0.0", "1.0", "3.0", "4.0")},
+        axis_types={"x": "continuous"},
+    )
+    f_buf = np.array([10.0, 2.0, 4.0, 8.0])
+    got = _eval(node, {"f_buf": f_buf, "np": np})
+    # 1.0*2 + 1.5*4 + 0.5*8 = 2 + 6 + 4 = 12
+    assert got == pytest.approx(12.0)
+
+
+def test_lower_apply_along_continuous_range_filter_rejects_non_pair() -> None:
+    """A continuous-axis filter must be exactly ``[lo, hi]``."""
+    body = Subscript(
+        name="f",
+        indices=(AxisIndex(axis="x", kind=AxisKind.FREE),),
+    )
+    expr = Reduce(
+        kind="apply_along",
+        bindings=(("x", "i"),),
+        body=body,
+        filters=(("x", ("0.0", "1.0", "3.0")),),
+        kernel="sum",
+    )
+    with pytest.raises(UnsupportedIRLoweringError, match="2-element"):
+        lower_to_vector_ast(
+            expr,
+            target_axes=(),
+            buffer_axes={"f": ("x",)},
+            axis_names=frozenset({"x"}),
+            reducible_axes=frozenset(),
+            axis_weights={"x": (0.5, 1.5, 1.0, 0.5)},
+            axis_coords={"x": ("0.0", "1.0", "3.0", "4.0")},
+            axis_types={"x": "continuous"},
+        )
+
+
+def test_lower_apply_along_continuous_range_filter_empty_subinterval_errors() -> None:
+    """A continuous-axis filter that selects no declared coord is rejected."""
+    body = Subscript(
+        name="f",
+        indices=(AxisIndex(axis="x", kind=AxisKind.FREE),),
+    )
+    expr = Reduce(
+        kind="apply_along",
+        bindings=(("x", "i"),),
+        body=body,
+        filters=(("x", ("1.5", "2.5")),),
+        kernel="sum",
+    )
+    with pytest.raises(UnsupportedIRLoweringError, match="selects no axis coords"):
+        lower_to_vector_ast(
+            expr,
+            target_axes=(),
+            buffer_axes={"f": ("x",)},
+            axis_names=frozenset({"x"}),
+            reducible_axes=frozenset(),
+            axis_weights={"x": (0.5, 1.5, 1.0, 0.5)},
+            axis_coords={"x": ("0.0", "1.0", "3.0", "4.0")},
+            axis_types={"x": "continuous"},
+        )

--- a/tests/op_system/test_op_system_ir_lower.py
+++ b/tests/op_system/test_op_system_ir_lower.py
@@ -355,3 +355,86 @@ def test_lift_then_lower_round_trip_evaluates_to_buffer_product() -> None:
     i_buf = np.array([[5.0, 6.0], [7.0, 8.0]])
     out = _eval(node, {"S_buf": s_buf, "I_buf": i_buf, "np": np})
     assert np.array_equal(out, s_buf * i_buf)
+
+
+# ---------------------------------------------------------------------------
+# Weighted reductions (integrate_over / continuous-axis bindings)
+# ---------------------------------------------------------------------------
+
+
+def test_lower_integrate_over_emits_weighted_sum_one_axis() -> None:
+    """``integrate_over`` over a single axis multiplies body by deltas then sums."""
+    body = Subscript(
+        name="f",
+        indices=(AxisIndex(axis="x", kind=AxisKind.FREE),),
+    )
+    expr = Reduce(kind="integrate_over", bindings=(("x", "x"),), body=body)
+    node = lower_to_vector_ast(
+        expr,
+        target_axes=(),
+        buffer_axes={"f": ("x",)},
+        axis_names=frozenset({"x"}),
+        axis_weights={"x": (0.5, 1.5, 1.0)},
+    )
+    f_buf = np.array([2.0, 4.0, 6.0])
+    got = _eval(node, {"f_buf": f_buf, "np": np})
+    assert got == pytest.approx(0.5 * 2.0 + 1.5 * 4.0 + 1.0 * 6.0)
+
+
+def test_lower_integrate_over_rejects_when_weights_missing() -> None:
+    """Without ``axis_weights`` for the bound axis, integration cannot lower."""
+    body = Subscript(
+        name="f",
+        indices=(AxisIndex(axis="x", kind=AxisKind.FREE),),
+    )
+    expr = Reduce(kind="integrate_over", bindings=(("x", "x"),), body=body)
+    with pytest.raises(UnsupportedIRLoweringError, match="integration weights"):
+        lower_to_vector_ast(
+            expr,
+            target_axes=(),
+            buffer_axes={"f": ("x",)},
+            axis_names=frozenset({"x"}),
+        )
+
+
+def test_lower_apply_along_with_weights_for_continuous_axis() -> None:
+    """``apply_along`` over a non-reducible axis lowers when weights are provided."""
+    body = Subscript(
+        name="f",
+        indices=(
+            AxisIndex(axis="x", kind=AxisKind.FREE),
+            AxisIndex(axis="age", kind=AxisKind.FREE),
+        ),
+    )
+    expr = Reduce(kind="apply_along", bindings=(("x", "i"),), body=body)
+    node = lower_to_vector_ast(
+        expr,
+        target_axes=("age",),
+        buffer_axes={"f": ("x", "age")},
+        axis_names=frozenset({"x", "age"}),
+        reducible_axes=frozenset({"age"}),
+        axis_weights={"x": (1.0, 2.0)},
+    )
+    f_buf = np.array([[1.0, 2.0, 3.0], [10.0, 20.0, 30.0]])  # shape (x=2, age=3)
+    got = _eval(node, {"f_buf": f_buf, "np": np})
+    expected = 1.0 * f_buf[0] + 2.0 * f_buf[1]
+    assert np.array_equal(got, expected)
+
+
+def test_lower_uniform_apply_along_unchanged_when_weights_absent() -> None:
+    """Plain ``apply_along`` over a reducible axis still lowers without weights."""
+    body = Subscript(
+        name="S",
+        indices=(AxisIndex(axis="age", kind=AxisKind.FREE),),
+    )
+    expr = Reduce(kind="apply_along", bindings=(("age", "a"),), body=body)
+    node = lower_to_vector_ast(
+        expr,
+        target_axes=(),
+        buffer_axes={"S": ("age",)},
+        axis_names=frozenset({"age"}),
+        reducible_axes=frozenset({"age"}),
+    )
+    s_buf = np.array([1.0, 2.0, 3.0])
+    got = _eval(node, {"S_buf": s_buf, "np": np})
+    assert got == pytest.approx(6.0)

--- a/tests/op_system/test_op_system_ir_lower.py
+++ b/tests/op_system/test_op_system_ir_lower.py
@@ -438,3 +438,149 @@ def test_lower_uniform_apply_along_unchanged_when_weights_absent() -> None:
     s_buf = np.array([1.0, 2.0, 3.0])
     got = _eval(node, {"S_buf": s_buf, "np": np})
     assert got == pytest.approx(6.0)
+
+
+def test_lower_apply_along_with_categorical_filter() -> None:
+    """A categorical filter restricts the sum to the listed coords."""
+    body = Subscript(
+        name="pop",
+        indices=(AxisIndex(axis="vax", kind=AxisKind.FREE),),
+    )
+    expr = Reduce(
+        kind="apply_along",
+        bindings=(("vax", "j"),),
+        body=body,
+        filters=(("vax", ("v", "w")),),
+    )
+    node = lower_to_vector_ast(
+        expr,
+        target_axes=(),
+        buffer_axes={"pop": ("vax",)},
+        axis_names=frozenset({"vax"}),
+        reducible_axes=frozenset({"vax"}),
+        axis_coords={"vax": ("u", "v", "w")},
+    )
+    pop_buf = np.array([1.0, 2.0, 4.0])
+    got = _eval(node, {"pop_buf": pop_buf, "np": np})
+    # Sum only over indices [1, 2] -> 2.0 + 4.0
+    assert got == pytest.approx(6.0)
+
+
+def test_lower_apply_along_filter_requires_axis_coords() -> None:
+    """Lowering refuses filters when ``axis_coords`` is missing."""
+    body = Subscript(
+        name="pop",
+        indices=(AxisIndex(axis="vax", kind=AxisKind.FREE),),
+    )
+    expr = Reduce(
+        kind="apply_along",
+        bindings=(("vax", "j"),),
+        body=body,
+        filters=(("vax", ("v", "w")),),
+    )
+    with pytest.raises(UnsupportedIRLoweringError, match="axis_coords"):
+        lower_to_vector_ast(
+            expr,
+            target_axes=(),
+            buffer_axes={"pop": ("vax",)},
+            axis_names=frozenset({"vax"}),
+            reducible_axes=frozenset({"vax"}),
+        )
+
+
+def test_lower_apply_along_filter_rejects_unknown_coord() -> None:
+    """A filter coord that is not declared on the axis is rejected."""
+    body = Subscript(
+        name="pop",
+        indices=(AxisIndex(axis="vax", kind=AxisKind.FREE),),
+    )
+    expr = Reduce(
+        kind="apply_along",
+        bindings=(("vax", "j"),),
+        body=body,
+        filters=(("vax", ("v", "z")),),
+    )
+    with pytest.raises(UnsupportedIRLoweringError, match="not declared"):
+        lower_to_vector_ast(
+            expr,
+            target_axes=(),
+            buffer_axes={"pop": ("vax",)},
+            axis_names=frozenset({"vax"}),
+            reducible_axes=frozenset({"vax"}),
+            axis_coords={"vax": ("u", "v", "w")},
+        )
+
+
+def test_lower_apply_along_kernel_integrate_requires_weights() -> None:
+    """``kernel='integrate'`` forces weighted sum even on reducible axes."""
+    body = Subscript(
+        name="S",
+        indices=(AxisIndex(axis="age", kind=AxisKind.FREE),),
+    )
+    expr = Reduce(
+        kind="apply_along",
+        bindings=(("age", "a"),),
+        body=body,
+        kernel="integrate",
+    )
+    with pytest.raises(UnsupportedIRLoweringError, match="integration weights"):
+        lower_to_vector_ast(
+            expr,
+            target_axes=(),
+            buffer_axes={"S": ("age",)},
+            axis_names=frozenset({"age"}),
+            reducible_axes=frozenset({"age"}),
+        )
+
+
+def test_lower_apply_along_kernel_sum_skips_weights_on_continuous_axis() -> None:
+    """``kernel='sum'`` forces uniform reduction even when weights exist."""
+    body = Subscript(
+        name="f",
+        indices=(AxisIndex(axis="x", kind=AxisKind.FREE),),
+    )
+    expr = Reduce(
+        kind="apply_along",
+        bindings=(("x", "i"),),
+        body=body,
+        kernel="sum",
+    )
+    node = lower_to_vector_ast(
+        expr,
+        target_axes=(),
+        buffer_axes={"f": ("x",)},
+        axis_names=frozenset({"x"}),
+        reducible_axes=frozenset(),  # x is non-reducible
+        axis_weights={"x": (1.0, 2.0, 3.0)},  # would normally be used
+    )
+    f_buf = np.array([10.0, 20.0, 30.0])
+    got = _eval(node, {"f_buf": f_buf, "np": np})
+    # Uniform sum: 10 + 20 + 30 = 60 (NOT 1*10 + 2*20 + 3*30 = 140)
+    assert got == pytest.approx(60.0)
+
+
+def test_lower_apply_along_categorical_filter_with_continuous_weighted_axis() -> None:
+    """Filter on a continuous axis subsets weights as well as body."""
+    body = Subscript(
+        name="f",
+        indices=(AxisIndex(axis="x", kind=AxisKind.FREE),),
+    )
+    expr = Reduce(
+        kind="integrate_over",
+        bindings=(("x", "i"),),
+        body=body,
+        filters=(("x", ("a", "c")),),
+    )
+    node = lower_to_vector_ast(
+        expr,
+        target_axes=(),
+        buffer_axes={"f": ("x",)},
+        axis_names=frozenset({"x"}),
+        reducible_axes=frozenset(),
+        axis_weights={"x": (1.0, 2.0, 3.0)},
+        axis_coords={"x": ("a", "b", "c")},
+    )
+    f_buf = np.array([10.0, 20.0, 30.0])
+    got = _eval(node, {"f_buf": f_buf, "np": np})
+    # Take indices [0, 2]; weights become (1.0, 3.0); sum = 1*10 + 3*30 = 100
+    assert got == pytest.approx(100.0)


### PR DESCRIPTION
This pull request introduces support for per-axis coordinate filters and explicit kernel selection in reduction operations within the IR (`Reduce`) and its lowering to vectorized AST code. The main changes enable specifying coordinate subsets for reductions (e.g., `axis=var in [c1, c2]`) and handling continuous/ordinal axis subranges, as well as supporting explicit kernel selection (`kernel=sum` or `kernel=integrate`). The lowering logic is extended to interpret these filters and kernels, including recomputing integration weights for continuous sub-intervals.

**Enhancements to Reduction IR and Filtering:**

* The `Reduce` IR node now includes `filters` (per-axis coordinate subsets for reductions) and a `kernel` field for explicit kernel selection. This enables reductions over subranges or subsets of axes, and the ability to force a particular reduction kernel. [[1]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6L75-R94) [[2]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R208-R249)
* The IR lowering logic (`_lower_single_helper`, `lower_helper_calls`, `substitute`, `_map_children`, `resolve_axis_kinds`) is updated to propagate and handle these new fields, ensuring that filters and kernels are preserved and correctly interpreted throughout the IR pipeline. [[1]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R208-R249) [[2]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R271-R272) [[3]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R818-R819) [[4]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6L729-R840) [[5]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6L874-R991)

**AST Lowering and Filter Interpretation:**

* The `lower_to_vector_ast` function and its helpers now accept `axis_weights`, `axis_coords`, and `axis_types` mappings, which are required to resolve and apply axis filters. The docstrings are expanded to explain these parameters and their roles. [[1]](diffhunk://#diff-972bd1d88a010cec7d13f086705a2dd6f19f85bcbd8ce19cda35f08eb771f9e3L222-R231) [[2]](diffhunk://#diff-972bd1d88a010cec7d13f086705a2dd6f19f85bcbd8ce19cda35f08eb771f9e3R252-R268) [[3]](diffhunk://#diff-972bd1d88a010cec7d13f086705a2dd6f19f85bcbd8ce19cda35f08eb771f9e3R306-R308) [[4]](diffhunk://#diff-972bd1d88a010cec7d13f086705a2dd6f19f85bcbd8ce19cda35f08eb771f9e3R317-R523)
* New helper functions (`_resolve_ordinal_range_filter`, `_resolve_continuous_range_filter`) are introduced to convert user-specified axis filters into index or interval selections, including recomputing trapezoidal weights for continuous axes when integrating over sub-intervals.

**Support for Weighted and Filtered Reductions:**

* The `_lower_reduce` function is extended to handle both uniform and weighted reductions, applying per-axis weights and slicing according to specified filters. It raises detailed errors for unsupported or malformed filter specifications, and for missing required weight/coord/type information.

**Parser Support for Filter Expressions:**

* The AST-to-IR parser (`to_ir`) now recognizes comparison expressions of the form `x in [c1, c2, ...]` as filter specifications, allowing these to be passed through and interpreted as axis filters in reductions.

These changes collectively add powerful new capabilities for expressing and lowering filtered and weighted reductions, especially useful for advanced numerical and scientific computing use cases.