### PR TITLE
refactor(#112): remove unused $-placeholder IR infrastructure

### DIFF
--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -47,7 +47,6 @@ class AxisIndex:
 
     axis: str
     coord: str | None = None
-    placeholder: str | None = None
     kind: AxisKind | None = None
 
 
@@ -300,9 +299,6 @@ def _call_name(func: ast.AST) -> str:
 
 def _axis_index_from_expr(node: ast.expr) -> AxisIndex:
     if isinstance(node, ast.Name):
-        if node.id.startswith("$"):
-            ph = node.id[1:]
-            return AxisIndex(axis=ph, placeholder=ph)
         return AxisIndex(axis=node.id)
     if isinstance(node, ast.Constant) and isinstance(
         node.value, (str, int, float, bool)
@@ -474,7 +470,7 @@ def _literal_coord_value(coord: str) -> int | float | str:
 def _axis_index_to_ast(idx: AxisIndex) -> ast.expr:
     if idx.coord is not None:
         return ast.Constant(value=_literal_coord_value(idx.coord))
-    return ast.Name(id=idx.placeholder or idx.axis, ctx=ast.Load())
+    return ast.Name(id=idx.axis, ctx=ast.Load())
 
 
 def _call_func_ast(name: str) -> ast.expr:
@@ -629,8 +625,6 @@ def _render_coord(coord: object) -> str:  # noqa: PLR0911
 
 
 def _unparse_axis_index(idx: AxisIndex) -> str:
-    if idx.placeholder is not None:
-        return f"${idx.placeholder}"
     if idx.coord is not None:
         rendered = _render_coord(idx.coord)
         if idx.axis and idx.axis != idx.coord:
@@ -797,10 +791,9 @@ class AxisKind(StrEnum):
     """Classification of an ``AxisIndex`` after axis resolution.
 
     Categories:
-        FREE: A known axis name with no coord or placeholder
+        FREE: A known axis name with no coord
             (e.g. ``K[age]`` where ``age`` is a registered axis).
         COORD: A literal coord value (e.g. ``K[0]`` or ``K['x']``).
-        PLACEHOLDER: A ``$``-prefixed independent placeholder (#88).
         COORD_SYMBOL: An identifier used in a subscript that is not a known
             axis - treated as a bound coord variable
             (e.g. the ``ap`` in ``K[age, ap]`` when only ``age`` is an axis).
@@ -808,7 +801,6 @@ class AxisKind(StrEnum):
 
     FREE = "free"
     COORD = "coord"
-    PLACEHOLDER = "placeholder"
     COORD_SYMBOL = "coord_symbol"
 
 
@@ -822,8 +814,6 @@ def classify_axis_index(idx: AxisIndex, *, axis_names: frozenset[str]) -> AxisKi
     Returns:
         The :class:`AxisKind` describing this index position.
     """
-    if idx.placeholder is not None:
-        return AxisKind.PLACEHOLDER
     if idx.coord is not None:
         return AxisKind.COORD
     if idx.axis in axis_names:
@@ -1128,9 +1118,7 @@ def _resolve_index(idx: AxisIndex, *, axis_names: frozenset[str]) -> AxisIndex:
     kind = classify_axis_index(idx, axis_names=axis_names)
     if idx.kind is kind:
         return idx
-    return AxisIndex(
-        axis=idx.axis, coord=idx.coord, placeholder=idx.placeholder, kind=kind
-    )
+    return AxisIndex(axis=idx.axis, coord=idx.coord, kind=kind)
 
 
 def resolve_axis_kinds(expr: Expr, *, axis_names: frozenset[str]) -> Expr:  # noqa: PLR0911

--- a/src/op_system/_ir_expand.py
+++ b/src/op_system/_ir_expand.py
@@ -291,7 +291,7 @@ def _substitute_in_body(  # noqa: PLR0911, PLR0913
     return body  # pragma: no cover - exhaustive over Expr union
 
 
-def _rewrite_subscript(  # noqa: C901, PLR0912, PLR0913, PLR0915
+def _rewrite_subscript(  # noqa: C901, PLR0912, PLR0913
     sub: Subscript,
     *,
     var_to_coord: Mapping[str, str],
@@ -305,7 +305,6 @@ def _rewrite_subscript(  # noqa: C901, PLR0912, PLR0913, PLR0915
 
     For each :class:`AxisIndex` position:
 
-    * ``placeholder`` indices are passed through unchanged.
     * ``coord`` indices whose value names a binding variable resolve to
       that binding's current coord (consumed).
     * Bare ``axis`` tokens consume to ``bound[axis]`` (or, in the
@@ -331,8 +330,6 @@ def _rewrite_subscript(  # noqa: C901, PLR0912, PLR0913, PLR0915
     pinned_axes: set[str] = set()
     bare_axes: set[str] = set()
     for idx in sub.indices:
-        if idx.placeholder is not None:
-            continue
         if idx.coord is not None:
             if idx.coord in var_to_coord:
                 pinned_axes.add(idx.axis)
@@ -344,10 +341,6 @@ def _rewrite_subscript(  # noqa: C901, PLR0912, PLR0913, PLR0915
     remaining: list[AxisIndex] = []
     resolved_full: list[tuple[str, str | None]] = []
     for idx in sub.indices:
-        if idx.placeholder is not None:
-            resolved_full.append((idx.axis, None))
-            remaining.append(idx)
-            continue
         if idx.coord is not None:
             if idx.coord in var_to_coord:
                 c = var_to_coord[idx.coord]

--- a/src/op_system/_ir_templates.py
+++ b/src/op_system/_ir_templates.py
@@ -44,12 +44,12 @@ if TYPE_CHECKING:
 def _expandable_axes(indices: Sequence[AxisIndex]) -> list[str] | None:
     """Return the list of bare-identifier axis names from ``indices``.
 
-    Returns ``None`` if any index carries a literal coord or placeholder, in
+    Returns ``None`` if any index carries a literal coord, in
     which case the subscript is not eligible for template expansion.
     """
     out: list[str] = []
     for idx in indices:
-        if idx.coord is not None or idx.placeholder is not None:
+        if idx.coord is not None:
             return None
         out.append(idx.axis)
     return out
@@ -135,7 +135,7 @@ def expand_inline_templates(
 
     Returns:
         A new IR expression with templated subscripts expanded. Subscripts
-        that are not eligible (literal coords, placeholders, unknown axis
+        that are not eligible (literal coords, unknown axis
         names) are left untouched.
 
     Raises:
@@ -166,7 +166,7 @@ def expand_inline_templates(
             return expr
         return Apply(op=expr.op, args=new_args)
     if isinstance(expr, Reduce):
-        # Reduce bindings shadow placeholder names: a bound name in this
+        # Reduce bindings shadow outer names: a bound name in this
         # scope should not be substituted from the outer assignment.
         bound = {bind for _, bind in expr.bindings}
         inner_assignment = (
@@ -190,8 +190,8 @@ def expand_inline_templates(
 __all__ = [
     "expand_inline_templates",
     "expand_over_axes",
+    "free_axes",
     "inline_aliases",
-    "placeholder_axes",
 ]
 
 _CYCLE_WHITE = 0
@@ -208,7 +208,7 @@ def _collect_subscript_axes(
     if sub.name in shaped:
         return
     for idx in sub.indices:
-        if idx.coord is not None or idx.placeholder is not None:
+        if idx.coord is not None:
             continue
         if idx.axis:
             out.setdefault(idx.axis, None)
@@ -235,17 +235,17 @@ def _walk_for_axes(
             seen.pop(bind, None)
 
 
-def placeholder_axes(
+def free_axes(
     expr: Expr,
     *,
     shaped_params: Mapping[str, tuple[str, ...]] | None = None,
 ) -> tuple[str, ...]:
-    """Collect placeholder axis names referenced by ``expr``.
+    """Collect free (unbound, non-literal) axis names referenced by ``expr``.
 
     Walks the IR and gathers every bare-identifier axis appearing inside a
     ``Subscript`` whose base name is *not* a registered shaped parameter.
-    Literal-coord and ``$``-placeholder positions are skipped. Order is
-    deterministic: first appearance in pre-order traversal wins.
+    Literal-coord positions are skipped. Order is deterministic: first
+    appearance in pre-order traversal wins.
 
     Args:
         expr: Root IR expression.

--- a/tests/op_system/test_op_system_ir_axes.py
+++ b/tests/op_system/test_op_system_ir_axes.py
@@ -30,12 +30,6 @@ def test_classify_literal_coord() -> None:
     assert classify_axis_index(idx, axis_names=AXES) == AxisKind.COORD
 
 
-def test_classify_placeholder() -> None:
-    """A placeholder classifies as PLACEHOLDER and takes priority over axis."""
-    idx = AxisIndex(axis="age", placeholder="age")
-    assert classify_axis_index(idx, axis_names=AXES) == AxisKind.PLACEHOLDER
-
-
 def test_classify_unknown_symbol_is_coord_symbol() -> None:
     """An unknown identifier used as a subscript classifies as COORD_SYMBOL."""
     idx = AxisIndex(axis="ap")
@@ -66,22 +60,6 @@ def test_axis_kinds_for_parsed_expression() -> None:
         AxisKind.FREE,
         AxisKind.COORD_SYMBOL,
         AxisKind.FREE,
-    )
-
-
-def test_axis_kinds_handles_placeholder_dollar_syntax() -> None:
-    """``$``-prefixed indices are classified as PLACEHOLDER."""
-    expr = Subscript(
-        name="C",
-        indices=(
-            AxisIndex(axis="age"),
-            AxisIndex(axis="age", placeholder="age"),
-        ),
-    )
-
-    assert axis_kinds(expr, axis_names=AXES) == (
-        AxisKind.FREE,
-        AxisKind.PLACEHOLDER,
     )
 
 

--- a/tests/op_system/test_op_system_ir_resolve.py
+++ b/tests/op_system/test_op_system_ir_resolve.py
@@ -67,22 +67,3 @@ def test_resolve_axis_kinds_does_not_change_unparse_output() -> None:
     out = resolve_axis_kinds(expr, axis_names=AXES)
 
     assert unparse_ir(expr) == unparse_ir(out)
-
-
-def test_resolve_axis_kinds_preserves_placeholder_classification() -> None:
-    """Placeholder indices stay PLACEHOLDER regardless of axis registry."""
-    expr = Subscript(
-        name="C",
-        indices=(
-            AxisIndex(axis="age"),
-            AxisIndex(axis="age", placeholder="age"),
-        ),
-    )
-
-    out = resolve_axis_kinds(expr, axis_names=AXES)
-
-    assert isinstance(out, Subscript)
-    assert tuple(i.kind for i in out.indices) == (
-        AxisKind.FREE,
-        AxisKind.PLACEHOLDER,
-    )

--- a/tests/op_system/test_op_system_ir_templates.py
+++ b/tests/op_system/test_op_system_ir_templates.py
@@ -16,8 +16,8 @@ from op_system._ir import (
 from op_system._ir_templates import (
     expand_inline_templates,
     expand_over_axes,
+    free_axes,
     inline_aliases,
-    placeholder_axes,
 )
 from op_system._templates import _apply_template_substitutions
 
@@ -52,15 +52,6 @@ def test_expand_leaves_subscript_with_literal_coord() -> None:
     expr = Subscript(
         name="theta",
         indices=(AxisIndex(axis="", coord="0"),),
-    )
-    assert expand_inline_templates(expr, assignment={"age": "0_5"}) is expr
-
-
-def test_expand_leaves_subscript_with_placeholder() -> None:
-    """``$``-style placeholders are preserved, not expanded."""
-    expr = Subscript(
-        name="C",
-        indices=(AxisIndex(axis="age", placeholder="age"),),
     )
     assert expand_inline_templates(expr, assignment={"age": "0_5"}) is expr
 
@@ -155,37 +146,25 @@ def test_expand_parity_with_string_path_shaped_param() -> None:
     assert ir_out == parse_expr_to_ir(string_out)
 
 
-def test_placeholder_axes_collects_in_first_seen_order() -> None:
+def test_free_axes_collects_in_first_seen_order() -> None:
     """Placeholder axes are returned deterministically by walk order."""
     expr = parse_expr_to_ir("S[age] * theta[imm] + I[pop] * S[age]")
-    assert placeholder_axes(expr) == ("age", "imm", "pop")
+    assert free_axes(expr) == ("age", "imm", "pop")
 
 
-def test_placeholder_axes_skips_shaped_param_subscripts() -> None:
+def test_free_axes_skips_shaped_param_subscripts() -> None:
     """Subscripts whose base is a shaped param do not contribute axes."""
     expr = parse_expr_to_ir("theta[imm] * S[age]")
-    out = placeholder_axes(expr, shaped_params={"theta": ("imm",)})
+    out = free_axes(expr, shaped_params={"theta": ("imm",)})
     assert out == ("age",)
 
 
-def test_placeholder_axes_ignores_literal_coords_and_placeholders() -> None:
-    """Literal coords and ``$``-placeholders are not collected."""
-    expr = Subscript(
-        name="K",
-        indices=(
-            AxisIndex(axis="", coord="0"),
-            AxisIndex(axis="age", placeholder="age"),
-        ),
-    )
-    assert placeholder_axes(expr) == ()
-
-
-def test_placeholder_axes_drops_reduce_bound_names() -> None:
+def test_free_axes_drops_reduce_bound_names() -> None:
     """Names bound by a Reduce do not appear in the result set."""
     body = Subscript(name="C", indices=(AxisIndex(axis="age"), AxisIndex(axis="ap")))
     expr = Reduce(kind="sum_over", bindings=(("age", "ap"),), body=body)
     # "age" is still a free placeholder; "ap" is bound and dropped.
-    assert placeholder_axes(expr) == ("age",)
+    assert free_axes(expr) == ("age",)
 
 
 def test_expand_over_axes_empty_axes_returns_singleton() -> None:
@@ -211,7 +190,7 @@ def test_expand_over_axes_matches_string_path_named_only() -> None:
     """Each IR expansion matches parsing the string-path expansion."""
     src = "beta * S[age] + I[age]"
     expr = parse_expr_to_ir(src)
-    axes = placeholder_axes(expr)
+    axes = free_axes(expr)
     ir_results = expand_over_axes(expr, axes=axes, axis_lookup=AXIS_LOOKUP)
 
     for assignment, ir_expr in ir_results:
@@ -226,7 +205,7 @@ def test_expand_over_axes_matches_string_path_with_shaped_param() -> None:
     src = "theta[imm] * S[age]"
     shaped = {"theta": ("imm",)}
     expr = parse_expr_to_ir(src)
-    axes = placeholder_axes(expr, shaped_params=shaped)
+    axes = free_axes(expr, shaped_params=shaped)
     ir_results = expand_over_axes(
         expr,
         axes=("age", "imm"),  # include imm so theta gets rewritten
@@ -314,7 +293,7 @@ def test_alias_template_expands_to_one_ir_per_coord() -> None:
     """expand_over_axes on a templated alias body yields one entry per coord."""
     src = "b0 * S[age]"
     expr = parse_expr_to_ir(src)
-    axes = placeholder_axes(expr)
+    axes = free_axes(expr)
     results = expand_over_axes(expr, axes=axes, axis_lookup=AXIS_LOOKUP)
 
     assert axes == ("age",)


### PR DESCRIPTION
AxisIndex.placeholder and AxisKind.PLACEHOLDER were designed for a '~name' / '$name' repeated-axis shorthand syntax (#88) that is fully expressible via the existing apply_along/sum_over bound-axis syntax. The feature was never wired into the normalization or lowering pipeline and the parser dead code (node.id.startswith('$')) could never trigger because ast.parse rejects '$' as invalid Python.

Removals:
- AxisIndex.placeholder field
- AxisKind.PLACEHOLDER enum value
- Dead parser branch in _axis_index_from_expr
- placeholder branch in _axis_index_to_ast and _unparse_axis_index
- classify_axis_index PLACEHOLDER branch
- placeholder= propagation in _resolve_index
- Two 'if idx.placeholder is not None: continue' guards in _ir_expand.py
- 'or idx.placeholder is not None' guards in _ir_templates.py

Rename placeholder_axes -> free_axes (more accurate: it collects free unbound axes for template expansion, not $-placeholder positions). Remove 5 placeholder-specific tests; rename remaining placeholder_axes test functions to test_free_axes_*.

Refs #112