### PR TITLE
Feat/112 retire string expansion

### DIFF
--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -635,7 +635,7 @@ def _unparse_call_args(args: tuple[Expr, ...]) -> str:
     return ", ".join(parts)
 
 
-def unparse_ir(expr: Expr) -> str:  # noqa: C901, PLR0911
+def unparse_ir(expr: Expr) -> str:
     """Render a typed IR expression back to its Python source string.
 
     Args:
@@ -644,6 +644,87 @@ def unparse_ir(expr: Expr) -> str:  # noqa: C901, PLR0911
     Returns:
         Python expression source string equivalent to ``expr``.
     """
+    return _unparse_ir(expr, parent_prec=0, is_right=False)
+
+
+# Operator precedence (higher binds tighter). Mirrors Python's grammar for
+# the operator subset accepted by the IR.
+_PREC_OR: int = 1
+_PREC_AND: int = 2
+_PREC_CMP: int = 4
+_PREC_ADD: int = 9
+_PREC_MUL: int = 10
+_PREC_UNARY: int = 11
+_PREC_POW: int = 12
+_PREC_ATOM: int = 100
+
+_BINARY_PREC: dict[str, int] = {
+    "or": _PREC_OR,
+    "and": _PREC_AND,
+    "==": _PREC_CMP,
+    "!=": _PREC_CMP,
+    "<": _PREC_CMP,
+    "<=": _PREC_CMP,
+    ">": _PREC_CMP,
+    ">=": _PREC_CMP,
+    "+": _PREC_ADD,
+    "-": _PREC_ADD,
+    "*": _PREC_MUL,
+    "/": _PREC_MUL,
+    "%": _PREC_MUL,
+}
+
+# Right operand of these left-associative ops needs parens at equal precedence
+# (e.g. ``a - (b + c)`` must not collapse to ``a - b + c``).
+_LEFT_ASSOC_NEEDS_RIGHT_PARENS: frozenset[str] = frozenset({"-", "/", "%"})
+
+
+def _expr_precedence(expr: Expr) -> int:
+    if isinstance(expr, Apply):
+        if expr.op in {"neg", "pos"}:
+            return _PREC_UNARY
+        if expr.op == "pow":
+            return _PREC_POW
+        if expr.op == "ifelse":
+            # ternary binds looser than ``or``
+            return 0
+        if expr.op in _BINARY_PREC:
+            return _BINARY_PREC[expr.op]
+    return _PREC_ATOM
+
+
+def _wrap(text: str, *, need: bool) -> str:
+    return f"({text})" if need else text
+
+
+def _unparse_binary(
+    expr: Apply,
+    *,
+    op: str,
+    prec: int,
+    parent_prec: int,
+    is_right: bool,
+) -> str:
+    sep = f" {op} "
+    # Fold args left-associatively so multi-arg flatten still renders correctly.
+    args = expr.args
+    left_str = _unparse_ir(args[0], parent_prec=prec, is_right=False)
+    rendered = left_str
+    for nxt in args[1:]:
+        right_str = _unparse_ir(nxt, parent_prec=prec, is_right=True)
+        rendered = f"{rendered}{sep}{right_str}"
+    need_parens = prec < parent_prec or (
+        prec == parent_prec and is_right and op in _LEFT_ASSOC_NEEDS_RIGHT_PARENS
+    )
+    return _wrap(rendered, need=need_parens)
+
+
+def _unparse_ir(  # noqa: C901, PLR0911
+    expr: Expr,
+    *,
+    parent_prec: int,
+    is_right: bool,
+) -> str:
     if isinstance(expr, Literal):
         return repr(expr.value)
 
@@ -656,27 +737,41 @@ def unparse_ir(expr: Expr) -> str:  # noqa: C901, PLR0911
 
     if isinstance(expr, Apply):
         if expr.op == "neg" and len(expr.args) == 1:
-            return f"-({unparse_ir(expr.args[0])})"
+            inner = _unparse_ir(expr.args[0], parent_prec=_PREC_UNARY, is_right=False)
+            need = parent_prec > _PREC_UNARY
+            return _wrap(f"-{inner}", need=need)
         if expr.op == "pos" and len(expr.args) == 1:
-            return f"+({unparse_ir(expr.args[0])})"
+            inner = _unparse_ir(expr.args[0], parent_prec=_PREC_UNARY, is_right=False)
+            need = parent_prec > _PREC_UNARY
+            return _wrap(f"+{inner}", need=need)
         if expr.op == "pow" and len(expr.args) == 2:
-            left, right = expr.args
-            return f"({unparse_ir(left)}) ** ({unparse_ir(right)})"
+            left = _unparse_ir(expr.args[0], parent_prec=_PREC_POW + 1, is_right=False)
+            right = _unparse_ir(expr.args[1], parent_prec=_PREC_POW, is_right=True)
+            need = parent_prec > _PREC_POW
+            return _wrap(f"{left} ** {right}", need=need)
         if expr.op == "ifelse" and len(expr.args) == 3:
             test, body, orelse = expr.args
