### PR TITLE
feat(#112): discriminated union ExprRhs|TransitionsRhs; 

### DIFF
--- a/src/op_system/__init__.py
+++ b/src/op_system/__init__.py
@@ -32,7 +32,9 @@ from op_system._typing import Array
 from .compile import CompiledRhs, EvalFn, compile_rhs
 from .specs import (
     ExpressionString,
+    ExprRhs,
     NormalizedRhs,
+    TransitionsRhs,
     normalize_expr_rhs,
     normalize_rhs,
     normalize_transitions_rhs,
@@ -110,10 +112,12 @@ __all__ = [
     "Array",
     "CompiledRhs",
     "EvalFn",
+    "ExprRhs",
     "ExpressionString",
     "IdentifierString",
     "NormalizedRhs",
     "StateString",
+    "TransitionsRhs",
     "__version__",
     "compile_rhs",
     "compile_spec",

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -121,10 +121,13 @@ class StateTemplate:
 
 
 @dataclass(frozen=True, slots=True)
-class NormalizedRhs:
-    """Normalized RHS representation suitable for compilation/execution."""
+class _RhsBase:
+    """Shared fields for all normalized-RHS kinds.  Not part of the public API.
 
-    kind: str
+    Use :data:`NormalizedRhs`, :class:`ExprRhs`, or :class:`TransitionsRhs`
+    instead.
+    """
+
     state_names: tuple[str, ...]
     equations: tuple[str, ...]
     aliases: Mapping[str, str]
@@ -134,21 +137,40 @@ class NormalizedRhs:
     state_templates: tuple[StateTemplate, ...] = ()
     shaped_params: tuple[tuple[str, tuple[str, ...]], ...] = ()
     time_varying_params: tuple[tuple[str, tuple[str, ...]], ...] = ()
+    # Post-expansion, alias-inlined IR (Reduce nodes expanded).
+    # Used by the scalar compile path (``compile.py._make_eval_fn``).
     aliases_ir: Mapping[str, Expr] = field(default_factory=dict)
     equations_ir: tuple[Expr | None, ...] = ()
-    equations_ir_raw: tuple[Expr | None, ...] = ()
-    # Helper-bearing IR variants: aliases/equations parsed from their
-    # *pre-expansion* string form (i.e. before ``_expand_helpers`` lowers
-    # ``apply_along`` / ``sum_over`` / ``integrate_over`` to per-cell
-    # sums) with ``parse_expr_to_ir(lower_helpers=True)``. Carries
-    # ``Reduce`` nodes; intended for downstream IR-fast-path consumers.
-    # Best-effort, parallel to ``aliases_ir`` / ``equations_ir`` — entries
-    # that fail to parse or inline are omitted (aliases) or stored as
-    # ``None`` (equations). Empty for ``kind == "transitions"`` (rates are
-    # not yet plumbed through this surface).
+    # Reduce-bearing IR (Reduce nodes preserved).
+    # Used by the vector compile path (``_vectorize.py``).
     aliases_ir_reduce: Mapping[str, Expr] = field(default_factory=dict)
     equations_ir_reduce: tuple[Expr | None, ...] = ()
     alias_templates: tuple[StateTemplate, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ExprRhs(_RhsBase):
+    """Normalized RHS for ``kind="expr"`` specs (explicit d(state)/dt equations).
+
+    Produced by :func:`normalize_expr_rhs`.  Use :data:`NormalizedRhs` as the
+    union type when you need to accept both kinds.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class TransitionsRhs(_RhsBase):
+    """Normalized RHS for ``kind="transitions"`` specs (per-capita hazard diagram).
+
+    Produced by :func:`normalize_transitions_rhs`.  Use :data:`NormalizedRhs`
+    as the union type when you need to accept both kinds.
+    """
+
+
+#: Discriminated union of the two normalized-RHS kinds.
+#:
+#: Use ``isinstance(rhs, ExprRhs)`` / ``isinstance(rhs, TransitionsRhs)`` to
+#: dispatch, rather than the legacy ``rhs.kind == "expr"`` string check.
+NormalizedRhs = ExprRhs | TransitionsRhs
 
 
 # ---------------------------------------------------------------------------
@@ -1432,7 +1454,7 @@ def _lookup_cell_expr(
     raise InvalidRhsSpecError(detail=f"Missing equation for state {cell!r}")
 
 
-def _build_equations_ir_from_raw(  # noqa: PLR0913, PLR0914
+def _build_equations_ir_from_raw(  # noqa: PLR0913
     *,
     state_expanded: Sequence[str],
     equations_map: Mapping[str, Any],
@@ -1442,7 +1464,6 @@ def _build_equations_ir_from_raw(  # noqa: PLR0913, PLR0914
     axis_lookup: Mapping[str, Sequence[str]],
     aliases_ir: Mapping[str, Expr] | None = None,
 ) -> tuple[
-    tuple[Expr | None, ...],
     tuple[Expr | None, ...],
     tuple[Expr | None, ...],
     set[str],
@@ -1458,11 +1479,12 @@ def _build_equations_ir_from_raw(  # noqa: PLR0913, PLR0914
     4. :func:`expand_reduce_pointwise` with the cell's LHS assignment.
     5. :func:`inline_aliases` against ``aliases_ir`` (post-expansion alias map).
 
-    The intermediate states after steps 3 and 4 (before alias inlining) are
-    returned as ``equations_ir_reduce`` and ``equations_ir_raw`` respectively.
+    The result after step 3 (Reduce-bearing, pre-expand) is returned as
+    ``equations_ir_reduce``; the fully inlined result after step 5 is returned
+    as ``equations_ir``.
 
     Returns:
-        ``(equations_ir, equations_ir_reduce, equations_ir_raw, all_syms)``
+        ``(equations_ir, equations_ir_reduce, all_syms)``
         where each IR tuple is aligned with ``state_expanded`` and failed
         cells are represented as ``None``.
     """
@@ -1486,7 +1508,6 @@ def _build_equations_ir_from_raw(  # noqa: PLR0913, PLR0914
             alias_cycle_ok = _detect_alias_cycle(aliases_ir) is None
 
     out_reduce: list[Expr | None] = []
-    out_raw: list[Expr | None] = []
     out_full: list[Expr | None] = []
     all_syms: set[str] = set()
     old_limit = sys.getrecursionlimit()
@@ -1512,7 +1533,6 @@ def _build_equations_ir_from_raw(  # noqa: PLR0913, PLR0914
                 lhs_assignment=assignment,
                 axis_coords=dict(axis_lookup),
             )
-            out_raw.append(ir_expanded)
             if aliases_ir:
                 try:
                     ir_inlined = inline_aliases(
@@ -1527,7 +1547,7 @@ def _build_equations_ir_from_raw(  # noqa: PLR0913, PLR0914
                 ir_inlined = ir_expanded
             all_syms |= free_symbols(ir_inlined)
             out_full.append(ir_inlined)
-        return tuple(out_full), tuple(out_reduce), tuple(out_raw), all_syms
+        return tuple(out_full), tuple(out_reduce), all_syms
     finally:
         if needed > old_limit:
             sys.setrecursionlimit(old_limit)
@@ -2552,10 +2572,9 @@ def normalize_rhs(spec: Mapping[str, Any] | None) -> NormalizedRhs:
         feature=f"rhs.kind={kind}",
         detail="Only 'expr' and 'transitions' are supported in v1.",
     )
-    return normalize_expr_rhs(spec)  # unreachable; satisfies return type checker
 
 
-def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:  # noqa: C901, PLR0914, PLR0915
+def normalize_expr_rhs(spec: Mapping[str, Any]) -> ExprRhs:  # noqa: C901, PLR0914, PLR0915
     """Normalize an expression-based RHS specification.
 
     Args:
@@ -2671,16 +2690,14 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:  # noqa: C901,
             detail=f"unknown equation key(s): {sorted(unknown_keys)}"
         )
 
-    equations_ir_built, equations_ir_reduce, equations_ir_raw, all_syms = (
-        _build_equations_ir_from_raw(
-            state_expanded=state_expanded,
-            equations_map=equations_map,
-            template_map=template_map_all,
-            axes=axes_meta,
-            shaped_params=shaped_params,
-            axis_lookup=axis_lookup_dict,
-            aliases_ir=aliases_ir_map,
-        )
+    equations_ir_built, equations_ir_reduce, all_syms = _build_equations_ir_from_raw(
+        state_expanded=state_expanded,
+        equations_map=equations_map,
+        template_map=template_map_all,
+        axes=axes_meta,
+        shaped_params=shaped_params,
+        axis_lookup=axis_lookup_dict,
+        aliases_ir=aliases_ir_map,
     )
     # Collect free symbols from alias bodies (alias bodies may reference
     # params not appearing in any equation directly).
@@ -2705,8 +2722,7 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:  # noqa: C901,
     equations_strings = _derive_equation_strings(equations_ir_built)
     aliases_strings = _derive_alias_strings(aliases_ir_map, aliases_ir_map)
 
-    return NormalizedRhs(
-        kind="expr",
+    return ExprRhs(
         state_names=tuple(state_expanded),
         equations=equations_strings,
         aliases=aliases_strings,
@@ -2733,7 +2749,6 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> NormalizedRhs:  # noqa: C901,
         time_varying_params=tuple(sorted(time_varying_full.items())),
         aliases_ir=aliases_ir_map,
         equations_ir=equations_ir_built,
-        equations_ir_raw=equations_ir_raw,
         aliases_ir_reduce=aliases_ir_reduce_map,
         equations_ir_reduce=equations_ir_reduce,
         alias_templates=_build_alias_templates(
@@ -2954,7 +2969,7 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
 
 def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
     spec: Mapping[str, Any],
-) -> NormalizedRhs:
+) -> TransitionsRhs:
     """Normalize a transition-based RHS specification (diagram/hazard semantics).
 
     Returns:
@@ -3127,8 +3142,7 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
     template_base_set = {parse_selector(k)[0] for k in template_map_all}
     eqs_tuple = _derive_equation_strings(equations_ir_pre_inline)
     equations_ir_built = _build_equations_ir(eqs_tuple, aliases_ir_map)
-    return NormalizedRhs(
-        kind="transitions",
+    return TransitionsRhs(
         state_names=tuple(state_expanded),
         equations=eqs_tuple,
         aliases=_derive_alias_strings(aliases_ir_map, aliases_ir_map),
@@ -3155,7 +3169,6 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
         time_varying_params=tuple(sorted(time_varying_full.items())),
         aliases_ir=aliases_ir_map,
         equations_ir=equations_ir_built,
-        equations_ir_raw=_build_equations_ir(eqs_tuple),
         aliases_ir_reduce=aliases_ir_reduce_map,
         equations_ir_reduce=equations_ir_reduce,
         alias_templates=_build_alias_templates(

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -449,15 +449,15 @@ def _try_cse_eq_plan(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0914
     # Prefer equations_ir_reduce (preserves Reduce helper structure) so that
     # lowering can emit np.sum() directly for apply_along terms.
     eq_ir_reduce = rhs.equations_ir_reduce
-    eq_ir_raw = rhs.equations_ir_raw
+    eq_ir = rhs.equations_ir
     lifted_irs: list[Expr] = []
     for buf in state_buffers:
         first_idx = buf.offset
         cell_ir: Expr | None = None
         if eq_ir_reduce and len(eq_ir_reduce) > first_idx:
             cell_ir = eq_ir_reduce[first_idx]
-        if cell_ir is None and eq_ir_raw and len(eq_ir_raw) > first_idx:
-            cell_ir = eq_ir_raw[first_idx]
+        if cell_ir is None and eq_ir and len(eq_ir) > first_idx:
+            cell_ir = eq_ir[first_idx]
         if cell_ir is None:
             return None
         try:
@@ -906,7 +906,7 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
             result = _vectorize_template_equations(
                 template=buf,
                 equations=rhs.equations,
-                equations_ir=rhs.equations_ir_raw,
+                equations_ir=None,
                 equations_ir_reduce=rhs.equations_ir_reduce,
                 name_to_template=name_to_template,
                 axis_index=axis_index,

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -39,6 +39,7 @@ from numpy.typing import NDArray
 
 from op_system._errors import InvalidExpressionError
 from op_system._ir import Expr, extract_common_subexpressions, ir_to_ast_expr
+from op_system._normalize import ExprRhs, TransitionsRhs
 from op_system._symbols import parse_expression_string
 
 if TYPE_CHECKING:
@@ -830,10 +831,10 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
             DeprecationWarning,
             stacklevel=2,
         )
-    if rhs.kind not in {"expr", "transitions"}:
+    if not isinstance(rhs, (ExprRhs, TransitionsRhs)):
         _raise_unsupported_feature(
-            feature=f"rhs.kind={rhs.kind}",
-            detail="Only 'expr' and 'transitions' are supported in v1.",
+            feature=f"rhs type={type(rhs).__name__}",
+            detail="Only ExprRhs and TransitionsRhs are supported in v1.",
         )
 
     # Lazy load via importlib to avoid a static circular import

--- a/src/op_system/specs.py
+++ b/src/op_system/specs.py
@@ -17,8 +17,10 @@ See ``op_system._normalize`` for the full implementation.
 from __future__ import annotations
 
 from op_system._normalize import (
+    ExprRhs,
     NormalizedRhs,
     StateTemplate,
+    TransitionsRhs,
     normalize_expr_rhs,
     normalize_rhs,
     normalize_transitions_rhs,
@@ -27,11 +29,13 @@ from op_system._symbols import ExpressionString
 from op_system._templates import PinnedToken, SelectorToken, WildcardToken
 
 __all__ = [
+    "ExprRhs",
     "ExpressionString",
     "NormalizedRhs",
     "PinnedToken",
     "SelectorToken",
     "StateTemplate",
+    "TransitionsRhs",
     "WildcardToken",
     "normalize_expr_rhs",
     "normalize_rhs",

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -28,8 +28,10 @@ from op_system._ir import (
 )
 from op_system._normalize import _derive_alias_strings, _derive_equation_strings
 from op_system.specs import (
+    ExprRhs,
     NormalizedRhs,
     StateTemplate,
+    TransitionsRhs,
     normalize_expr_rhs,
     normalize_rhs,
     normalize_transitions_rhs,
@@ -50,8 +52,8 @@ def test_normalize_expr_rhs_happy_path() -> None:
     }
 
     out = normalize_expr_rhs(spec)
+    assert isinstance(out, ExprRhs)
     assert isinstance(out, NormalizedRhs)
-    assert out.kind == "expr"
     assert out.state_names == ("S", "I", "R")
     assert out.aliases["N"] == "S + I + R"
     assert out.equations[0].startswith("-(") or "beta" in out.equations[0]
@@ -89,7 +91,7 @@ def test_normalize_transitions_rhs_happy_path() -> None:
     }
 
     out = normalize_transitions_rhs(spec)
-    assert out.kind == "transitions"
+    assert isinstance(out, TransitionsRhs)
     assert out.state_names == ("S", "I", "R")
     assert out.param_names == ("beta", "gamma")
 
@@ -160,7 +162,7 @@ def test_normalize_rhs_preserves_reserved_blocks_in_meta() -> None:
     }
 
     out = normalize_rhs(spec)
-    assert out.kind == "transitions"
+    assert isinstance(out, TransitionsRhs)
     assert out.meta.get("operators") == {"default": {"scheme": "cn"}}
     assert out.meta.get("sources") == {"S": "0.0"}
 
@@ -2133,17 +2135,11 @@ def test_equations_ir_aligned_with_equations_expr_kind() -> None:
     }
     out = normalize_expr_rhs(spec)
     assert len(out.equations_ir) == len(out.equations)
-    assert len(out.equations_ir_raw) == len(out.equations)
     assert all(expr is not None for expr in out.equations_ir)
     # Aliases inlined: ``N`` should not appear in any equation IR.
     for expr in out.equations_ir:
         assert expr is not None
         assert "N" not in free_symbols(expr)
-    # Raw equation IR is available for consumers that still want alias-buffer
-    # references rather than inlined alias bodies.
-    assert any(
-        expr is not None and "N" in free_symbols(expr) for expr in out.equations_ir_raw
-    )
 
 
 def test_equations_ir_present_for_transitions_kind() -> None:
@@ -2159,7 +2155,6 @@ def test_equations_ir_present_for_transitions_kind() -> None:
     }
     out = normalize_transitions_rhs(spec)
     assert len(out.equations_ir) == len(out.equations)
-    assert len(out.equations_ir_raw) == len(out.equations)
     assert all(expr is not None for expr in out.equations_ir)
     for expr in out.equations_ir:
         assert expr is not None
@@ -2253,13 +2248,11 @@ def test_equations_ir_reduce_matches_equations_ir_for_transitions_without_helper
     }
     out = normalize_transitions_rhs(spec)
     assert out.aliases_ir_reduce == out.aliases_ir
-    assert len(out.equations_ir_reduce) == len(out.equations_ir_raw)
-    for ir_reduce, ir_raw in zip(
-        out.equations_ir_reduce,
-        out.equations_ir_raw,
-        strict=True,
-    ):
-        assert ir_reduce == ir_raw
+    assert len(out.equations_ir_reduce) == len(out.equations_ir)
+    # Without apply_along helpers there should be no Reduce nodes.
+    for expr in out.equations_ir_reduce:
+        if expr is not None:
+            assert not any(isinstance(node, Reduce) for node in walk(expr))
 
 
 def test_equations_ir_reduce_contains_reduce_nodes_for_transitions_helpers() -> None:
@@ -2302,10 +2295,10 @@ def test_equations_ir_reduce_matches_equations_ir_when_no_helpers() -> None:
     }
     out = normalize_expr_rhs(spec)
     assert len(out.equations_ir_reduce) == len(out.equations_ir)
-    for ir_reduce, ir_raw in zip(
-        out.equations_ir_reduce, out.equations_ir_raw, strict=True
-    ):
-        assert ir_reduce == ir_raw
+    # Without apply_along helpers there should be no Reduce nodes in either form.
+    for expr in out.equations_ir_reduce:
+        if expr is not None:
+            assert not any(isinstance(node, Reduce) for node in walk(expr))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request refactors the handling of normalized right-hand side (RHS) representations in the operator system. It introduces explicit dataclasses for the two RHS kinds (`ExprRhs` and `TransitionsRhs`), replaces legacy string-based kind checks with type-based dispatch, and removes the now-redundant `equations_ir_raw` field. These changes improve type safety, code clarity, and make the API easier to use and maintain.

Key changes include:

**Refactoring of Normalized RHS Types:**

- Introduced new dataclasses `ExprRhs` and `TransitionsRhs` to explicitly represent the two kinds of normalized RHS, replacing the previous `NormalizedRhs` class with a type union of these two. Type-based dispatch (`isinstance`) is now used instead of string-based kind checks. [[1]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L124-L127) [[2]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531R140-R175) [[3]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L2555-R2577) [[4]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L2708-R2725) [[5]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L2957-R2972) [[6]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L3130-R3145) [[7]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R42) [[8]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71L833-R837) [[9]](diffhunk://#diff-2cf5cbdc728c64834ab5618986671e86ab9591ee37c08c34eaaa386cfdb415c4R35-R37) [[10]](diffhunk://#diff-2cf5cbdc728c64834ab5618986671e86ab9591ee37c08c34eaaa386cfdb415c4R115-R120) [[11]](diffhunk://#diff-e7347f5d6678762d5e06831993041c5299fedd3852fb3fd368c3de26dd09b66cR20-R23) [[12]](diffhunk://#diff-e7347f5d6678762d5e06831993041c5299fedd3852fb3fd368c3de26dd09b66cR32-R38)

**API and Public Interface Updates:**

- Updated the public API to export `ExprRhs` and `TransitionsRhs` from `op_system/__init__.py` and `op_system/specs.py`. [[1]](diffhunk://#diff-2cf5cbdc728c64834ab5618986671e86ab9591ee37c08c34eaaa386cfdb415c4R35-R37) [[2]](diffhunk://#diff-2cf5cbdc728c64834ab5618986671e86ab9591ee37c08c34eaaa386cfdb415c4R115-R120) [[3]](diffhunk://#diff-e7347f5d6678762d5e06831993041c5299fedd3852fb3fd368c3de26dd09b66cR20-R23) [[4]](diffhunk://#diff-e7347f5d6678762d5e06831993041c5299fedd3852fb3fd368c3de26dd09b66cR32-R38)

**Removal of Redundant Equation IR Field:**

- Removed the `equations_ir_raw` field from normalized RHS objects, simplifying the IR structure and related logic. All code and tests referring to this field have been updated or removed. [[1]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531R140-R175) [[2]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L1435-R1457) [[3]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L1445) [[4]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L1461-R1487) [[5]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L1489) [[6]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L1515) [[7]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L1530-R1550) [[8]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L2674-R2693) [[9]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L2684) [[10]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L2736) [[11]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L3158) [[12]](diffhunk://#diff-78dd8e3dce178eddee83fcabf5b111b1ef0d74232edd87f4e8e46516bd748193L452-R460) [[13]](diffhunk://#diff-78dd8e3dce178eddee83fcabf5b111b1ef0d74232edd87f4e8e46516bd748193L909-R909)

**Test Suite Updates:**

- Updated tests to use `isinstance` checks for `ExprRhs` and `TransitionsRhs` instead of checking the `kind` string, and removed or updated assertions related to `equations_ir_raw`. [[1]](diffhunk://#diff-36e364ac2850dcbaf98a9d8947baec052b6fc82135b5733a3a53e387c1803fe0R31-R34) [[2]](diffhunk://#diff-36e364ac2850dcbaf98a9d8947baec052b6fc82135b5733a3a53e387c1803fe0R55-L54) [[3]](diffhunk://#diff-36e364ac2850dcbaf98a9d8947baec052b6fc82135b5733a3a53e387c1803fe0L92-R94) [[4]](diffhunk://#diff-36e364ac2850dcbaf98a9d8947baec052b6fc82135b5733a3a53e387c1803fe0L163-R165) [[5]](diffhunk://#diff-36e364ac2850dcbaf98a9d8947baec052b6fc82135b5733a3a53e387c1803fe0L2136-L2146) [[6]](diffhunk://#diff-36e364ac2850dcbaf98a9d8947baec052b6fc82135b5733a3a53e387c1803fe0L2162)

These changes modernize the codebase, making it more robust and maintainable, and pave the way for further improvements to the operator system's normalization and compilation logic.