### PR TITLE
Feat/112 remove string fallbacks

### DIFF
--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -861,6 +861,44 @@ def walk(expr: Expr) -> Iterator[Expr]:
         yield from walk(expr.body)
 
 
+def _free_symbols_push_children(
+    stack: list[tuple[Expr, bool]],
+    node: Expr,
+    memo: Mapping[int, frozenset[str]],
+) -> None:
+    """Push unresolved children for ``free_symbols`` post-order traversal."""
+    if isinstance(node, Apply):
+        stack.append((node, True))
+        stack.extend((arg, False) for arg in reversed(node.args) if id(arg) not in memo)
+        return
+    if isinstance(node, Reduce):
+        stack.append((node, True))
+        if id(node.body) not in memo:
+            stack.append((node.body, False))
+        return
+    _invalid(detail=f"unsupported IR node in free_symbols: {type(node).__name__}")
+
+
+def _free_symbols_finalize(
+    node: Expr,
+    memo: Mapping[int, frozenset[str]],
+) -> frozenset[str]:
+    """Combine already-computed child results for ``free_symbols``.
+
+    Returns:
+        The free-symbol set for ``node`` assembled from cached child results.
+    """
+    if isinstance(node, Apply):
+        acc: set[str] = set()
+        for arg in node.args:
+            acc.update(memo[id(arg)])
+        return frozenset(acc)
+    if isinstance(node, Reduce):
+        bound = {bind for _, bind in node.bindings}
+        return frozenset(memo[id(node.body)] - bound)
+    _invalid(detail=f"unsupported IR node in free_symbols: {type(node).__name__}")
+
+
 def free_symbols(
     expr: Expr,
     memo: dict[int, frozenset[str]] | None = None,
@@ -884,26 +922,27 @@ def free_symbols(
     """
     if memo is None:
         memo = {}
-    key = id(expr)
-    cached = memo.get(key)
+    root_key = id(expr)
+    cached = memo.get(root_key)
     if cached is not None:
         return cached
-    if isinstance(expr, Sym):
-        out: frozenset[str] = frozenset({expr.name})
-    elif isinstance(expr, (Literal, Subscript)):
-        out = frozenset()
-    elif isinstance(expr, Apply):
-        acc: set[str] = set()
-        for arg in expr.args:
-            acc |= free_symbols(arg, memo)
-        out = frozenset(acc)
-    elif isinstance(expr, Reduce):
-        bound = {bind for _, bind in expr.bindings}
-        out = frozenset(free_symbols(expr.body, memo) - bound)
-    else:
-        _invalid(detail=f"unsupported IR node in free_symbols: {type(expr).__name__}")
-    memo[key] = out
-    return out
+    stack: list[tuple[Expr, bool]] = [(expr, False)]
+    while stack:
+        node, expanded = stack.pop()
+        key = id(node)
+        if key in memo:
+            continue
+        if isinstance(node, Sym):
+            memo[key] = frozenset({node.name})
+            continue
+        if isinstance(node, (Literal, Subscript)):
+            memo[key] = frozenset()
+            continue
+        if expanded:
+            memo[key] = _free_symbols_finalize(node, memo)
+            continue
+        _free_symbols_push_children(stack, node, memo)
+    return memo[root_key]
 
 
 def substitute(

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -1377,58 +1377,77 @@ def _build_equations_ir_via_pointwise(  # noqa: C901, PLR0913
 
 def _derive_equation_strings(
     equations_ir: tuple[Expr | None, ...],
-    legacy: tuple[str, ...],
 ) -> tuple[str, ...]:
-    """Render each equation's RHS from its IR, falling back to legacy strings.
-
-    When an entry in ``equations_ir`` is ``None``, the corresponding legacy
-    string is used. This keeps positional alignment intact while letting the
-    IR-side pipeline serve as the authoritative source for apply_along-bearing
-    equations.
+    """Render each equation's RHS directly from typed IR.
 
     Args:
-        equations_ir: Per-cell post-expansion IR (``None`` allowed).
-        legacy: Pre-existing string equations to fall back on.
+        equations_ir: Per-cell post-expansion IR.
 
     Returns:
         Tuple of equation strings aligned with ``equations_ir``.
+
+    Raises:
+        InvalidRhsSpecError: If any equation IR is missing or cannot be
+            rendered back to source.
     """
-    rendered: list[str] = []
-    for ir, fallback in zip(equations_ir, legacy, strict=False):
-        if ir is None:
-            rendered.append(fallback)
-            continue
-        try:
-            rendered.append(unparse_ir(ir))
-        except (ValueError, RecursionError):
-            rendered.append(fallback)
-    return tuple(rendered)
+    old_limit = sys.getrecursionlimit()
+    sys.setrecursionlimit(max(old_limit, 10_000))
+    try:
+        rendered: list[str] = []
+        for idx, ir in enumerate(equations_ir):
+            if ir is None:
+                raise InvalidRhsSpecError(
+                    detail=f"equations[{idx}] is missing typed IR during rendering"
+                )
+            try:
+                rendered.append(unparse_ir(ir))
+            except (ValueError, RecursionError) as exc:
+                raise InvalidRhsSpecError(
+                    detail=f"equations[{idx}] could not be rendered from typed IR"
+                ) from exc
+        return tuple(rendered)
+    finally:
+        with contextlib.suppress(ValueError, RecursionError):
+            sys.setrecursionlimit(old_limit)
 
 
 def _derive_alias_strings(
     aliases_ir: Mapping[str, Expr],
-    legacy: Mapping[str, str],
+    alias_order: Mapping[str, str],
 ) -> dict[str, str]:
-    """Render each alias body from its IR, falling back to legacy strings.
+    """Render each alias body directly from typed IR.
 
     Args:
         aliases_ir: Alias-name → IR map.
-        legacy: Pre-existing alias-name → string map (preserves ordering).
+        alias_order: Alias-name → string map used only to preserve ordering.
 
     Returns:
-        New alias mapping with IR-derived bodies where available.
+        New alias mapping with IR-derived bodies.
+
+    Raises:
+        InvalidRhsSpecError: If any alias IR is missing or cannot be rendered
+            back to source.
     """
-    out: dict[str, str] = {}
-    for name, body in legacy.items():
-        ir = aliases_ir.get(name)
-        if ir is None:
-            out[name] = body
-            continue
-        try:
-            out[name] = unparse_ir(ir)
-        except (ValueError, RecursionError):
-            out[name] = body
-    return out
+    old_limit = sys.getrecursionlimit()
+    sys.setrecursionlimit(max(old_limit, 10_000))
+    try:
+        out: dict[str, str] = {}
+        for name in alias_order:
+            ir = aliases_ir.get(name)
+            if ir is None:
+                raise InvalidRhsSpecError(
+                    detail=f"alias {name!r} is missing typed IR during rendering"
+                )
+            try:
+                out[name] = unparse_ir(ir)
+            except (ValueError, RecursionError) as exc:
+                raise InvalidRhsSpecError(
+                    detail=f"alias {name!r} could not be rendered from typed IR"
+                ) from exc
+        return out
+    finally:
+        with contextlib.suppress(ValueError, RecursionError):
+            sys.setrecursionlimit(old_limit)
 
 
 _INITIAL_STATE_SHAPED_KEY = "shaped"
@@ -2924,7 +2943,7 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:  # noqa: C901,
         axis_lookup=axis_lookup_dict,
     ) or _build_equations_ir(eqs_tuple, aliases_ir_map)
 
-    equations_strings = _derive_equation_strings(equations_ir_built, eqs_tuple)
+    equations_strings = _derive_equation_strings(equations_ir_built)
     aliases_strings = _derive_alias_strings(aliases_ir_map, aliases)
 
     return NormalizedRhs(

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -1665,6 +1665,7 @@ class _TransitionEndpoints:
     template_map: Mapping[str, list[tuple[str, dict[str, str]]]]
     axis_lookup: dict[str, list[str]]
     shaped_params: Mapping[str, tuple[str, ...]] | None = None
+    passthrough_helpers: bool = False
 
 
 def _collect_transition_wildcard_axes(
@@ -1690,6 +1691,11 @@ def _collect_transition_wildcard_axes(
             endpoints.name_s, shaped_param_names=skip
         )
     for ph in sorted(expr_placeholders):
+        if ":" in ph or "=" in ph:
+            # Helper-bound names like ``pop:j`` or ``age=ap`` are local to the
+            # helper call and should not participate in transition template
+            # wildcard expansion.
+            continue
         if ph not in seen:
             if ph not in endpoints.axis_lookup:
                 raise InvalidRhsSpecError(
@@ -1732,7 +1738,10 @@ def _render_transition_combo(
         axis_lookup=endpoints.axis_lookup,
     )
     tr_out["rate"] = _expand_helpers(
-        rate_sub, axes=endpoints.axes, shaped_params=endpoints.shaped_params
+        rate_sub,
+        axes=endpoints.axes,
+        shaped_params=endpoints.shaped_params,
+        passthrough=endpoints.passthrough_helpers,
     )
     if endpoints.name_s:
         tr_out["name"] = _apply_template_substitutions(
@@ -1761,7 +1770,9 @@ def _expand_single_transition(
     Raises:
         InvalidRhsSpecError: If validation fails.
     """
-    tr_valid = _validate_transition_mapping(tr_map, idx=0)
+    tr_work = dict(tr_map)
+    passthrough_helpers = bool(tr_work.pop("_passthrough_helpers", False))
+    tr_valid = _validate_transition_mapping(tr_work, idx=0)
     frm_s = _get_required_str(tr_valid, idx=0, key="from")
     to_s = _get_required_str(tr_valid, idx=0, key="to")
     rate_s = _get_required_str(tr_valid, idx=0, key="rate")
@@ -1780,6 +1791,7 @@ def _expand_single_transition(
         template_map=template_map,
         axis_lookup=axis_lookup,
         shaped_params=shaped_params,
+        passthrough_helpers=passthrough_helpers,
     )
     wildcard_axes = _collect_transition_wildcard_axes(endpoints)
 
@@ -1810,6 +1822,7 @@ def _expand_transition_templates(
     axes: list[dict[str, Any]],
     template_map: Mapping[str, list[tuple[str, dict[str, str]]]],
     shaped_params: Mapping[str, tuple[str, ...]] | None = None,
+    passthrough_helpers: bool = False,
 ) -> list[dict[str, Any]]:
     """Expand templated transitions over categorical axes.
 
@@ -1824,9 +1837,11 @@ def _expand_transition_templates(
 
     expanded: list[dict[str, Any]] = []
     for tr_map in transitions_raw:
+        tr_context = dict(tr_map)
+        tr_context["_passthrough_helpers"] = passthrough_helpers
         expanded.extend(
             _expand_single_transition(
-                tr_map,
+                tr_context,
                 axes=axes,
                 template_map=template_map,
                 axis_lookup=axis_lookup,
@@ -3203,6 +3218,40 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
     eqs_tuple = tuple(_build_transition_equations(state_expanded, d_terms))
     aliases_ir_map = _build_aliases_ir(aliases)
     equations_ir_built = _build_equations_ir(eqs_tuple, aliases_ir_map)
+    aliases_ir_reduce_map: Mapping[str, Expr] = {}
+    equations_ir_reduce: tuple[Expr | None, ...] = ()
+    try:
+        aliases_pre, _alias_template_map_pre = _expand_alias_templates(
+            meta_parts[0],
+            axes=axes_meta,
+            template_map_seed=state_template_map,
+            shaped_params=shaped_params,
+            axis_lookup=axis_lookup_dict,
+            passthrough_helpers=True,
+        )
+        transitions_expanded_pre = _expand_transition_templates(
+            transitions_raw,
+            axes=axes_meta,
+            template_map=template_map_all,
+            shaped_params=shaped_params,
+            passthrough_helpers=True,
+        )
+        d_terms_pre: dict[str, list[str]] = {s: [] for s in state_expanded}
+        all_syms_pre: set[str] = set()
+        for idx, tr_map in enumerate(transitions_expanded_pre):
+            _apply_transition(
+                idx=idx,
+                tr=tr_map,
+                state_set=state_set,
+                all_syms=all_syms_pre,
+                d_terms=d_terms_pre,
+            )
+        eqs_pre = tuple(_build_transition_equations(state_expanded, d_terms_pre))
+        aliases_ir_reduce_map = _build_aliases_ir(aliases_pre, lower_helpers=True)
+        equations_ir_reduce = _build_equations_ir(eqs_pre, None, lower_helpers=True)
+    except (ValueError, RecursionError, InvalidRhsSpecError):
+        aliases_ir_reduce_map = {}
+        equations_ir_reduce = ()
     return NormalizedRhs(
         kind="transitions",
         state_names=tuple(state_expanded),
@@ -3232,4 +3281,6 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
         aliases_ir=aliases_ir_map,
         equations_ir=equations_ir_built,
         equations_ir_raw=_build_equations_ir(eqs_tuple),
+        aliases_ir_reduce=aliases_ir_reduce_map,
+        equations_ir_reduce=equations_ir_reduce,
     )

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -3202,11 +3202,12 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
     template_base_set = {parse_selector(k)[0] for k in template_map_all}
     eqs_tuple = tuple(_build_transition_equations(state_expanded, d_terms))
     aliases_ir_map = _build_aliases_ir(aliases)
+    equations_ir_built = _build_equations_ir(eqs_tuple, aliases_ir_map)
     return NormalizedRhs(
         kind="transitions",
         state_names=tuple(state_expanded),
         equations=eqs_tuple,
-        aliases=aliases,
+        aliases=_derive_alias_strings(aliases_ir_map, aliases),
         param_names=_sorted_unique(
             sym
             for sym in all_syms
@@ -3229,6 +3230,6 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
         shaped_params=tuple(sorted(shaped_params.items())),
         time_varying_params=tuple(sorted(time_varying_full.items())),
         aliases_ir=aliases_ir_map,
-        equations_ir=_build_equations_ir(eqs_tuple, aliases_ir_map),
+        equations_ir=equations_ir_built,
         equations_ir_raw=_build_equations_ir(eqs_tuple),
     )

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -1162,11 +1162,9 @@ def _build_aliases_ir(
 ) -> dict[str, Expr]:
     """Parse each alias body to IR and inline alias-to-alias references.
 
-    Best-effort: when parsing or inlining fails (cyclic aliases, AST recursion
-    on very long expanded chains, unsupported syntax), the failing alias is
-    omitted rather than aborting normalization. Existing string-based consumers
-    rely on lazy cycle detection at evaluation time, so this preserves
-    backward-compatible behaviour while still exposing IR where available.
+    Parsing is strict: invalid alias expressions abort normalization with the
+    original parser error. Alias inlining remains best-effort so cyclic aliases
+    can still survive to the existing lazy cycle detection at evaluation time.
 
     Args:
         aliases: Mapping from alias name to body string.
@@ -1177,8 +1175,7 @@ def _build_aliases_ir(
             reduction IR to downstream consumers.
 
     Returns:
-        Mapping from alias name to its (fully inlined) IR expression. Entries
-        that could not be parsed or inlined are omitted.
+        Mapping from alias name to its (fully inlined) IR expression.
     """
     # Long expanded Add chains (e.g. ``apply_along`` over many coords) can
     # exceed Python's default recursion limit during AST descent / inlining.
@@ -1189,11 +1186,7 @@ def _build_aliases_ir(
             sys.setrecursionlimit(needed)
         parsed: dict[str, Expr] = {}
         for name, body in aliases.items():
-            try:
-                expr = parse_expr_to_ir(body, lower_helpers=lower_helpers)
-            except (ValueError, RecursionError):
-                continue
-            parsed[name] = expr
+            parsed[name] = parse_expr_to_ir(body, lower_helpers=lower_helpers)
         # Validate the alias graph once and share a free_symbols memo across
         # all per-alias inline_aliases calls: alias bodies are reused by
         # identity, so id-keyed caching turns the inner traversal cost from
@@ -1230,10 +1223,9 @@ def _build_equations_ir(
 ) -> tuple[Expr | None, ...]:
     """Parse each equation RHS to IR, optionally inlining alias references.
 
-    Best-effort: entries that fail to parse or inline are returned as ``None``
-    so positional alignment with ``equations`` is preserved. Mirrors the
-    fallback policy of :func:`_build_aliases_ir` to keep this slice purely
-    additive — existing string-based consumers remain authoritative.
+    Parsing is strict: invalid equation expressions abort normalization with
+    the original parser error. Alias inlining remains best-effort so callers
+    retain the current cycle/lowering behavior once parsing succeeds.
 
     Args:
         equations: Tuple of equation RHS strings.
@@ -1243,8 +1235,7 @@ def _build_equations_ir(
             with pre-expansion equation strings.
 
     Returns:
-        Tuple of IR expressions (or ``None`` for failed entries) aligned
-        positionally with ``equations``.
+        Tuple of IR expressions aligned positionally with ``equations``.
     """
     old_limit = sys.getrecursionlimit()
     needed = max(old_limit, 10_000)
@@ -1263,13 +1254,9 @@ def _build_equations_ir(
                 cycle_validated = cycle is None
             except (ValueError, RecursionError):
                 cycle_validated = False
-        out: list[Expr | None] = []
+        out: list[Expr] = []
         for eq in equations:
-            try:
-                expr = parse_expr_to_ir(eq, lower_helpers=lower_helpers)
-            except (ValueError, RecursionError):
-                out.append(None)
-                continue
+            expr = parse_expr_to_ir(eq, lower_helpers=lower_helpers)
             if aliases_ir is None:
                 out.append(expr)
                 continue

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -27,7 +27,6 @@ import numpy as np
 import pytest
 
 from op_system import compile_spec
-from op_system._errors import InvalidRhsSpecError
 from op_system.compile import CompiledRhs, _collect_eq_code, compile_rhs
 from op_system.specs import NormalizedRhs, normalize_rhs
 
@@ -172,11 +171,10 @@ def test_compile_rejects_disallowed_attribute_access() -> None:
     """Disallowed attribute access should be rejected before evaluation."""
     spec = {"kind": "expr", "state": ["x"], "equations": {"x": "x.real"}}
     with pytest.raises(
-        (ValueError, InvalidRhsSpecError),
-        match=r"disallowed attribute access|missing typed IR",
+        ValueError,
+        match=r"unsupported AST node in IR parser: Attribute",
     ):
-        rhs = normalize_rhs(spec)
-        compile_rhs(rhs, xp=np)
+        normalize_rhs(spec)
 
 
 def test_eval_allows_whitelisted_np_calls() -> None:

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -27,6 +27,7 @@ import numpy as np
 import pytest
 
 from op_system import compile_spec
+from op_system._errors import InvalidRhsSpecError
 from op_system.compile import CompiledRhs, _collect_eq_code, compile_rhs
 from op_system.specs import NormalizedRhs, normalize_rhs
 
@@ -168,10 +169,13 @@ def test_compile_rejects_nonwhitelisted_helper() -> None:
 
 
 def test_compile_rejects_disallowed_attribute_access() -> None:
-    """Disallowed attribute access should be rejected."""
+    """Disallowed attribute access should be rejected before evaluation."""
     spec = {"kind": "expr", "state": ["x"], "equations": {"x": "x.real"}}
-    rhs = normalize_rhs(spec)
-    with pytest.raises(ValueError, match=r"disallowed attribute access"):
+    with pytest.raises(
+        (ValueError, InvalidRhsSpecError),
+        match=r"disallowed attribute access|missing typed IR",
+    ):
+        rhs = normalize_rhs(spec)
         compile_rhs(rhs, xp=np)
 
 

--- a/tests/op_system/test_op_system_ir_substitute.py
+++ b/tests/op_system/test_op_system_ir_substitute.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from op_system._ir import (
     Apply,
     AxisIndex,
+    Expr,
     Literal,
     Reduce,
     Subscript,
@@ -50,6 +51,18 @@ def test_free_symbols_respects_reduce_binding_shadowing() -> None:
     body = Apply(op="*", args=(Sym(name="ap"), Sym(name="beta")))
     expr = Reduce(kind="sum_over", bindings=(("age", "ap"),), body=body)
     assert free_symbols(expr) == frozenset({"beta"})
+
+
+def test_free_symbols_handles_deep_add_chain_iteratively() -> None:
+    """Deep Apply trees should not require Python recursion headroom."""
+    expr: Expr = Sym(name="x0")
+    expected = {"x0"}
+    for idx in range(1, 2500):
+        name = f"x{idx}"
+        expr = Apply(op="+", args=(expr, Sym(name=name)))
+        expected.add(name)
+
+    assert free_symbols(expr) == frozenset(expected)
 
 
 def test_substitute_replaces_matching_sym() -> None:

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -2235,8 +2235,9 @@ def test_aliases_ir_reduce_contains_reduce_for_aliased_apply_along() -> None:
     assert reduces[0].kind == "apply_along"
 
 
-def test_equations_ir_reduce_empty_for_transitions_kind() -> None:
-    """``transitions`` kind leaves the reduce-bearing IR fields empty."""
+def test_equations_ir_reduce_matches_equations_ir_for_transitions_without_helpers(
+) -> None:
+    """Transitions without helpers still populate reduce-bearing IR fields."""
     spec = {
         "kind": "transitions",
         "state": ["S", "I", "R"],
@@ -2247,8 +2248,45 @@ def test_equations_ir_reduce_empty_for_transitions_kind() -> None:
         ],
     }
     out = normalize_transitions_rhs(spec)
-    assert out.aliases_ir_reduce == {}
-    assert out.equations_ir_reduce == ()
+    assert out.aliases_ir_reduce == out.aliases_ir
+    assert len(out.equations_ir_reduce) == len(out.equations_ir_raw)
+    for ir_reduce, ir_raw in zip(
+        out.equations_ir_reduce,
+        out.equations_ir_raw,
+        strict=True,
+    ):
+        assert ir_reduce == ir_raw
+
+
+def test_equations_ir_reduce_contains_reduce_nodes_for_transitions_helpers() -> None:
+    """Transitions with helper-bearing rates should populate reduce IR."""
+    spec = {
+        "kind": "transitions",
+        "axes": [{"name": "pop", "coords": ["p1", "p2"]}],
+        "state": ["S[pop]", "I[pop]", "R[pop]"],
+        "aliases": {"I_total": "apply_along(I[pop:j], pop=j)"},
+        "transitions": [
+            {
+                "from": "S[pop]",
+                "to": "I[pop]",
+                "rate": "beta * apply_along(I[pop:j], pop=j)",
+            },
+            {"from": "I[pop]", "to": "R[pop]", "rate": "gamma"},
+        ],
+    }
+    out = normalize_transitions_rhs(spec)
+    assert "I_total" in out.aliases_ir_reduce
+    reduces = [
+        node
+        for node in walk(out.aliases_ir_reduce["I_total"])
+        if isinstance(node, Reduce)
+    ]
+    assert reduces
+    assert len(out.equations_ir_reduce) == len(out.equations)
+    assert any(
+        expr is not None and any(isinstance(node, Reduce) for node in walk(expr))
+        for expr in out.equations_ir_reduce
+    )
 
 
 def test_equations_ir_reduce_matches_equations_ir_when_no_helpers() -> None:

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -99,11 +99,7 @@ def test_normalize_transitions_rhs_happy_path() -> None:
     # The exact parenthesization may vary between the raw transition builder
     # form and canonical IR-rendered forms.
     assert eq_s.startswith("-(")
-    assert (
-        ")*(S)" in eq_s
-        or "*(S)" in eq_s
-        or eq_s.endswith((" * S)", "* S)"))
-    )
+    assert ")*(S)" in eq_s or "*(S)" in eq_s or eq_s.endswith((" * S)", "* S)"))
 
     assert "+(" in eq_r or eq_r.startswith("(") or "gamma" in eq_r
 
@@ -2235,8 +2231,9 @@ def test_aliases_ir_reduce_contains_reduce_for_aliased_apply_along() -> None:
     assert reduces[0].kind == "apply_along"
 
 
-def test_equations_ir_reduce_matches_equations_ir_for_transitions_without_helpers(
-) -> None:
+def test_equations_ir_reduce_matches_equations_ir_for_transitions_without_helpers() -> (
+    None
+):
     """Transitions without helpers still populate reduce-bearing IR fields."""
     spec = {
         "kind": "transitions",

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -19,6 +19,7 @@ from op_system import compile_rhs
 from op_system._constraints import _ConstraintRule, _normalize_constraints
 from op_system._errors import InvalidRhsSpecError
 from op_system._ir import Apply, Reduce, free_symbols, parse_expr_to_ir, walk
+from op_system._normalize import _derive_alias_strings, _derive_equation_strings
 from op_system.specs import (
     NormalizedRhs,
     StateTemplate,
@@ -51,6 +52,18 @@ def test_normalize_expr_rhs_happy_path() -> None:
     assert "S" in out.all_symbols
     assert "beta" in out.all_symbols
     assert "N" in out.all_symbols
+
+
+def test_derive_equation_strings_requires_typed_ir() -> None:
+    """Equation rendering should fail fast when typed IR is missing."""
+    with pytest.raises(InvalidRhsSpecError, match=r"equations\[0\] is missing typed IR"):
+        _derive_equation_strings((None,))
+
+
+def test_derive_alias_strings_requires_typed_ir() -> None:
+    """Alias rendering should fail fast when typed IR is missing."""
+    with pytest.raises(InvalidRhsSpecError, match="alias 'N' is missing typed IR"):
+        _derive_alias_strings({}, {"N": "S + I + R"})
 
 
 def test_normalize_transitions_rhs_happy_path() -> None:

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -56,7 +56,10 @@ def test_normalize_expr_rhs_happy_path() -> None:
 
 def test_derive_equation_strings_requires_typed_ir() -> None:
     """Equation rendering should fail fast when typed IR is missing."""
-    with pytest.raises(InvalidRhsSpecError, match=r"equations\[0\] is missing typed IR"):
+    with pytest.raises(
+        InvalidRhsSpecError,
+        match=r"equations\[0\] is missing typed IR",
+    ):
         _derive_equation_strings((None,))
 
 
@@ -93,9 +96,14 @@ def test_normalize_transitions_rhs_happy_path() -> None:
     assert "I" in eq_r
 
     # S must lose infection flow; R must gain recovery flow.
-    # The current normalization format is: -((rate_expr)*(from_state))
+    # The exact parenthesization may vary between the raw transition builder
+    # form and canonical IR-rendered forms.
     assert eq_s.startswith("-(")
-    assert ")*(S)" in eq_s or "*(S)" in eq_s
+    assert (
+        ")*(S)" in eq_s
+        or "*(S)" in eq_s
+        or eq_s.endswith((" * S)", "* S)"))
+    )
 
     assert "+(" in eq_r or eq_r.startswith("(") or "gamma" in eq_r
 
@@ -2086,6 +2094,21 @@ def test_aliases_ir_present_for_transitions_kind() -> None:
     }
     out = normalize_transitions_rhs(spec)
     assert "N" in out.aliases_ir
+
+
+def test_transitions_alias_strings_are_rendered_from_ir() -> None:
+    """Transitions aliases should be returned from canonical IR rendering."""
+    spec = {
+        "kind": "transitions",
+        "state": ["S", "I", "R"],
+        "aliases": {"N": "S+I+R"},
+        "transitions": [
+            {"from": "S", "to": "I", "rate": "beta * I / N"},
+            {"from": "I", "to": "R", "rate": "gamma"},
+        ],
+    }
+    out = normalize_transitions_rhs(spec)
+    assert out.aliases["N"] == "S + I + R"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces several important improvements and refactors to the normalization and IR-handling logic in the `op_system` module. The most significant changes include making parsing of aliases and equations strict (failing fast on invalid input), refactoring the `free_symbols` function to use an iterative approach for better performance and stack safety, and improving error handling and reporting throughout the normalization pipeline. Additionally, the rendering of aliases and equations from IR is now stricter, raising errors instead of silently falling back to legacy strings. Several tests were also updated and added to reflect these changes.

**IR Traversal and Symbol Analysis:**
- Refactored the `free_symbols` function in `src/op_system/_ir.py` to use an iterative, stack-based approach instead of recursion, improving performance and preventing stack overflows on deep expression trees. Helper functions `_free_symbols_push_children` and `_free_symbols_finalize` were introduced for this purpose. [[1]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R864-R901) [[2]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6L887-R945)
- Added a new test to verify that `free_symbols` can handle deep `Apply` chains without recursion errors.

**Normalization Pipeline Strictness and Error Handling:**
- Made parsing of aliases and equations strict in `_build_aliases_ir` and `_build_equations_ir`, so that any parsing error aborts normalization instead of omitting the entry or returning `None`. Alias inlining remains best-effort for cyclic references. [[1]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L1165-R1167) [[2]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L1180-R1178) [[3]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L1192-R1189) [[4]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L1233-R1228) [[5]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L1246-R1238) [[6]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L1266-L1272)
- Updated `_derive_equation_strings` and `_derive_alias_strings` to raise `InvalidRhsSpecError` if IR is missing or cannot be rendered, instead of falling back to legacy strings.

**Transition Expansion and Helper Handling:**
- Added support for a `passthrough_helpers` flag in transition template expansion, allowing helper-bound names to be excluded from wildcard expansion and passed through as needed. [[1]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531R1668) [[2]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531R1694-R1698) [[3]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L1729-R1744) [[4]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L1758-R1775) [[5]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531R1794) [[6]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531R1825) [[7]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531R1840-R1844)

**Testing and Error Message Improvements:**
- Updated tests to reflect stricter error handling, ensuring that disallowed attribute access is rejected before evaluation, and improved error messages for unsupported AST nodes.
- Added imports and test coverage for the new stricter rendering and normalization logic. [[1]](diffhunk://#diff-a120b0d814fed061c21553b06657afb01efac0199ff50f387926361f1d9f1ee4R8) [[2]](diffhunk://#diff-36e364ac2850dcbaf98a9d8947baec052b6fc82135b5733a3a53e387c1803fe0R22)

**Normalization Output and API Consistency:**
- Updated normalization output to use the new strict rendering logic for aliases and equations, and to include additional IR representations for reduced forms. [[1]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L2927-R2948) [[2]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531R3220-R3259) [[3]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L3226-R3285)

These changes collectively improve the reliability, correctness, and maintainability of the normalization and IR-handling code, while providing clearer error reporting and safer handling of complex expressions.