-            return (
-                f"({unparse_ir(body)}) if ({unparse_ir(test)})"
-                f" else ({unparse_ir(orelse)})"
+            rendered = (
+                f"{_unparse_ir(body, parent_prec=1, is_right=False)} if "
+                f"{_unparse_ir(test, parent_prec=1, is_right=False)} else "
+                f"{_unparse_ir(orelse, parent_prec=0, is_right=False)}"
             )
-        if expr.op in _BINARY_OPS and len(expr.args) >= 2:
-            sep = f" {expr.op} "
-            return "(" + sep.join(unparse_ir(a) for a in expr.args) + ")"
+            return _wrap(rendered, need=parent_prec > 0)
+        if expr.op in _BINARY_PREC and len(expr.args) >= 2:
+            return _unparse_binary(
+                expr,
+                op=expr.op,
+                prec=_BINARY_PREC[expr.op],
+                parent_prec=parent_prec,
+                is_right=is_right,
+            )
         return f"{expr.op}({_unparse_call_args(expr.args)})"
 
     if isinstance(expr, Reduce):
         binding_str = ", ".join(f"{k}={v}" for k, v in expr.bindings)
         suffix = f", {binding_str}" if binding_str else ""
-        return f"{expr.kind}({unparse_ir(expr.body)}{suffix})"
+        body_str = _unparse_ir(expr.body, parent_prec=0, is_right=False)
+        return f"{expr.kind}({body_str}{suffix})"
 
     _invalid(detail=f"unsupported IR node in unparser: {type(expr).__name__}")
 

--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -8,6 +8,7 @@ expressions into typed IR nodes without changing compile/normalize behavior.
 from __future__ import annotations
 
 import ast
+import re
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING, NoReturn
@@ -579,11 +580,45 @@ def ir_to_ast_expr(expr: Expr) -> ast.expr:  # noqa: C901, PLR0911, PLR0912
     _invalid(detail=f"unsupported IR node for AST conversion: {type(expr).__name__}")
 
 
+_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _render_coord(coord: object) -> str:  # noqa: PLR0911
+    """Render an ``AxisIndex.coord`` value for source-text unparsing.
+
+    Integer-like coords render as bare integers, identifier-like coords render
+    bare, and anything else falls back to ``repr``.
+
+    Args:
+        coord: Coordinate value held on an :class:`AxisIndex` node.
+
+    Returns:
+        Source-text rendering of ``coord`` suitable for embedding in a
+        subscript or bound-axis expression.
+    """
+    if isinstance(coord, bool):
+        return repr(coord)
+    if isinstance(coord, int):
+        return str(coord)
+    if isinstance(coord, float):
+        return repr(coord)
+    if isinstance(coord, str):
+        if coord.lstrip("-").isdigit():
+            return coord
+        if _IDENT_RE.match(coord):
+            return coord
+        return repr(coord)
+    return repr(coord)
+
+
 def _unparse_axis_index(idx: AxisIndex) -> str:
     if idx.placeholder is not None:
         return f"${idx.placeholder}"
     if idx.coord is not None:
-        return repr(idx.coord)
+        rendered = _render_coord(idx.coord)
+        if idx.axis and idx.axis != idx.coord:
+            return f"{idx.axis}:{rendered}"
+        return rendered
     return idx.axis
 
 

--- a/src/op_system/_ir_expand.py
+++ b/src/op_system/_ir_expand.py
@@ -16,7 +16,6 @@ the surrounding pass only ever sees already-pointwise children.
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
 from itertools import product
 from typing import TYPE_CHECKING, Any
 
@@ -31,17 +30,17 @@ from op_system._ir import (
 )
 from op_system._templates import _sanitize_fragment
 
-if TYPE_CHECKING:  # pragma: no cover - import cycle break
-    pass
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
 
 
 def expand_reduce_pointwise(
     expr: Expr,
     *,
-    axes: list[dict[str, Any]],
+    axes: Sequence[Mapping[str, Any]],
     shaped_params: Mapping[str, tuple[str, ...]] | None = None,
     lhs_assignment: Mapping[str, str] | None = None,
-    axis_coords: Mapping[str, list[str]] | None = None,
+    axis_coords: Mapping[str, Sequence[str]] | None = None,
 ) -> Expr:
     """Recursively expand ``Reduce`` nodes into pointwise IR.
 
@@ -90,12 +89,16 @@ def expand_reduce_pointwise(
 def _expand_children(
     expr: Expr,
     *,
-    axes: list[dict[str, Any]],
+    axes: Sequence[Mapping[str, Any]],
     shaped_params: Mapping[str, tuple[str, ...]],
     lhs_assignment: Mapping[str, str],
-    axis_coords: Mapping[str, list[str]],
+    axis_coords: Mapping[str, Sequence[str]],
 ) -> Expr:
-    """Recurse into ``expr``'s children, expanding ``Reduce`` nodes."""
+    """Recurse into ``expr``'s children, expanding ``Reduce`` nodes.
+
+    Returns:
+        ``expr`` with every nested ``Reduce`` replaced by its expansion.
+    """
     if isinstance(expr, (Literal, Sym, Subscript)):
         return expr
     if isinstance(expr, Apply):
@@ -133,20 +136,26 @@ def _expand_children(
 def _expand_one_reduce(
     expr: Reduce,
     *,
-    axes: list[dict[str, Any]],
+    axes: Sequence[Mapping[str, Any]],
     shaped_params: Mapping[str, tuple[str, ...]],
     lhs_assignment: Mapping[str, str],
-    axis_coords: Mapping[str, list[str]],
+    axis_coords: Mapping[str, Sequence[str]],
 ) -> Expr:
-    """Expand a single ``Reduce`` node into a pointwise weighted-sum IR."""
+    """Expand a single ``Reduce`` node into a pointwise weighted-sum IR.
+
+    Returns:
+        The pointwise IR replacement for ``expr``.
+    """
     # Late import to avoid a hard cycle: _normalize imports _ir_expand
     # for its IR-build path.
-    from op_system._normalize import (
+    from op_system._normalize import (  # noqa: PLC0415
         _build_apply_along_axis_options,
         _select_apply_along_kernel,
     )
 
-    axis_lookup = {str(ax.get("name")): ax for ax in axes if ax.get("name")}
+    axis_lookup: dict[str, dict[str, Any]] = {
+        str(ax.get("name")): dict(ax) for ax in axes if ax.get("name")
+    }
     axis_order = tuple(str(ax["name"]) for ax in axes if ax.get("name"))
     filters_dict: dict[str, list[str] | None] = {
         ax: list(coords) if coords else None for ax, coords in expr.filters
@@ -164,7 +173,8 @@ def _expand_one_reduce(
         kernel_form = "integrate"
     else:  # "apply_along"
         kernel_form = expr.kernel
-    kernel = _select_apply_along_kernel(bindings, kernel_form, axes=axes)
+    axes_list: list[dict[str, Any]] = [dict(ax) for ax in axes]
+    kernel = _select_apply_along_kernel(bindings, kernel_form, axes=axes_list)
 
     axis_options = [
         _build_apply_along_axis_options(
@@ -178,9 +188,7 @@ def _expand_one_reduce(
         var_to_coord: dict[str, str] = {}
         bound: dict[str, str] = {}
         weight = 1.0
-        for (ax_name, var_name, _filt), (coord, w) in zip(
-            bindings, combo, strict=True
-        ):
+        for (ax_name, var_name, _filt), (coord, w) in zip(bindings, combo, strict=True):
             var_to_coord[var_name] = coord
             bound[ax_name] = coord
             weight *= w
@@ -207,7 +215,7 @@ def _expand_one_reduce(
     return folded
 
 
-def _substitute_in_body(  # noqa: PLR0913
+def _substitute_in_body(  # noqa: PLR0911, PLR0913
     body: Expr,
     *,
     var_to_coord: Mapping[str, str],
@@ -215,13 +223,16 @@ def _substitute_in_body(  # noqa: PLR0913
     axis_order: Sequence[str],
     shaped_params: Mapping[str, tuple[str, ...]],
     lhs_assignment: Mapping[str, str],
-    axis_coords: Mapping[str, list[str]],
+    axis_coords: Mapping[str, Sequence[str]],
 ) -> Expr:
     """Substitute bound coords into ``body`` (Subscripts and arithmetic Syms).
 
     Inner ``Reduce`` nodes are *not* re-expanded here (the caller handles
     that bottom-up); but their inner body is recursively substituted while
     shadowing any inner binding variable from ``var_to_coord``.
+
+    Returns:
+        A new IR expression with substitutions applied.
     """
     if isinstance(body, Literal):
         return body
@@ -282,7 +293,7 @@ def _substitute_in_body(  # noqa: PLR0913
     return body  # pragma: no cover - exhaustive over Expr union
 
 
-def _rewrite_subscript(  # noqa: C901, PLR0912, PLR0913, PLR0914
+def _rewrite_subscript(  # noqa: C901, PLR0912, PLR0913, PLR0915
     sub: Subscript,
     *,
     var_to_coord: Mapping[str, str],
@@ -290,7 +301,7 @@ def _rewrite_subscript(  # noqa: C901, PLR0912, PLR0913, PLR0914
     axis_order: Sequence[str],
     shaped_params: Mapping[str, tuple[str, ...]],
     lhs_assignment: Mapping[str, str],
-    axis_coords: Mapping[str, list[str]],
+    axis_coords: Mapping[str, Sequence[str]],
 ) -> Expr:
     """IR-level equivalent of :func:`_substitute_apply_along_brackets`.
 
@@ -309,6 +320,11 @@ def _rewrite_subscript(  # noqa: C901, PLR0912, PLR0913, PLR0914
     consumed (axis, coord) pairs are folded into a canonical-order
     ``__axis_<coord>`` suffix on the name and any remaining positions
     are kept in brackets.
+
+    Returns:
+        The rewritten IR node (``Sym`` if all positions are consumed,
+        ``Subscript`` if some positions remain, or the original ``sub``
+        unchanged if no positions were consumed).
     """
     name = sub.name
 
@@ -376,17 +392,16 @@ def _rewrite_subscript(  # noqa: C901, PLR0912, PLR0913, PLR0914
         ):
             try:
                 int_idx = [
-                    axis_coords[param_axes[i]].index(c)  # type: ignore[arg-type]
+                    list(axis_coords[param_axes[i]]).index(c)
                     for i, (_, c) in enumerate(resolved_full)
+                    if c is not None
                 ]
             except ValueError:
                 int_idx = None
             if int_idx is not None:
                 return Subscript(
                     name=name,
-                    indices=tuple(
-                        AxisIndex(axis="", coord=str(i)) for i in int_idx
-                    ),
+                    indices=tuple(AxisIndex(axis="", coord=str(i)) for i in int_idx),
                 )
 
     # Otherwise: fold consumed pairs into a name suffix (canonical axis
@@ -408,6 +423,10 @@ def _split_name_suffix(
     Mirrors :func:`_normalize._substitute_apply_along_brackets._split_suffix`
     so that nested ``apply_along`` expansions converge on the same
     canonical mangled state name regardless of binding order.
+
+    Returns:
+        ``(base_name, [(axis, coord), ...])`` where pairs are in left-to-
+        right order as they appeared in ``name``.
     """
     if not axis_order:
         return name, []
@@ -438,10 +457,12 @@ def _split_name_suffix(
     return base, suffix_pairs
 
 
-def _emit_suffix(
-    pairs: list[tuple[str, str]], axis_order: Sequence[str]
-) -> str:
-    """Render ``pairs`` as ``__axis_<coord>`` tokens in canonical axis order."""
+def _emit_suffix(pairs: list[tuple[str, str]], axis_order: Sequence[str]) -> str:
+    """Render ``pairs`` as ``__axis_<coord>`` tokens in canonical axis order.
+
+    Returns:
+        The concatenated suffix string (empty when ``pairs`` is empty).
+    """
     priority = {ax: i for i, ax in enumerate(axis_order)}
     if not priority:
         return "".join(f"__{ax}_{_sanitize_fragment(c)}" for ax, c in pairs)
@@ -450,6 +471,4 @@ def _emit_suffix(
         key=lambda p: priority[p[0]],
     )
     unknown = [p for p in pairs if p[0] not in priority]
-    return "".join(
-        f"__{ax}_{_sanitize_fragment(c)}" for ax, c in known + unknown
-    )
+    return "".join(f"__{ax}_{_sanitize_fragment(c)}" for ax, c in known + unknown)

--- a/src/op_system/_ir_expand.py
+++ b/src/op_system/_ir_expand.py
@@ -1,0 +1,455 @@
+"""IR-side expansion of ``Reduce`` nodes into pointwise IR.
+
+This module mirrors the string-level :func:`_normalize._expand_apply_along`
+pipeline but operates on typed IR. After running
+:func:`expand_reduce_pointwise` on an expression every ``Reduce`` node
+(``apply_along``, ``sum_over``, ``integrate_over``) is folded into an
+explicit ``Apply("+", ...)`` chain of per-coord pointwise terms, where
+each :class:`Subscript` reference whose bound positions are resolved has
+its name mangled (e.g. ``I__pop_p1``) or — for multi-axis shaped
+parameters whose every position is resolved — is rewritten as a
+literal-integer subscript (e.g. ``K[2, 0]``).
+
+The pass is bottom-up: nested ``Reduce`` nodes are expanded first, so
+the surrounding pass only ever sees already-pointwise children.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from itertools import product
+from typing import TYPE_CHECKING, Any
+
+from op_system._ir import (
+    Apply,
+    AxisIndex,
+    Expr,
+    Literal,
+    Reduce,
+    Subscript,
+    Sym,
+)
+from op_system._templates import _sanitize_fragment
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle break
+    pass
+
+
+def expand_reduce_pointwise(
+    expr: Expr,
+    *,
+    axes: list[dict[str, Any]],
+    shaped_params: Mapping[str, tuple[str, ...]] | None = None,
+    lhs_assignment: Mapping[str, str] | None = None,
+    axis_coords: Mapping[str, list[str]] | None = None,
+) -> Expr:
+    """Recursively expand ``Reduce`` nodes into pointwise IR.
+
+    Args:
+        expr: Root IR expression to expand.
+        axes: Normalized axis dicts (each with ``name``, ``type``,
+            ``coords``, and optional ``deltas``).
+        shaped_params: Mapping from shaped-parameter name to its declared
+            axis tuple. Multi-axis entries enable integer-indexed
+            rewriting when every position is resolved.
+        lhs_assignment: Free-axis assignment from the equation's LHS
+            template row (e.g. ``{"age": "a0"}``). Required to
+            disambiguate same-axis-twice references like
+            ``K[age, age:ap]`` inside a templated equation.
+        axis_coords: ``{axis_name: [coord, ...]}`` for resolving coord
+            names to integer positions on shaped-parameter axes.
+
+    Returns:
+        A pointwise IR expression: same shape as ``expr`` but with every
+        ``Reduce`` replaced by its expanded weighted-sum form.
+    """
+    shaped_params = shaped_params or {}
+    lhs_assignment = lhs_assignment or {}
+    axis_coords = axis_coords or {}
+
+    # Bottom-up: expand children first so the current node only sees
+    # already-pointwise sub-expressions.
+    expanded = _expand_children(
+        expr,
+        axes=axes,
+        shaped_params=shaped_params,
+        lhs_assignment=lhs_assignment,
+        axis_coords=axis_coords,
+    )
+    if isinstance(expanded, Reduce):
+        return _expand_one_reduce(
+            expanded,
+            axes=axes,
+            shaped_params=shaped_params,
+            lhs_assignment=lhs_assignment,
+            axis_coords=axis_coords,
+        )
+    return expanded
+
+
+def _expand_children(
+    expr: Expr,
+    *,
+    axes: list[dict[str, Any]],
+    shaped_params: Mapping[str, tuple[str, ...]],
+    lhs_assignment: Mapping[str, str],
+    axis_coords: Mapping[str, list[str]],
+) -> Expr:
+    """Recurse into ``expr``'s children, expanding ``Reduce`` nodes."""
+    if isinstance(expr, (Literal, Sym, Subscript)):
+        return expr
+    if isinstance(expr, Apply):
+        return Apply(
+            op=expr.op,
+            args=tuple(
+                expand_reduce_pointwise(
+                    a,
+                    axes=axes,
+                    shaped_params=shaped_params,
+                    lhs_assignment=lhs_assignment,
+                    axis_coords=axis_coords,
+                )
+                for a in expr.args
+            ),
+        )
+    if isinstance(expr, Reduce):
+        new_body = expand_reduce_pointwise(
+            expr.body,
+            axes=axes,
+            shaped_params=shaped_params,
+            lhs_assignment=lhs_assignment,
+            axis_coords=axis_coords,
+        )
+        return Reduce(
+            kind=expr.kind,
+            bindings=expr.bindings,
+            body=new_body,
+            filters=expr.filters,
+            kernel=expr.kernel,
+        )
+    return expr
+
+
+def _expand_one_reduce(
+    expr: Reduce,
+    *,
+    axes: list[dict[str, Any]],
+    shaped_params: Mapping[str, tuple[str, ...]],
+    lhs_assignment: Mapping[str, str],
+    axis_coords: Mapping[str, list[str]],
+) -> Expr:
+    """Expand a single ``Reduce`` node into a pointwise weighted-sum IR."""
+    # Late import to avoid a hard cycle: _normalize imports _ir_expand
+    # for its IR-build path.
+    from op_system._normalize import (
+        _build_apply_along_axis_options,
+        _select_apply_along_kernel,
+    )
+
+    axis_lookup = {str(ax.get("name")): ax for ax in axes if ax.get("name")}
+    axis_order = tuple(str(ax["name"]) for ax in axes if ax.get("name"))
+    filters_dict: dict[str, list[str] | None] = {
+        ax: list(coords) if coords else None for ax, coords in expr.filters
+    }
+    bindings: list[tuple[str, str, list[str] | None]] = [
+        (ax, var, filters_dict.get(ax)) for ax, var in expr.bindings
+    ]
+
+    # Determine the kernel form (sum|integrate|None=auto) from Reduce.kind
+    # and explicit Reduce.kernel; mirror the string-side selection.
+    kind = expr.kind
+    if kind == "sum_over":
+        kernel_form: str | None = "sum"
+    elif kind == "integrate_over":
+        kernel_form = "integrate"
+    else:  # "apply_along"
+        kernel_form = expr.kernel
+    kernel = _select_apply_along_kernel(bindings, kernel_form, axes=axes)
+
+    axis_options = [
+        _build_apply_along_axis_options(
+            ax_name, filt, kernel=kernel, axis=axis_lookup[ax_name]
+        )
+        for ax_name, _var, filt in bindings
+    ]
+
+    terms: list[Expr] = []
+    for combo in product(*axis_options):
+        var_to_coord: dict[str, str] = {}
+        bound: dict[str, str] = {}
+        weight = 1.0
+        for (ax_name, var_name, _filt), (coord, w) in zip(
+            bindings, combo, strict=True
+        ):
+            var_to_coord[var_name] = coord
+            bound[ax_name] = coord
+            weight *= w
+        replaced = _substitute_in_body(
+            expr.body,
+            var_to_coord=var_to_coord,
+            bound=bound,
+            axis_order=axis_order,
+            shaped_params=shaped_params,
+            lhs_assignment=lhs_assignment,
+            axis_coords=axis_coords,
+        )
+        if kernel == "integrate":
+            replaced = Apply(op="*", args=(Literal(value=weight), replaced))
+        terms.append(replaced)
+
+    if not terms:  # pragma: no cover - guarded by axis_options non-empty
+        return Literal(value=0.0)
+    if len(terms) == 1:
+        return terms[0]
+    folded: Expr = terms[0]
+    for nxt in terms[1:]:
+        folded = Apply(op="+", args=(folded, nxt))
+    return folded
+
+
+def _substitute_in_body(  # noqa: PLR0913
+    body: Expr,
+    *,
+    var_to_coord: Mapping[str, str],
+    bound: Mapping[str, str],
+    axis_order: Sequence[str],
+    shaped_params: Mapping[str, tuple[str, ...]],
+    lhs_assignment: Mapping[str, str],
+    axis_coords: Mapping[str, list[str]],
+) -> Expr:
+    """Substitute bound coords into ``body`` (Subscripts and arithmetic Syms).
+
+    Inner ``Reduce`` nodes are *not* re-expanded here (the caller handles
+    that bottom-up); but their inner body is recursively substituted while
+    shadowing any inner binding variable from ``var_to_coord``.
+    """
+    if isinstance(body, Literal):
+        return body
+    if isinstance(body, Sym):
+        if body.name in var_to_coord:
+            # Mirror the string-side re.sub(rf"\b{var}\b", coord, ...);
+            # the coord token becomes a bare identifier (which downstream
+            # treats as either a literal coord name or a defined Sym).
+            return Sym(name=var_to_coord[body.name])
+        return body
+    if isinstance(body, Apply):
+        return Apply(
+            op=body.op,
+            args=tuple(
+                _substitute_in_body(
+                    a,
+                    var_to_coord=var_to_coord,
+                    bound=bound,
+                    axis_order=axis_order,
+                    shaped_params=shaped_params,
+                    lhs_assignment=lhs_assignment,
+                    axis_coords=axis_coords,
+                )
+                for a in body.args
+            ),
+        )
+    if isinstance(body, Subscript):
+        return _rewrite_subscript(
+            body,
+            var_to_coord=var_to_coord,
+            bound=bound,
+            axis_order=axis_order,
+            shaped_params=shaped_params,
+            lhs_assignment=lhs_assignment,
+            axis_coords=axis_coords,
+        )
+    if isinstance(body, Reduce):
+        inner_vars = {var for _, var in body.bindings}
+        outer_var_to_coord = {
+            k: v for k, v in var_to_coord.items() if k not in inner_vars
+        }
+        new_inner = _substitute_in_body(
+            body.body,
+            var_to_coord=outer_var_to_coord,
+            bound=bound,
+            axis_order=axis_order,
+            shaped_params=shaped_params,
+            lhs_assignment=lhs_assignment,
+            axis_coords=axis_coords,
+        )
+        return Reduce(
+            kind=body.kind,
+            bindings=body.bindings,
+            body=new_inner,
+            filters=body.filters,
+            kernel=body.kernel,
+        )
+    return body  # pragma: no cover - exhaustive over Expr union
+
+
+def _rewrite_subscript(  # noqa: C901, PLR0912, PLR0913, PLR0914
+    sub: Subscript,
+    *,
+    var_to_coord: Mapping[str, str],
+    bound: Mapping[str, str],
+    axis_order: Sequence[str],
+    shaped_params: Mapping[str, tuple[str, ...]],
+    lhs_assignment: Mapping[str, str],
+    axis_coords: Mapping[str, list[str]],
+) -> Expr:
+    """IR-level equivalent of :func:`_substitute_apply_along_brackets`.
+
+    For each :class:`AxisIndex` position:
+
+    * ``placeholder`` indices are passed through unchanged.
+    * ``coord`` indices whose value names a binding variable resolve to
+      that binding's current coord (consumed).
+    * Bare ``axis`` tokens consume to ``bound[axis]`` (or, in the
+      same-axis-twice case, to ``lhs_assignment[axis]``).
+    * Literal ``coord`` indices that happen to equal ``bound[axis]`` are
+      consumed; otherwise they remain as-is.
+
+    If every position of a multi-axis shaped parameter is resolved, the
+    result is a literal-integer :class:`Subscript`. Otherwise the
+    consumed (axis, coord) pairs are folded into a canonical-order
+    ``__axis_<coord>`` suffix on the name and any remaining positions
+    are kept in brackets.
+    """
+    name = sub.name
+
+    # Detect same-axis-twice: an axis appears with both a bare token AND
+    # a coord token that names a binding variable.
+    pinned_axes: set[str] = set()
+    bare_axes: set[str] = set()
+    for idx in sub.indices:
+        if idx.placeholder is not None:
+            continue
+        if idx.coord is not None:
+            if idx.coord in var_to_coord:
+                pinned_axes.add(idx.axis)
+        elif idx.axis:
+            bare_axes.add(idx.axis)
+    same_axis_twice = pinned_axes & bare_axes
+
+    consumed: list[tuple[str, str]] = []
+    remaining: list[AxisIndex] = []
+    resolved_full: list[tuple[str, str | None]] = []
+    for idx in sub.indices:
+        if idx.placeholder is not None:
+            resolved_full.append((idx.axis, None))
+            remaining.append(idx)
+            continue
+        if idx.coord is not None:
+            if idx.coord in var_to_coord:
+                c = var_to_coord[idx.coord]
+                resolved_full.append((idx.axis, c))
+                consumed.append((idx.axis, c))
+            elif idx.axis in bound and bound[idx.axis] == idx.coord:
+                resolved_full.append((idx.axis, idx.coord))
+                consumed.append((idx.axis, idx.coord))
+            else:
+                resolved_full.append((idx.axis, idx.coord))
+                remaining.append(idx)
+            continue
+        # Bare axis token.
+        if idx.axis in same_axis_twice and idx.axis in lhs_assignment:
+            c = lhs_assignment[idx.axis]
+            resolved_full.append((idx.axis, c))
+            consumed.append((idx.axis, c))
+        elif idx.axis in bound:
+            c = bound[idx.axis]
+            resolved_full.append((idx.axis, c))
+            consumed.append((idx.axis, c))
+        else:
+            resolved_full.append((idx.axis, None))
+            remaining.append(idx)
+
+    if not consumed:
+        return sub
+
+    # Multi-axis shaped parameter → integer-indexed Subscript when every
+    # position is resolved and every axis matches the param's declared
+    # order positionally.
+    if name in shaped_params and len(shaped_params[name]) > 1:
+        param_axes = shaped_params[name]
+        if (
+            len(resolved_full) == len(param_axes)
+            and not remaining
+            and all(c is not None for _, c in resolved_full)
+            and all(ax == param_axes[i] for i, (ax, _) in enumerate(resolved_full))
+            and all(ax in axis_coords for ax in param_axes)
+        ):
+            try:
+                int_idx = [
+                    axis_coords[param_axes[i]].index(c)  # type: ignore[arg-type]
+                    for i, (_, c) in enumerate(resolved_full)
+                ]
+            except ValueError:
+                int_idx = None
+            if int_idx is not None:
+                return Subscript(
+                    name=name,
+                    indices=tuple(
+                        AxisIndex(axis="", coord=str(i)) for i in int_idx
+                    ),
+                )
+
+    # Otherwise: fold consumed pairs into a name suffix (canonical axis
+    # order). Merge with any pre-existing suffix on the name so nested
+    # apply_along expansions converge on the same canonical state name.
+    base, existing = _split_name_suffix(name, axis_order)
+    suffix = _emit_suffix(existing + consumed, axis_order)
+    new_name = f"{base}{suffix}"
+    if remaining:
+        return Subscript(name=new_name, indices=tuple(remaining))
+    return Sym(name=new_name)
+
+
+def _split_name_suffix(
+    name: str, axis_order: Sequence[str]
+) -> tuple[str, list[tuple[str, str]]]:
+    """Strip trailing ``__<axis>_<coord>`` tokens recognised by ``axis_order``.
+
+    Mirrors :func:`_normalize._substitute_apply_along_brackets._split_suffix`
+    so that nested ``apply_along`` expansions converge on the same
+    canonical mangled state name regardless of binding order.
+    """
+    if not axis_order:
+        return name, []
+    parts = name.split("__")
+    if len(parts) <= 1:
+        return name, []
+    suffix_pairs: list[tuple[str, str]] = []
+    cut = len(parts)
+    for i in range(len(parts) - 1, 0, -1):
+        tok = parts[i]
+        best: str | None = None
+        for ax in axis_order:
+            if (
+                tok.startswith(f"{ax}_")
+                and len(tok) > len(ax) + 1
+                and (best is None or len(ax) > len(best))
+            ):
+                best = ax
+        if best is None:
+            break
+        coord = tok[len(best) + 1 :]
+        suffix_pairs.append((best, coord))
+        cut = i
+    if not suffix_pairs:
+        return name, []
+    suffix_pairs.reverse()
+    base = "__".join(parts[:cut])
+    return base, suffix_pairs
+
+
+def _emit_suffix(
+    pairs: list[tuple[str, str]], axis_order: Sequence[str]
+) -> str:
+    """Render ``pairs`` as ``__axis_<coord>`` tokens in canonical axis order."""
+    priority = {ax: i for i, ax in enumerate(axis_order)}
+    if not priority:
+        return "".join(f"__{ax}_{_sanitize_fragment(c)}" for ax, c in pairs)
+    known = sorted(
+        (p for p in pairs if p[0] in priority),
+        key=lambda p: priority[p[0]],
+    )
+    unknown = [p for p in pairs if p[0] not in priority]
+    return "".join(
+        f"__{ax}_{_sanitize_fragment(c)}" for ax, c in known + unknown
+    )

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -1289,7 +1289,7 @@ def _build_equations_ir(
             sys.setrecursionlimit(old_limit)
 
 
-def _build_equations_ir_via_pointwise(
+def _build_equations_ir_via_pointwise(  # noqa: PLR0913
     *,
     equations_ir_reduce: tuple[Expr | None, ...],
     aliases_ir_reduce: Mapping[str, Expr],
@@ -1310,15 +1310,18 @@ def _build_equations_ir_via_pointwise(
 
     Best-effort: cells whose IR cannot be inlined or expanded are returned
     as ``None`` to preserve positional alignment with ``state_expanded``.
+
+    Returns:
+        Tuple of expanded pointwise IR (or ``None`` for failed entries)
+        aligned positionally with ``state_expanded``.
     """
-    from op_system._ir_expand import expand_reduce_pointwise
+    from op_system._ir_expand import expand_reduce_pointwise  # noqa: PLC0415
 
     if not equations_ir_reduce:
         return ()
     cell_to_assignment: dict[str, Mapping[str, str]] = {}
     for variants in template_map.values():
-        for cell, assignment in variants:
-            cell_to_assignment[cell] = assignment
+        cell_to_assignment.update(dict(variants))
 
     memo: dict[int, frozenset[str]] = {}
     try:
@@ -1349,7 +1352,7 @@ def _build_equations_ir_via_pointwise(
             try:
                 expanded = expand_reduce_pointwise(
                     inlined,
-                    axes=list(axes),
+                    axes=axes,
                     shaped_params=shaped_params,
                     lhs_assignment=assignment,
                     axis_coords=axis_lookup,

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -1289,6 +1289,80 @@ def _build_equations_ir(
             sys.setrecursionlimit(old_limit)
 
 
+def _build_equations_ir_via_pointwise(
+    *,
+    equations_ir_reduce: tuple[Expr | None, ...],
+    aliases_ir_reduce: Mapping[str, Expr],
+    state_expanded: Sequence[str],
+    template_map: Mapping[str, Sequence[tuple[str, Mapping[str, str]]]],
+    axes: Sequence[Mapping[str, Any]],
+    shaped_params: Mapping[str, tuple[str, ...]],
+    axis_lookup: Mapping[str, Sequence[str]],
+) -> tuple[Expr | None, ...]:
+    """Build pointwise equation IR by IR-side expansion of ``Reduce`` nodes.
+
+    For each state cell, inline alias references (resolved against the
+    pre-expansion ``aliases_ir_reduce`` map so nested ``Reduce`` nodes are
+    preserved) and then call :func:`expand_reduce_pointwise` with the cell's
+    LHS template assignment so that same-axis-twice references resolve
+    correctly. Avoids the string roundtrip that :func:`_build_equations_ir`
+    performs against ``_expand_apply_along`` output.
+
+    Best-effort: cells whose IR cannot be inlined or expanded are returned
+    as ``None`` to preserve positional alignment with ``state_expanded``.
+    """
+    from op_system._ir_expand import expand_reduce_pointwise
+
+    if not equations_ir_reduce:
+        return ()
+    cell_to_assignment: dict[str, Mapping[str, str]] = {}
+    for variants in template_map.values():
+        for cell, assignment in variants:
+            cell_to_assignment[cell] = assignment
+
+    memo: dict[int, frozenset[str]] = {}
+    try:
+        cycle_validated = _detect_alias_cycle(aliases_ir_reduce) is None
+    except (ValueError, RecursionError):
+        cycle_validated = False
+
+    out: list[Expr | None] = []
+    old_limit = sys.getrecursionlimit()
+    needed = max(old_limit, 10_000)
+    try:
+        if needed > old_limit:
+            sys.setrecursionlimit(needed)
+        for cell, ir in zip(state_expanded, equations_ir_reduce, strict=False):
+            if ir is None:
+                out.append(None)
+                continue
+            try:
+                inlined = inline_aliases(
+                    ir,
+                    aliases_ir_reduce,
+                    memo=memo,
+                    skip_cycle_check=cycle_validated,
+                )
+            except (ValueError, RecursionError):
+                inlined = ir
+            assignment = cell_to_assignment.get(cell, {})
+            try:
+                expanded = expand_reduce_pointwise(
+                    inlined,
+                    axes=list(axes),
+                    shaped_params=shaped_params,
+                    lhs_assignment=assignment,
+                    axis_coords=axis_lookup,
+                )
+            except (ValueError, RecursionError, KeyError):
+                expanded = None
+            out.append(expanded)
+        return tuple(out)
+    finally:
+        if needed > old_limit:
+            sys.setrecursionlimit(old_limit)
+
+
 _INITIAL_STATE_SHAPED_KEY = "shaped"
 _INITIAL_STATE_SHAPED_AXES_KEY = "axes"
 _INITIAL_STATE_SHAPED_ALLOWED_KEYS = frozenset((
@@ -3232,7 +3306,16 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:  # noqa: C901,
         shaped_params=tuple(sorted(shaped_params.items())),
         time_varying_params=tuple(sorted(time_varying_full.items())),
         aliases_ir=aliases_ir_map,
-        equations_ir=_build_equations_ir(eqs_tuple, aliases_ir_map),
+        equations_ir=_build_equations_ir_via_pointwise(
+            equations_ir_reduce=equations_ir_reduce,
+            aliases_ir_reduce=aliases_ir_reduce_map,
+            state_expanded=state_expanded,
+            template_map=template_map_all,
+            axes=axes_meta,
+            shaped_params=shaped_params,
+            axis_lookup=axis_lookup_dict,
+        )
+        or _build_equations_ir(eqs_tuple, aliases_ir_map),
         equations_ir_raw=_build_equations_ir(eqs_tuple),
         aliases_ir_reduce=aliases_ir_reduce_map,
         equations_ir_reduce=equations_ir_reduce,

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -36,7 +36,7 @@ from op_system._helpers import (
     _ensure_str_list,
     _sorted_unique,
 )
-from op_system._ir import Expr, parse_expr_to_ir
+from op_system._ir import Expr, parse_expr_to_ir, unparse_ir
 from op_system._ir_templates import _detect_alias_cycle, inline_aliases
 from op_system._symbols import _collect_names, _parse_expr
 from op_system._templates import (
@@ -1364,6 +1364,62 @@ def _build_equations_ir_via_pointwise(  # noqa: PLR0913
     finally:
         if needed > old_limit:
             sys.setrecursionlimit(old_limit)
+
+
+def _derive_equation_strings(
+    equations_ir: tuple[Expr | None, ...],
+    legacy: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Render each equation's RHS from its IR, falling back to legacy strings.
+
+    When an entry in ``equations_ir`` is ``None``, the corresponding legacy
+    string is used. This keeps positional alignment intact while letting the
+    IR-side pipeline serve as the authoritative source for apply_along-bearing
+    equations.
+
+    Args:
+        equations_ir: Per-cell post-expansion IR (``None`` allowed).
+        legacy: Pre-existing string equations to fall back on.
+
+    Returns:
+        Tuple of equation strings aligned with ``equations_ir``.
+    """
+    rendered: list[str] = []
+    for ir, fallback in zip(equations_ir, legacy, strict=False):
+        if ir is None:
+            rendered.append(fallback)
+            continue
+        try:
+            rendered.append(unparse_ir(ir))
+        except (ValueError, RecursionError):
+            rendered.append(fallback)
+    return tuple(rendered)
+
+
+def _derive_alias_strings(
+    aliases_ir: Mapping[str, Expr],
+    legacy: Mapping[str, str],
+) -> dict[str, str]:
+    """Render each alias body from its IR, falling back to legacy strings.
+
+    Args:
+        aliases_ir: Alias-name → IR map.
+        legacy: Pre-existing alias-name → string map (preserves ordering).
+
+    Returns:
+        New alias mapping with IR-derived bodies where available.
+    """
+    out: dict[str, str] = {}
+    for name, body in legacy.items():
+        ir = aliases_ir.get(name)
+        if ir is None:
+            out[name] = body
+            continue
+        try:
+            out[name] = unparse_ir(ir)
+        except (ValueError, RecursionError):
+            out[name] = body
+    return out
 
 
 _INITIAL_STATE_SHAPED_KEY = "shaped"
@@ -3282,11 +3338,24 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:  # noqa: C901,
         aliases_ir_reduce_map = {}
         equations_ir_reduce = ()
 
+    equations_ir_built = _build_equations_ir_via_pointwise(
+        equations_ir_reduce=equations_ir_reduce,
+        aliases_ir_reduce=aliases_ir_reduce_map,
+        state_expanded=state_expanded,
+        template_map=template_map_all,
+        axes=axes_meta,
+        shaped_params=shaped_params,
+        axis_lookup=axis_lookup_dict,
+    ) or _build_equations_ir(eqs_tuple, aliases_ir_map)
+
+    equations_strings = _derive_equation_strings(equations_ir_built, eqs_tuple)
+    aliases_strings = _derive_alias_strings(aliases_ir_map, aliases)
+
     return NormalizedRhs(
         kind="expr",
         state_names=tuple(state_expanded),
-        equations=eqs_tuple,
-        aliases=aliases,
+        equations=equations_strings,
+        aliases=aliases_strings,
         param_names=_sorted_unique(
             sym
             for sym in all_syms
@@ -3309,16 +3378,7 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:  # noqa: C901,
         shaped_params=tuple(sorted(shaped_params.items())),
         time_varying_params=tuple(sorted(time_varying_full.items())),
         aliases_ir=aliases_ir_map,
-        equations_ir=_build_equations_ir_via_pointwise(
-            equations_ir_reduce=equations_ir_reduce,
-            aliases_ir_reduce=aliases_ir_reduce_map,
-            state_expanded=state_expanded,
-            template_map=template_map_all,
-            axes=axes_meta,
-            shaped_params=shaped_params,
-            axis_lookup=axis_lookup_dict,
-        )
-        or _build_equations_ir(eqs_tuple, aliases_ir_map),
+        equations_ir=equations_ir_built,
         equations_ir_raw=_build_equations_ir(eqs_tuple),
         aliases_ir_reduce=aliases_ir_reduce_map,
         equations_ir_reduce=equations_ir_reduce,

--- a/tests/op_system/test_ir_expand.py
+++ b/tests/op_system/test_ir_expand.py
@@ -1,27 +1,34 @@
-"""Parity tests for IR-side ``expand_reduce_pointwise`` vs string expander."""
+"""Parity and structure tests for IR-side ``expand_reduce_pointwise``."""
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
 import pytest
 
-from op_system._ir import parse_expr_to_ir, unparse_ir
+from op_system._ir import Apply, Subscript, Sym, parse_expr_to_ir, unparse_ir
 from op_system._ir_expand import expand_reduce_pointwise
 from op_system._normalize import _expand_apply_along
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
-def _normalize_spaces(s: str) -> str:
-    """Strip whitespace + outer parens so we can compare semantically."""
-    return "".join(s.split())
+    from op_system._ir import Expr
 
 
 def _ir_expand_to_string(
     src: str,
     *,
-    axes,
-    shaped_params=None,
-    lhs_assignment=None,
-    axis_coords=None,
+    axes: list[dict[str, Any]],
+    shaped_params: Mapping[str, tuple[str, ...]] | None = None,
+    lhs_assignment: Mapping[str, str] | None = None,
+    axis_coords: Mapping[str, list[str]] | None = None,
 ) -> str:
+    """Helper: parse ``src``, expand, then unparse for substring checks.
+
+    Returns:
+        The unparsed pointwise expression string.
+    """
     ir = parse_expr_to_ir(src, lower_helpers=True)
     expanded = expand_reduce_pointwise(
         ir,
@@ -34,15 +41,20 @@ def _ir_expand_to_string(
 
 
 @pytest.fixture
-def axes_age_pop():
+def axes_age_pop() -> list[dict[str, Any]]:
+    """Two categorical axes used by several tests.
+
+    Returns:
+        A list of two categorical axis dicts (age, pop).
+    """
     return [
         {"name": "age", "type": "categorical", "coords": ["a0", "a1", "a2"]},
         {"name": "pop", "type": "categorical", "coords": ["p1", "p2"]},
     ]
 
 
-def test_single_axis_sum_basic_names(axes_age_pop):
-    """Expanded names must include the canonical __axis_<coord> suffix."""
+def test_single_axis_sum_basic_names(axes_age_pop: list[dict[str, Any]]) -> None:
+    """Expanded names include the canonical ``__axis_<coord>`` suffix."""
     out = _ir_expand_to_string(
         "apply_along(I[pop:j], pop=j)",
         axes=axes_age_pop,
@@ -51,10 +63,8 @@ def test_single_axis_sum_basic_names(axes_age_pop):
     assert "I__pop_p2" in out
 
 
-def test_single_axis_sum_two_term_sum(axes_age_pop):
-    """A 2-coord apply_along produces a binary Apply('+') of two pointwise terms."""
-    from op_system._ir import Apply
-
+def test_single_axis_sum_two_term_sum(axes_age_pop: list[dict[str, Any]]) -> None:
+    """A 2-coord apply_along produces a binary Apply('+') of two terms."""
     ir = parse_expr_to_ir("apply_along(I[pop:j], pop=j)", lower_helpers=True)
     expanded = expand_reduce_pointwise(ir, axes=axes_age_pop)
     assert isinstance(expanded, Apply)
@@ -62,11 +72,11 @@ def test_single_axis_sum_two_term_sum(axes_age_pop):
     assert len(expanded.args) == 2
 
 
-def test_same_axis_twice_with_lhs_assignment():
-    """K[age, age:ap] with lhs={age:a0}: row pinned to 0 via lhs, col bound 0..1."""
-    from op_system._ir import Apply, AxisIndex, Subscript, Sym
-
-    axes = [{"name": "age", "type": "categorical", "coords": ["a0", "a1"]}]
+def test_same_axis_twice_with_lhs_assignment() -> None:
+    """K[age, age:ap] with lhs={age:a0}: row pinned to 0, col bound 0..1."""
+    axes: list[dict[str, Any]] = [
+        {"name": "age", "type": "categorical", "coords": ["a0", "a1"]},
+    ]
     shaped = {"K": ("age", "age")}
     axis_coords = {"age": ["a0", "a1"]}
     ir = parse_expr_to_ir(
@@ -79,13 +89,20 @@ def test_same_axis_twice_with_lhs_assignment():
         lhs_assignment={"age": "a0"},
         axis_coords=axis_coords,
     )
-    # Two-term sum K[0,0]*I__age_a0 + K[0,1]*I__age_a1.
-    assert isinstance(expanded, Apply) and expanded.op == "+"
+    assert isinstance(expanded, Apply)
+    assert expanded.op == "+"
     summands = expanded.args
     assert len(summands) == 2
 
-    def _extract_k_index(term):
-        # term = Apply("*", [Subscript(K,...), Sym("I__age_aX")])
+    def _extract_k_index(term: Expr) -> tuple[str | None, ...] | None:
+        """Return K's index tuple if ``term`` is K * something, else None.
+
+        Returns:
+            Tuple of coord strings (one per axis), or ``None`` if K is
+            not present in this term.
+        """
+        if not isinstance(term, Apply):
+            return None
         for arg in term.args:
             if isinstance(arg, Subscript) and arg.name == "K":
                 return tuple(idx.coord for idx in arg.indices)
@@ -97,21 +114,22 @@ def test_same_axis_twice_with_lhs_assignment():
     i_names = {
         a.name
         for term in summands
+        if isinstance(term, Apply)
         for a in term.args
         if isinstance(a, Sym) and a.name.startswith("I__")
     }
     assert i_names == {"I__age_a0", "I__age_a1"}
 
 
-def test_integrate_kernel_emits_weight_literal():
+def test_integrate_kernel_emits_weight_literal() -> None:
     """Continuous-axis apply_along with kernel=integrate emits float weights."""
-    axes = [
+    axes: list[dict[str, Any]] = [
         {
             "name": "t",
             "type": "continuous",
             "coords": ["0.0", "1.0", "2.0"],
             "deltas": [0.5, 1.0, 0.5],
-        }
+        },
     ]
     out = _ir_expand_to_string(
         "apply_along(f[t:tau], t=tau, kernel=integrate)",
@@ -119,31 +137,34 @@ def test_integrate_kernel_emits_weight_literal():
     )
     assert "0.5" in out
     assert "1.0" in out
-    assert "f__t_0_0" in out or "f__t_0" in out  # depends on _sanitize_fragment
 
 
-def test_parity_with_string_expander_single_axis(axes_age_pop):
-    """IR expansion must produce a string equivalent to the string expander."""
+def test_parity_with_string_expander_single_axis(
+    axes_age_pop: list[dict[str, Any]],
+) -> None:
+    """IR expansion produces the same per-coord names as the string expander."""
     src = "apply_along(I[pop:j], pop=j)"
     ir_out = _ir_expand_to_string(src, axes=axes_age_pop)
     str_out = _expand_apply_along(src, axes=axes_age_pop)
-    # Both should reference the same per-coord names.
     for name in ("I__pop_p1", "I__pop_p2"):
         assert name in ir_out
         assert name in str_out
 
 
-def test_parity_two_axis_cartesian(axes_age_pop):
-    """Multi-axis apply_along produces |age|*|pop| terms."""
+def test_parity_two_axis_cartesian(axes_age_pop: list[dict[str, Any]]) -> None:
+    """Multi-axis apply_along produces ``|age|*|pop|`` summands."""
     src = "apply_along(I[age:i, pop:j], age=i, pop=j)"
     ir = parse_expr_to_ir(src, lower_helpers=True)
     expanded = expand_reduce_pointwise(ir, axes=axes_age_pop)
-    # Should be a fold of 3*2 = 6 terms.
-    from op_system._ir import Apply
 
-    def count_summands(e):
+    def _count_summands(e: Expr) -> int:
+        """Count leaf summands in a left-associative ``Apply('+')`` fold.
+
+        Returns:
+            Number of leaf terms.
+        """
         if isinstance(e, Apply) and e.op == "+":
-            return sum(count_summands(a) for a in e.args)
+            return sum(_count_summands(a) for a in e.args)
         return 1
 
-    assert count_summands(expanded) == 6
+    assert _count_summands(expanded) == 6

--- a/tests/op_system/test_ir_expand.py
+++ b/tests/op_system/test_ir_expand.py
@@ -1,0 +1,149 @@
+"""Parity tests for IR-side ``expand_reduce_pointwise`` vs string expander."""
+
+from __future__ import annotations
+
+import pytest
+
+from op_system._ir import parse_expr_to_ir, unparse_ir
+from op_system._ir_expand import expand_reduce_pointwise
+from op_system._normalize import _expand_apply_along
+
+
+def _normalize_spaces(s: str) -> str:
+    """Strip whitespace + outer parens so we can compare semantically."""
+    return "".join(s.split())
+
+
+def _ir_expand_to_string(
+    src: str,
+    *,
+    axes,
+    shaped_params=None,
+    lhs_assignment=None,
+    axis_coords=None,
+) -> str:
+    ir = parse_expr_to_ir(src, lower_helpers=True)
+    expanded = expand_reduce_pointwise(
+        ir,
+        axes=axes,
+        shaped_params=shaped_params,
+        lhs_assignment=lhs_assignment,
+        axis_coords=axis_coords,
+    )
+    return unparse_ir(expanded)
+
+
+@pytest.fixture
+def axes_age_pop():
+    return [
+        {"name": "age", "type": "categorical", "coords": ["a0", "a1", "a2"]},
+        {"name": "pop", "type": "categorical", "coords": ["p1", "p2"]},
+    ]
+
+
+def test_single_axis_sum_basic_names(axes_age_pop):
+    """Expanded names must include the canonical __axis_<coord> suffix."""
+    out = _ir_expand_to_string(
+        "apply_along(I[pop:j], pop=j)",
+        axes=axes_age_pop,
+    )
+    assert "I__pop_p1" in out
+    assert "I__pop_p2" in out
+
+
+def test_single_axis_sum_two_term_sum(axes_age_pop):
+    """A 2-coord apply_along produces a binary Apply('+') of two pointwise terms."""
+    from op_system._ir import Apply
+
+    ir = parse_expr_to_ir("apply_along(I[pop:j], pop=j)", lower_helpers=True)
+    expanded = expand_reduce_pointwise(ir, axes=axes_age_pop)
+    assert isinstance(expanded, Apply)
+    assert expanded.op == "+"
+    assert len(expanded.args) == 2
+
+
+def test_same_axis_twice_with_lhs_assignment():
+    """K[age, age:ap] with lhs={age:a0}: row pinned to 0 via lhs, col bound 0..1."""
+    from op_system._ir import Apply, AxisIndex, Subscript, Sym
+
+    axes = [{"name": "age", "type": "categorical", "coords": ["a0", "a1"]}]
+    shaped = {"K": ("age", "age")}
+    axis_coords = {"age": ["a0", "a1"]}
+    ir = parse_expr_to_ir(
+        "apply_along(K[age, age:ap] * I[age:ap], age=ap)", lower_helpers=True
+    )
+    expanded = expand_reduce_pointwise(
+        ir,
+        axes=axes,
+        shaped_params=shaped,
+        lhs_assignment={"age": "a0"},
+        axis_coords=axis_coords,
+    )
+    # Two-term sum K[0,0]*I__age_a0 + K[0,1]*I__age_a1.
+    assert isinstance(expanded, Apply) and expanded.op == "+"
+    summands = expanded.args
+    assert len(summands) == 2
+
+    def _extract_k_index(term):
+        # term = Apply("*", [Subscript(K,...), Sym("I__age_aX")])
+        for arg in term.args:
+            if isinstance(arg, Subscript) and arg.name == "K":
+                return tuple(idx.coord for idx in arg.indices)
+        return None
+
+    k_indices = {_extract_k_index(t) for t in summands}
+    assert k_indices == {("0", "0"), ("0", "1")}
+
+    i_names = {
+        a.name
+        for term in summands
+        for a in term.args
+        if isinstance(a, Sym) and a.name.startswith("I__")
+    }
+    assert i_names == {"I__age_a0", "I__age_a1"}
+
+
+def test_integrate_kernel_emits_weight_literal():
+    """Continuous-axis apply_along with kernel=integrate emits float weights."""
+    axes = [
+        {
+            "name": "t",
+            "type": "continuous",
+            "coords": ["0.0", "1.0", "2.0"],
+            "deltas": [0.5, 1.0, 0.5],
+        }
+    ]
+    out = _ir_expand_to_string(
+        "apply_along(f[t:tau], t=tau, kernel=integrate)",
+        axes=axes,
+    )
+    assert "0.5" in out
+    assert "1.0" in out
+    assert "f__t_0_0" in out or "f__t_0" in out  # depends on _sanitize_fragment
+
+
+def test_parity_with_string_expander_single_axis(axes_age_pop):
+    """IR expansion must produce a string equivalent to the string expander."""
+    src = "apply_along(I[pop:j], pop=j)"
+    ir_out = _ir_expand_to_string(src, axes=axes_age_pop)
+    str_out = _expand_apply_along(src, axes=axes_age_pop)
+    # Both should reference the same per-coord names.
+    for name in ("I__pop_p1", "I__pop_p2"):
+        assert name in ir_out
+        assert name in str_out
+
+
+def test_parity_two_axis_cartesian(axes_age_pop):
+    """Multi-axis apply_along produces |age|*|pop| terms."""
+    src = "apply_along(I[age:i, pop:j], age=i, pop=j)"
+    ir = parse_expr_to_ir(src, lower_helpers=True)
+    expanded = expand_reduce_pointwise(ir, axes=axes_age_pop)
+    # Should be a fold of 3*2 = 6 terms.
+    from op_system._ir import Apply
+
+    def count_summands(e):
+        if isinstance(e, Apply) and e.op == "+":
+            return sum(count_summands(a) for a in e.args)
+        return 1
+
+    assert count_summands(expanded) == 6

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -181,8 +181,10 @@ def test_alias_and_param_templates_expand_over_axes() -> None:
     expected_aliases = {"beta__age_y", "beta__age_o", "k__age_y", "k__age_o"}
     assert set(out.aliases) == expected_aliases
 
-    assert any("beta__age_y" in eq for eq in out.equations)
-    assert any("beta__age_o" in eq for eq in out.equations)
+    # Aliases are inlined into equations (IR-derived strings); the templated
+    # alias *bodies* — and the LHS cells they multiply — must appear per axis.
+    assert any("offset[0]" in eq and "S__age_y" in eq for eq in out.equations)
+    assert any("offset[1]" in eq and "S__age_o" in eq for eq in out.equations)
 
     # ``offset[age]`` is now a shaped parameter (not per-coord scalars and
     # not included in ``param_names`` — those list scalar params only).
@@ -320,9 +322,9 @@ def test_same_axis_twice_apply_along_per_row_contraction() -> None:
     assert dict(rhs.shaped_params) == {"K": ("age", "age")}
     foi_eqs = rhs.equations[3:6]
     expected = [
-        "((K[0, 0] * I__age_a0) + (K[0, 1] * I__age_a1) + (K[0, 2] * I__age_a2))",
-        "((K[1, 0] * I__age_a0) + (K[1, 1] * I__age_a1) + (K[1, 2] * I__age_a2))",
-        "((K[2, 0] * I__age_a0) + (K[2, 1] * I__age_a1) + (K[2, 2] * I__age_a2))",
+        "K[0, 0] * I__age_a0 + K[0, 1] * I__age_a1 + K[0, 2] * I__age_a2",
+        "K[1, 0] * I__age_a0 + K[1, 1] * I__age_a1 + K[1, 2] * I__age_a2",
+        "K[2, 0] * I__age_a0 + K[2, 1] * I__age_a1 + K[2, 2] * I__age_a2",
     ]
     assert list(foi_eqs) == expected
 


### PR DESCRIPTION
This pull request introduces a new IR-based pipeline for expanding and unparsing equations and aliases, making IR the authoritative source for string rendering and improving consistency between IR and string-based representations. It adds a new pointwise IR expander, updates the equation and alias string derivation logic to use IR when possible, and refactors the IR unparser to produce more idiomatic Python expressions. Comprehensive tests are also added to ensure parity and correctness of the new pipeline.

**IR Pipeline and Equation/Alias Expansion:**

* Introduced `_build_equations_ir_via_pointwise`, `_derive_equation_strings`, and `_derive_alias_strings` in `src/op_system/_normalize.py` to expand equations and aliases directly from IR, falling back to legacy strings only when IR expansion fails. This ensures that string representations are derived from the canonical IR pipeline.
* Updated `normalize_expr_rhs` to use the new IR-based expansion and string derivation, ensuring that `equations`, `aliases`, and `equations_ir` fields are consistently aligned and IR-derived. [[1]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531R3341-R3358) [[2]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L3235-R3381)

**IR Unparser Improvements:**

* Refactored `unparse_ir` and its helpers in `src/op_system/_ir.py` to handle operator precedence, associativity, and rendering of coordinates more idiomatically, resulting in cleaner and more accurate Python source strings. [[1]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R583-R621) [[2]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R647-R727) [[3]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6L624-R774)
* Added `_render_coord` to ensure axis indices are rendered as bare identifiers or integers when possible, improving readability of expanded equations.

**Testing and Validation:**

* Added `tests/op_system/test_ir_expand.py` with comprehensive tests to verify parity between IR-based and legacy string-based expansion, covering single and multi-axis cases, shaped parameters, and kernel integration.
* Updated `tests/op_system/test_op_system_specs.py` to check for IR-derived equation and alias strings, ensuring that the new pipeline's output matches expectations and is used in downstream code. [[1]](diffhunk://#diff-36e364ac2850dcbaf98a9d8947baec052b6fc82135b5733a3a53e387c1803fe0L184-R187) [[2]](diffhunk://#diff-36e364ac2850dcbaf98a9d8947baec052b6fc82135b5733a3a53e387c1803fe0L323-R327)

**Other Minor Updates:**

* Updated imports to expose `unparse_ir` where needed.

These changes collectively modernize the equation and alias expansion pipeline, improve maintainability, and ensure more robust and readable output from the IR system.