### PR TITLE
perf(#145): drive normalize_transitions_rhs from ~25s to ~2.45s on continuum spec

### DIFF
--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -436,6 +436,9 @@ def to_ir(node: ast.AST) -> Expr:  # noqa: C901, PLR0911, PLR0912
     _invalid(detail=f"unsupported AST node in IR parser: {type(node).__name__}")
 
 
+_PARSE_IR_CACHE: dict[tuple[str, bool], Expr] = {}
+
+
 def parse_expr_to_ir(expr: str, *, lower_helpers: bool = False) -> Expr:
     """Parse an expression string and convert it to typed IR.
 
@@ -447,13 +450,18 @@ def parse_expr_to_ir(expr: str, *, lower_helpers: bool = False) -> Expr:
         Parsed IR tree.
 
     """
+    key = (expr, lower_helpers)
+    cached = _PARSE_IR_CACHE.get(key)
+    if cached is not None:
+        return cached
     try:
         tree = ast.parse(expr, mode="eval")
     except SyntaxError as exc:
         _invalid(detail=f"invalid expression syntax: {exc.msg}")
     ir = to_ir(tree)
     if lower_helpers:
-        return lower_helper_calls(ir)
+        ir = lower_helper_calls(ir)
+    _PARSE_IR_CACHE[key] = ir
     return ir
 
 

--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -641,29 +641,47 @@ def _unparse_axis_index(idx: AxisIndex) -> str:
     return idx.axis
 
 
-def _unparse_call_args(args: tuple[Expr, ...]) -> str:
+def _unparse_call_args(
+    args: tuple[Expr, ...],
+    *,
+    _memo: dict[tuple[int, int, bool], str] | None = None,
+) -> str:
     parts: list[str] = []
     for arg in args:
         if isinstance(arg, Apply) and arg.op == "kwarg":
             key_node, value_node = arg.args
             if not isinstance(key_node, Literal) or not isinstance(key_node.value, str):
                 _invalid(detail="malformed kwarg node in IR unparser")
-            parts.append(f"{key_node.value}={unparse_ir(value_node)}")
+            parts.append(
+                f"{key_node.value}="
+                f"{_unparse_ir(value_node, parent_prec=0, is_right=False, _memo=_memo)}"
+            )
         else:
-            parts.append(unparse_ir(arg))
+            parts.append(_unparse_ir(arg, parent_prec=0, is_right=False, _memo=_memo))
     return ", ".join(parts)
 
 
-def unparse_ir(expr: Expr) -> str:
+def unparse_ir(
+    expr: Expr,
+    *,
+    _memo: dict[tuple[int, int, bool], str] | None = None,
+) -> str:
     """Render a typed IR expression back to its Python source string.
 
     Args:
         expr: Typed IR expression.
+        _memo: Optional identity-keyed cache of already-rendered
+            subexpressions, used to amortize rendering of structurally
+            shared IR across many top-level expressions (e.g. when many
+            cells of one template share the same synthesized IR object;
+            issue #145). When provided, the cache must not be reused
+            across IR trees built with different ``parse_expr_to_ir``
+            options.
 
     Returns:
         Python expression source string equivalent to ``expr``.
     """
-    return _unparse_ir(expr, parent_prec=0, is_right=False)
+    return _unparse_ir(expr, parent_prec=0, is_right=False, _memo=_memo)
 
 
 # Operator precedence (higher binds tighter). Mirrors Python's grammar for
@@ -723,14 +741,15 @@ def _unparse_binary(
     prec: int,
     parent_prec: int,
     is_right: bool,
+    _memo: dict[tuple[int, int, bool], str] | None = None,
 ) -> str:
     sep = f" {op} "
     # Fold args left-associatively so multi-arg flatten still renders correctly.
     args = expr.args
-    left_str = _unparse_ir(args[0], parent_prec=prec, is_right=False)
+    left_str = _unparse_ir(args[0], parent_prec=prec, is_right=False, _memo=_memo)
     rendered = left_str
     for nxt in args[1:]:
-        right_str = _unparse_ir(nxt, parent_prec=prec, is_right=True)
+        right_str = _unparse_ir(nxt, parent_prec=prec, is_right=True, _memo=_memo)
         rendered = f"{rendered}{sep}{right_str}"
     need_parens = prec < parent_prec or (
         prec == parent_prec and is_right and op in _LEFT_ASSOC_NEEDS_RIGHT_PARENS
@@ -738,59 +757,92 @@ def _unparse_binary(
     return _wrap(rendered, need=need_parens)
 
 
-def _unparse_ir(  # noqa: C901, PLR0911
+def _unparse_ir(  # noqa: C901, PLR0912
     expr: Expr,
     *,
     parent_prec: int,
     is_right: bool,
+    _memo: dict[tuple[int, int, bool], str] | None = None,
 ) -> str:
+    key: tuple[int, int, bool] | None = None
+    if _memo is not None:
+        key = (id(expr), parent_prec, is_right)
+        cached = _memo.get(key)
+        if cached is not None:
+            return cached
+
+    result: str
     if isinstance(expr, Literal):
-        return repr(expr.value)
+        result = repr(expr.value)
+        if _memo is not None and key is not None:
+            _memo[key] = result
+        return result
 
     if isinstance(expr, Sym):
+        if _memo is not None and key is not None:
+            _memo[key] = expr.name
         return expr.name
 
     if isinstance(expr, Subscript):
         idx_str = ", ".join(_unparse_axis_index(i) for i in expr.indices)
-        return f"{expr.name}[{idx_str}]"
+        result = f"{expr.name}[{idx_str}]"
+        if _memo is not None and key is not None:
+            _memo[key] = result
+        return result
 
     if isinstance(expr, Apply):
         if expr.op == "neg" and len(expr.args) == 1:
-            inner = _unparse_ir(expr.args[0], parent_prec=_PREC_UNARY, is_right=False)
+            inner = _unparse_ir(
+                expr.args[0], parent_prec=_PREC_UNARY, is_right=False, _memo=_memo
+            )
             need = parent_prec > _PREC_UNARY
-            return _wrap(f"-{inner}", need=need)
-        if expr.op == "pos" and len(expr.args) == 1:
-            inner = _unparse_ir(expr.args[0], parent_prec=_PREC_UNARY, is_right=False)
+            result = _wrap(f"-{inner}", need=need)
+        elif expr.op == "pos" and len(expr.args) == 1:
+            inner = _unparse_ir(
+                expr.args[0], parent_prec=_PREC_UNARY, is_right=False, _memo=_memo
+            )
             need = parent_prec > _PREC_UNARY
-            return _wrap(f"+{inner}", need=need)
-        if expr.op == "pow" and len(expr.args) == 2:
-            left = _unparse_ir(expr.args[0], parent_prec=_PREC_POW + 1, is_right=False)
-            right = _unparse_ir(expr.args[1], parent_prec=_PREC_POW, is_right=True)
+            result = _wrap(f"+{inner}", need=need)
+        elif expr.op == "pow" and len(expr.args) == 2:
+            left = _unparse_ir(
+                expr.args[0], parent_prec=_PREC_POW + 1, is_right=False, _memo=_memo
+            )
+            right = _unparse_ir(
+                expr.args[1], parent_prec=_PREC_POW, is_right=True, _memo=_memo
+            )
             need = parent_prec > _PREC_POW
-            return _wrap(f"{left} ** {right}", need=need)
-        if expr.op == "ifelse" and len(expr.args) == 3:
+            result = _wrap(f"{left} ** {right}", need=need)
+        elif expr.op == "ifelse" and len(expr.args) == 3:
             test, body, orelse = expr.args
             rendered = (
-                f"{_unparse_ir(body, parent_prec=1, is_right=False)} if "
-                f"{_unparse_ir(test, parent_prec=1, is_right=False)} else "
-                f"{_unparse_ir(orelse, parent_prec=0, is_right=False)}"
+                f"{_unparse_ir(body, parent_prec=1, is_right=False, _memo=_memo)} if "
+                f"{_unparse_ir(test, parent_prec=1, is_right=False, _memo=_memo)} else "
+                f"{_unparse_ir(orelse, parent_prec=0, is_right=False, _memo=_memo)}"
             )
-            return _wrap(rendered, need=parent_prec > 0)
-        if expr.op in _BINARY_PREC and len(expr.args) >= 2:
-            return _unparse_binary(
+            result = _wrap(rendered, need=parent_prec > 0)
+        elif expr.op in _BINARY_PREC and len(expr.args) >= 2:
+            result = _unparse_binary(
                 expr,
                 op=expr.op,
                 prec=_BINARY_PREC[expr.op],
                 parent_prec=parent_prec,
                 is_right=is_right,
+                _memo=_memo,
             )
-        return f"{expr.op}({_unparse_call_args(expr.args)})"
+        else:
+            result = f"{expr.op}({_unparse_call_args(expr.args, _memo=_memo)})"
+        if _memo is not None and key is not None:
+            _memo[key] = result
+        return result
 
     if isinstance(expr, Reduce):
         binding_str = ", ".join(f"{k}={v}" for k, v in expr.bindings)
         suffix = f", {binding_str}" if binding_str else ""
-        body_str = _unparse_ir(expr.body, parent_prec=0, is_right=False)
-        return f"{expr.kind}({body_str}{suffix})"
+        body_str = _unparse_ir(expr.body, parent_prec=0, is_right=False, _memo=_memo)
+        result = f"{expr.kind}({body_str}{suffix})"
+        if _memo is not None and key is not None:
+            _memo[key] = result
+        return result
 
     _invalid(detail=f"unsupported IR node in unparser: {type(expr).__name__}")
 

--- a/src/op_system/_ir_expand.py
+++ b/src/op_system/_ir_expand.py
@@ -102,19 +102,19 @@ def _expand_children(
     if isinstance(expr, (Literal, Sym, Subscript)):
         return expr
     if isinstance(expr, Apply):
-        return Apply(
-            op=expr.op,
-            args=tuple(
-                expand_reduce_pointwise(
-                    a,
-                    axes=axes,
-                    shaped_params=shaped_params,
-                    lhs_assignment=lhs_assignment,
-                    axis_coords=axis_coords,
-                )
-                for a in expr.args
-            ),
+        new_args = tuple(
+            expand_reduce_pointwise(
+                a,
+                axes=axes,
+                shaped_params=shaped_params,
+                lhs_assignment=lhs_assignment,
+                axis_coords=axis_coords,
+            )
+            for a in expr.args
         )
+        if all(n is o for n, o in zip(new_args, expr.args, strict=True)):
+            return expr
+        return Apply(op=expr.op, args=new_args)
     if isinstance(expr, Reduce):
         new_body = expand_reduce_pointwise(
             expr.body,
@@ -123,6 +123,8 @@ def _expand_children(
             lhs_assignment=lhs_assignment,
             axis_coords=axis_coords,
         )
+        if new_body is expr.body:
+            return expr
         return Reduce(
             kind=expr.kind,
             bindings=expr.bindings,
@@ -242,21 +244,21 @@ def _substitute_in_body(  # noqa: PLR0911, PLR0913
             return Sym(name=var_to_coord[body.name])
         return body
     if isinstance(body, Apply):
-        return Apply(
-            op=body.op,
-            args=tuple(
-                _substitute_in_body(
-                    a,
-                    var_to_coord=var_to_coord,
-                    bound=bound,
-                    axis_order=axis_order,
-                    shaped_params=shaped_params,
-                    lhs_assignment=lhs_assignment,
-                    axis_coords=axis_coords,
-                )
-                for a in body.args
-            ),
+        new_args = tuple(
+            _substitute_in_body(
+                a,
+                var_to_coord=var_to_coord,
+                bound=bound,
+                axis_order=axis_order,
+                shaped_params=shaped_params,
+                lhs_assignment=lhs_assignment,
+                axis_coords=axis_coords,
+            )
+            for a in body.args
         )
+        if all(n is o for n, o in zip(new_args, body.args, strict=True)):
+            return body
+        return Apply(op=body.op, args=new_args)
     if isinstance(body, Subscript):
         return _rewrite_subscript(
             body,
@@ -281,6 +283,8 @@ def _substitute_in_body(  # noqa: PLR0911, PLR0913
             lhs_assignment=lhs_assignment,
             axis_coords=axis_coords,
         )
+        if new_inner is body.body:
+            return body
         return Reduce(
             kind=body.kind,
             bindings=body.bindings,

--- a/src/op_system/_ir_expand.py
+++ b/src/op_system/_ir_expand.py
@@ -419,6 +419,25 @@ def _split_name_suffix(
         ``(base_name, [(axis, coord), ...])`` where pairs are in left-to-
         right order as they appeared in ``name``.
     """
+    ao = tuple(axis_order)
+    key = (name, ao)
+    cached = _SPLIT_SUFFIX_CACHE.get(key)
+    if cached is not None:
+        base, pairs = cached
+        return base, list(pairs)
+    base, pairs_list = _split_name_suffix_impl(name, ao)
+    _SPLIT_SUFFIX_CACHE[key] = (base, tuple(pairs_list))
+    return base, pairs_list
+
+
+_SPLIT_SUFFIX_CACHE: dict[
+    tuple[str, tuple[str, ...]], tuple[str, tuple[tuple[str, str], ...]]
+] = {}
+
+
+def _split_name_suffix_impl(
+    name: str, axis_order: Sequence[str]
+) -> tuple[str, list[tuple[str, str]]]:
     if not axis_order:
         return name, []
     parts = name.split("__")
@@ -454,12 +473,23 @@ def _emit_suffix(pairs: list[tuple[str, str]], axis_order: Sequence[str]) -> str
     Returns:
         The concatenated suffix string (empty when ``pairs`` is empty).
     """
-    priority = {ax: i for i, ax in enumerate(axis_order)}
+    ao = tuple(axis_order)
+    key = (tuple(pairs), ao)
+    cached = _EMIT_SUFFIX_CACHE.get(key)
+    if cached is not None:
+        return cached
+    priority = {ax: i for i, ax in enumerate(ao)}
     if not priority:
-        return "".join(f"__{ax}_{_sanitize_fragment(c)}" for ax, c in pairs)
-    known = sorted(
-        (p for p in pairs if p[0] in priority),
-        key=lambda p: priority[p[0]],
-    )
-    unknown = [p for p in pairs if p[0] not in priority]
-    return "".join(f"__{ax}_{_sanitize_fragment(c)}" for ax, c in known + unknown)
+        result = "".join(f"__{ax}_{_sanitize_fragment(c)}" for ax, c in pairs)
+    else:
+        known = sorted(
+            (p for p in pairs if p[0] in priority),
+            key=lambda p: priority[p[0]],
+        )
+        unknown = [p for p in pairs if p[0] not in priority]
+        result = "".join(f"__{ax}_{_sanitize_fragment(c)}" for ax, c in known + unknown)
+    _EMIT_SUFFIX_CACHE[key] = result
+    return result
+
+
+_EMIT_SUFFIX_CACHE: dict[tuple[tuple[tuple[str, str], ...], tuple[str, ...]], str] = {}

--- a/src/op_system/_ir_templates.py
+++ b/src/op_system/_ir_templates.py
@@ -367,13 +367,14 @@ def _detect_alias_cycle(
     return None
 
 
-def inline_aliases(
+def inline_aliases(  # noqa: C901, PLR0913
     expr: Expr,
     aliases: Mapping[str, Expr],
     *,
     max_depth: int = 64,
     memo: dict[int, frozenset[str]] | None = None,
     skip_cycle_check: bool = False,
+    result_memo: dict[int, Expr] | None = None,
 ) -> Expr:
     """Fixed-point inline ``Sym`` references that match ``aliases`` keys.
 
@@ -398,6 +399,11 @@ def inline_aliases(
             Callers that batch-inline many expressions against the same
             ``aliases`` mapping should validate once and set this flag on
             subsequent calls.
+        result_memo: Optional identity-keyed cache mapping ``id(expr)`` to
+            the fully-inlined result. When the same IR object is inlined
+            many times against the same ``aliases`` (e.g. one template's
+            synthesized IR shared across many state cells), pass a
+            single dict to amortize the substitution work across calls.
 
     Returns:
         A new IR expression with all alias references resolved.
@@ -408,6 +414,10 @@ def inline_aliases(
     """
     if not aliases:
         return expr
+    if result_memo is not None:
+        cached_result = result_memo.get(id(expr))
+        if cached_result is not None:
+            return cached_result
 
     if not skip_cycle_check:
         cycle = _detect_alias_cycle(aliases)
@@ -447,6 +457,8 @@ def inline_aliases(
     live = free_symbols(current, memo) & keys
     for _ in range(max_depth):
         if not live:
+            if result_memo is not None:
+                result_memo[id(expr)] = current
             return current
         mapping = {name: aliases[name] for name in live}
         current = substitute(current, mapping, memo)

--- a/src/op_system/_ir_templates.py
+++ b/src/op_system/_ir_templates.py
@@ -144,39 +144,46 @@ def _free_axes_in(
     cached = memo.get(id(node))
     if cached is not None:
         return cached
-    if isinstance(node, (Literal, Sym)):
-        result = _EMPTY_AXES
-    elif isinstance(node, Subscript):
-        if node.name in shaped:
-            # Treat all registered axes as referenced so shaped rewrite
-            # still fires when ``assignment`` covers them.
-            result = frozenset(shaped[node.name])
-        else:
-            out: set[str] = set()
-            for idx in node.indices:
-                if idx.coord is None and idx.axis:
-                    out.add(idx.axis)
-            result = frozenset(out) if out else _EMPTY_AXES
-    elif isinstance(node, Apply):
-        if not node.args:
-            result = _EMPTY_AXES
-        else:
-            acc: set[str] = set()
-            for arg in node.args:
-                acc |= _free_axes_in(arg, shaped=shaped, memo=memo)
-            result = frozenset(acc) if acc else _EMPTY_AXES
-    elif isinstance(node, Reduce):
-        body_axes = _free_axes_in(node.body, shaped=shaped, memo=memo)
-        bound = {b for _, b in node.bindings}
-        if bound and body_axes:
-            remaining = body_axes - bound
-            result = remaining if remaining else _EMPTY_AXES
-        else:
-            result = body_axes
-    else:
-        result = _EMPTY_AXES
+    result = _compute_free_axes(node, shaped=shaped, memo=memo)
     memo[id(node)] = result
     return result
+
+
+def _free_axes_subscript(
+    node: Subscript, *, shaped: Mapping[str, tuple[str, ...]]
+) -> frozenset[str]:
+    if node.name in shaped:
+        # Treat all registered axes as referenced so shaped rewrite
+        # still fires when ``assignment`` covers them.
+        return frozenset(shaped[node.name])
+    out: set[str] = set()
+    for idx in node.indices:
+        if idx.coord is None and idx.axis:
+            out.add(idx.axis)
+    return frozenset(out) or _EMPTY_AXES
+
+
+def _compute_free_axes(
+    node: Expr,
+    *,
+    shaped: Mapping[str, tuple[str, ...]],
+    memo: dict[int, frozenset[str]],
+) -> frozenset[str]:
+    if isinstance(node, Subscript):
+        return _free_axes_subscript(node, shaped=shaped)
+    if isinstance(node, Apply):
+        acc: set[str] = set()
+        for arg in node.args:
+            acc |= _free_axes_in(arg, shaped=shaped, memo=memo)
+        return frozenset(acc) or _EMPTY_AXES
+    if isinstance(node, Reduce):
+        body_axes = _free_axes_in(node.body, shaped=shaped, memo=memo)
+        bound = {b for _, b in node.bindings}
+        if not (bound and body_axes):
+            return body_axes
+        return (body_axes - bound) or _EMPTY_AXES
+    # Literal, Sym, and any other leaf node carry no free axes.
+    return _EMPTY_AXES
 
 
 def expand_inline_templates(
@@ -240,40 +247,74 @@ def expand_inline_templates(
     ):
         return expr
     if isinstance(expr, Apply):
-        new_args = tuple(
-            expand_inline_templates(
-                arg,
-                assignment=assignment,
-                shaped_params=shaped,
-                axis_lookup=axis_lookup,
-                _free_axes_memo=_free_axes_memo,
-            )
-            for arg in expr.args
-        )
-        if new_args == expr.args:
-            return expr
-        return Apply(op=expr.op, args=new_args)
-    if isinstance(expr, Reduce):
-        # Reduce bindings shadow outer names: a bound name in this
-        # scope should not be substituted from the outer assignment.
-        bound = {bind for _, bind in expr.bindings}
-        inner_assignment = (
-            assignment
-            if not bound
-            else {k: v for k, v in assignment.items() if k not in bound}
-        )
-        new_body = expand_inline_templates(
-            expr.body,
-            assignment=inner_assignment,
+        return _expand_apply(
+            expr,
+            assignment=assignment,
             shaped_params=shaped,
             axis_lookup=axis_lookup,
-            _free_axes_memo=_free_axes_memo,
+            free_axes_memo=_free_axes_memo,
         )
-        if new_body is expr.body:
-            return expr
-        return Reduce(kind=expr.kind, bindings=expr.bindings, body=new_body)
+    if isinstance(expr, Reduce):
+        return _expand_reduce(
+            expr,
+            assignment=assignment,
+            shaped_params=shaped,
+            axis_lookup=axis_lookup,
+            free_axes_memo=_free_axes_memo,
+        )
     msg = f"unsupported IR node in expand_inline_templates: {type(expr).__name__}"
     raise TypeError(msg)
+
+
+def _expand_apply(
+    expr: Apply,
+    *,
+    assignment: Mapping[str, str],
+    shaped_params: Mapping[str, tuple[str, ...]],
+    axis_lookup: Mapping[str, Sequence[str]] | None,
+    free_axes_memo: dict[int, frozenset[str]] | None,
+) -> Expr:
+    new_args = tuple(
+        expand_inline_templates(
+            arg,
+            assignment=assignment,
+            shaped_params=shaped_params,
+            axis_lookup=axis_lookup,
+            _free_axes_memo=free_axes_memo,
+        )
+        for arg in expr.args
+    )
+    if new_args == expr.args:
+        return expr
+    return Apply(op=expr.op, args=new_args)
+
+
+def _expand_reduce(
+    expr: Reduce,
+    *,
+    assignment: Mapping[str, str],
+    shaped_params: Mapping[str, tuple[str, ...]],
+    axis_lookup: Mapping[str, Sequence[str]] | None,
+    free_axes_memo: dict[int, frozenset[str]] | None,
+) -> Expr:
+    # Reduce bindings shadow outer names: a bound name in this
+    # scope should not be substituted from the outer assignment.
+    bound = {bind for _, bind in expr.bindings}
+    inner_assignment = (
+        assignment
+        if not bound
+        else {k: v for k, v in assignment.items() if k not in bound}
+    )
+    new_body = expand_inline_templates(
+        expr.body,
+        assignment=inner_assignment,
+        shaped_params=shaped_params,
+        axis_lookup=axis_lookup,
+        _free_axes_memo=free_axes_memo,
+    )
+    if new_body is expr.body:
+        return expr
+    return Reduce(kind=expr.kind, bindings=expr.bindings, body=new_body)
 
 
 __all__ = [

--- a/src/op_system/_ir_templates.py
+++ b/src/op_system/_ir_templates.py
@@ -41,6 +41,15 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
 
 
+# Identity-keyed cache mapping ``id(aliases)`` -> ``(aliases, body_refs)``.
+# Many ``inline_aliases`` calls in batch passes share the same ``aliases``
+# mapping, and the ``body_refs`` precomputation is the dominant non-substitute
+# cost (free_symbols over each large alias body). Cache by identity but also
+# store the dict object so we can defensively guard against ``id()`` reuse
+# across distinct ``aliases`` instances (issue #145).
+_BODY_REFS_CACHE: dict[int, tuple[Mapping[str, Expr], dict[str, frozenset[str]]]] = {}
+
+
 def _expandable_axes(indices: Sequence[AxisIndex]) -> list[str] | None:
     """Return the list of bare-identifier axis names from ``indices``.
 
@@ -308,15 +317,28 @@ def expand_over_axes(
     return out
 
 
-def _detect_alias_cycle(aliases: Mapping[str, Expr]) -> list[str] | None:
+def _detect_alias_cycle(
+    aliases: Mapping[str, Expr],
+    *,
+    memo: dict[int, frozenset[str]] | None = None,
+) -> list[str] | None:
     """Return a cycle of alias names if one exists, else ``None``.
 
     Builds a name -> referenced-alias-names graph (only edges into the
     alias namespace itself count) and DFS-checks for a back edge.
+
+    Args:
+        aliases: Mapping of alias name to IR body.
+        memo: Optional identity-keyed ``free_symbols`` cache (shared
+            with downstream ``inline_aliases`` calls to avoid
+            recomputing per-body free-symbol sets).
     """
     keys = set(aliases)
+    if memo is None:
+        memo = {}
     graph: dict[str, frozenset[str]] = {
-        name: frozenset(free_symbols(body) & keys) for name, body in aliases.items()
+        name: frozenset(free_symbols(body, memo=memo) & keys)
+        for name, body in aliases.items()
     }
 
     color: dict[str, int] = dict.fromkeys(graph, _CYCLE_WHITE)
@@ -401,9 +423,26 @@ def inline_aliases(
     # entries over the just-inlined names, so we never need to re-walk the
     # substituted expression with ``free_symbols`` (which on large inlined
     # bodies dominates inline cost when many equations share one alias).
-    body_refs: dict[str, frozenset[str]] = {
-        name: free_symbols(body, memo) & keys for name, body in aliases.items()
-    }
+    # Cache by ``id(aliases)`` so batch-inlining many expressions against the
+    # same alias mapping pays this O(|aliases| * body_size) cost only once
+    # rather than once per call (issue #145).
+    cached_refs = _BODY_REFS_CACHE.get(id(aliases))
+    if cached_refs is None:
+        body_refs: dict[str, frozenset[str]] = {
+            name: free_symbols(body, memo) & keys for name, body in aliases.items()
+        }
+        _BODY_REFS_CACHE[id(aliases)] = (aliases, body_refs)
+    else:
+        # Guard against id() reuse: only trust the cache when the mapping
+        # object is the same instance.
+        cached_obj, cached_body_refs = cached_refs
+        body_refs = (
+            cached_body_refs
+            if cached_obj is aliases
+            else {
+                name: free_symbols(body, memo) & keys for name, body in aliases.items()
+            }
+        )
     current = expr
     live = free_symbols(current, memo) & keys
     for _ in range(max_depth):

--- a/src/op_system/_ir_templates.py
+++ b/src/op_system/_ir_templates.py
@@ -121,12 +121,71 @@ def _expand_subscript(
     return Sym(name=rendered)
 
 
+_EMPTY_AXES: frozenset[str] = frozenset()
+
+
+def _free_axes_in(
+    node: Expr,
+    *,
+    shaped: Mapping[str, tuple[str, ...]],
+    memo: dict[int, frozenset[str]],
+) -> frozenset[str]:
+    """Return the set of placeholder axis names referenced under ``node``.
+
+    Walks the IR subtree counting any unbound axis appearing inside a
+    ``Subscript``. For shaped-parameter subscripts (whose axes are rewritten
+    to literal integer coords by ``_rewrite_shaped_indices``), the
+    registered axis tuple is included so callers using this set for
+    disjoint-check pruning still descend when ``assignment`` covers them.
+    ``Reduce`` bindings shadow outer names and are subtracted from the body
+    set. Memoized by ``id(node)`` so repeated calls with the same memo
+    visit each unique subtree at most once (issue #145).
+    """
+    cached = memo.get(id(node))
+    if cached is not None:
+        return cached
+    if isinstance(node, (Literal, Sym)):
+        result = _EMPTY_AXES
+    elif isinstance(node, Subscript):
+        if node.name in shaped:
+            # Treat all registered axes as referenced so shaped rewrite
+            # still fires when ``assignment`` covers them.
+            result = frozenset(shaped[node.name])
+        else:
+            out: set[str] = set()
+            for idx in node.indices:
+                if idx.coord is None and idx.axis:
+                    out.add(idx.axis)
+            result = frozenset(out) if out else _EMPTY_AXES
+    elif isinstance(node, Apply):
+        if not node.args:
+            result = _EMPTY_AXES
+        else:
+            acc: set[str] = set()
+            for arg in node.args:
+                acc |= _free_axes_in(arg, shaped=shaped, memo=memo)
+            result = frozenset(acc) if acc else _EMPTY_AXES
+    elif isinstance(node, Reduce):
+        body_axes = _free_axes_in(node.body, shaped=shaped, memo=memo)
+        bound = {b for _, b in node.bindings}
+        if bound and body_axes:
+            remaining = body_axes - bound
+            result = remaining if remaining else _EMPTY_AXES
+        else:
+            result = body_axes
+    else:
+        result = _EMPTY_AXES
+    memo[id(node)] = result
+    return result
+
+
 def expand_inline_templates(
     expr: Expr,
     *,
     assignment: Mapping[str, str],
     shaped_params: Mapping[str, tuple[str, ...]] | None = None,
     axis_lookup: Mapping[str, Sequence[str]] | None = None,
+    _free_axes_memo: dict[int, frozenset[str]] | None = None,
 ) -> Expr:
     """Expand placeholder subscripts in ``expr`` using ``assignment``.
 
@@ -141,6 +200,13 @@ def expand_inline_templates(
             symbols.
         axis_lookup: Optional mapping from axis name to its coord list,
             used to resolve shaped-parameter indices.
+        _free_axes_memo: Optional id-keyed cache of the per-subtree
+            unbound-axis set. When supplied, the walk short-circuits at
+            compound nodes whose free-axis set is disjoint from
+            ``assignment``. Callers that invoke this function repeatedly
+            with the same root (e.g. per-coord alias pinning) should
+            share one dict to avoid recomputing the cache. Caller-owned
+            so callers control lifetime; pass an empty dict to enable.
 
     Returns:
         A new IR expression with templated subscripts expanded. Subscripts
@@ -161,6 +227,18 @@ def expand_inline_templates(
             shaped_params=shaped,
             axis_lookup=axis_lookup,
         )
+    # Compound nodes (Apply / Reduce): skip the recursion entirely when
+    # the cached free-axis set is disjoint from ``assignment``. This is
+    # the dominant win for per-coord alias pinning where ``assignment``
+    # is ``{<one-axis>: ...}`` but the body spans many axes (issue #145).
+    if (
+        _free_axes_memo is not None
+        and assignment
+        and _free_axes_in(expr, shaped=shaped, memo=_free_axes_memo).isdisjoint(
+            assignment
+        )
+    ):
+        return expr
     if isinstance(expr, Apply):
         new_args = tuple(
             expand_inline_templates(
@@ -168,6 +246,7 @@ def expand_inline_templates(
                 assignment=assignment,
                 shaped_params=shaped,
                 axis_lookup=axis_lookup,
+                _free_axes_memo=_free_axes_memo,
             )
             for arg in expr.args
         )
@@ -188,6 +267,7 @@ def expand_inline_templates(
             assignment=inner_assignment,
             shaped_params=shaped,
             axis_lookup=axis_lookup,
+            _free_axes_memo=_free_axes_memo,
         )
         if new_body is expr.body:
             return expr

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -1510,6 +1510,25 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
     # plus 72k dict lookups (issue #145).
     outer_inline_memo: dict[int, Expr] = {}
 
+    def _inline_outer(expr: Expr) -> Expr:
+        """Run alias-inlining for one outer equation expression.
+
+        Returns:
+            The inlined expression (possibly the original ``expr`` when no
+            inlining was needed).
+        """
+        if isinstance(expr, Apply) and expr.op == "+":
+            new_args = tuple(_inline_one(a) for a in expr.args)
+            if all(n is o for n, o in zip(new_args, expr.args, strict=True)):
+                return expr
+            dedup_key = tuple(id(a) for a in new_args)
+            cached_apply = apply_plus_dedup.get(dedup_key)
+            if cached_apply is None:
+                cached_apply = Apply(op="+", args=new_args)
+                apply_plus_dedup[dedup_key] = cached_apply
+            return cached_apply
+        return _inline_one(expr)
+
     equations_ir_built_list: list[Expr | None] = []
     for expr in equations_ir_pre_inline:
         if expr is None:
@@ -1523,19 +1542,7 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
             equations_ir_built_list.append(cached_outer)
             continue
         try:
-            if isinstance(expr, Apply) and expr.op == "+":
-                new_args = tuple(_inline_one(a) for a in expr.args)
-                if all(n is o for n, o in zip(new_args, expr.args, strict=True)):
-                    result_expr: Expr = expr
-                else:
-                    dedup_key = tuple(id(a) for a in new_args)
-                    cached_apply = apply_plus_dedup.get(dedup_key)
-                    if cached_apply is None:
-                        cached_apply = Apply(op="+", args=new_args)
-                        apply_plus_dedup[dedup_key] = cached_apply
-                    result_expr = cached_apply
-            else:
-                result_expr = _inline_one(expr)
+            result_expr = _inline_outer(expr)
         except (ValueError, RecursionError):
             result_expr = expr
         outer_inline_memo[id(expr)] = result_expr

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -54,6 +54,7 @@ from op_system._ir import (
     free_symbols,
     parse_expr_to_ir,
     unparse_ir,
+    walk,
 )
 from op_system._ir_templates import (
     expand_inline_templates,
@@ -538,6 +539,7 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
     shaped_params: Mapping[str, tuple[str, ...]] | None = None,
     mask_names: Mapping[tuple[str, str], str] | None = None,
     time_axis_name: str | None = None,
+    alias_bases: set[str] | None = None,
 ) -> tuple[
     tuple[Expr | None, ...],
     tuple[Expr | None, ...],
@@ -557,6 +559,7 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
     shaped = shaped_params or {}
     masks = mask_names or {}
     ax_lookup_dict = dict(axis_lookup)
+    alias_base_set: set[str] = set(alias_bases or ())
     d_ir_full: dict[str, list[Expr]] = {s: [] for s in state_expanded}
     d_ir_reduce: dict[str, list[Expr]] = {s: [] for s in state_expanded}
     all_syms: set[str] = set()
@@ -671,6 +674,76 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
             )
             to_names_for_synthesis: set[str] = set()
             from_names_for_synthesis: set[str] = set()
+            # Template-uniform non-synth fast-path. When the from-template
+            # and the to-template have the same wildcard axis set and
+            # there are no pinned tokens, no destination-only axes, and
+            # no rate-only axes, every (from_cell, to_cell) combo of this
+            # transition contributes the SAME ``rate * from_state``
+            # template-form flow to its respective cell. Building that
+            # IR once at the template level (``assignment={}``, with the
+            # ``from`` reference as a ``Subscript`` carrying symbolic
+            # ``AxisIndex(coord=None)`` slots) lets every cell of both
+            # templates share the same IR by object identity, which
+            # collapses the dominant per-cell ``inline_aliases`` /
+            # ``unparse_ir`` / ``free_symbols`` work from O(n_state) to
+            # O(n_template) on continuum specs (issue #145).
+            tpl_uniform = (
+                not synthesize
+                and bool(frm_wc_axes)
+                and frm_wc_set == to_wc_set
+                and not from_only_axes
+                and not to_only_axes
+                and not expr_only_axes
+                and not has_pinned
+            )
+            if tpl_uniform and alias_base_set:
+                # Disable the fast-path when the rate references an
+                # alias. The downstream alias-inline pass keys on
+                # fully-pinned ``Sym("alias__axis_coord")`` references
+                # (produced by per-combo ``expand_inline_templates`` with
+                # a non-empty ``assignment``); a template-form
+                # ``Subscript("alias", (AxisIndex(coord=None), ...))``
+                # would slip through unresolved and break compilation.
+                for node in walk(ir_rate_raw):
+                    if (
+                        isinstance(node, (Sym, Subscript))
+                        and node.name in alias_base_set
+                    ):
+                        tpl_uniform = False
+                        break
+            tpl_neg_flow_full: Expr | None = None
+            tpl_flow_full: Expr | None = None
+            tpl_neg_flow_reduce: Expr | None = None
+            tpl_flow_reduce: Expr | None = None
+            tpl_ir_rate_full: Expr | None = None
+            tpl_rate_string: str | None = None
+            if tpl_uniform:
+                # Build template-form (axes symbolic) rate IR once.
+                tpl_ir_rate_reduce = expand_inline_templates(
+                    ir_rate_raw,
+                    assignment={},
+                    shaped_params=shaped,
+                    axis_lookup=ax_lookup_dict,
+                )
+                tpl_ir_rate_full = expand_reduce_pointwise(
+                    tpl_ir_rate_reduce,
+                    axes=list(axes),
+                    shaped_params=shaped,
+                    lhs_assignment={},
+                    axis_coords=ax_lookup_dict,
+                )
+                # ``from`` reference as a template-form Subscript over the
+                # from-template's wildcard axes.
+                tpl_from_sub = Subscript(
+                    name=frm_base,
+                    indices=tuple(AxisIndex(axis=ax, coord=None) for ax in frm_wc_axes),
+                )
+                tpl_flow_full = Apply(op="*", args=(tpl_ir_rate_full, tpl_from_sub))
+                tpl_flow_reduce = Apply(op="*", args=(tpl_ir_rate_reduce, tpl_from_sub))
+                tpl_neg_flow_full = Apply(op="neg", args=(tpl_flow_full,))
+                tpl_neg_flow_reduce = Apply(op="neg", args=(tpl_flow_reduce,))
+                all_syms |= free_symbols(tpl_ir_rate_full)
+                tpl_rate_string = unparse_ir(tpl_ir_rate_full)
             # Reduce bindings: from-template axes that need to be summed
             # away when evaluating the to-side. Always include from-pinned
             # axes (the mask inside the reduce filters to the pinned
@@ -704,26 +777,48 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                         detail=f"transitions[{tr_idx}].to={to_name!r} not in state"
                     )
 
-                # Rate IR: template-substituted, Reduce nodes preserved
-                ir_rate_reduce = expand_inline_templates(
-                    ir_rate_raw,
-                    assignment=assignment,
-                    shaped_params=shaped,
-                    axis_lookup=ax_lookup_dict,
-                )
-                # Rate IR: fully expanded, no Reduce nodes
-                ir_rate_full = expand_reduce_pointwise(
-                    ir_rate_reduce,
-                    axes=list(axes),
-                    shaped_params=shaped,
-                    lhs_assignment=assignment,
-                    axis_coords=ax_lookup_dict,
-                )
+                # Rate IR: template-substituted, Reduce nodes preserved.
+                # In the ``tpl_uniform`` fast-path the template-form
+                # rate IR was built once before the combo loop and is
+                # shared by identity across all combos via
+                # ``tpl_neg_flow_full`` / ``tpl_flow_full`` (etc.); we
+                # therefore skip per-combo rate construction entirely.
+                if tpl_uniform:
+                    ir_rate_reduce: Expr = tpl_ir_rate_reduce
+                    ir_rate_full: Expr = tpl_ir_rate_full  # type: ignore[assignment]
+                else:
+                    ir_rate_reduce = expand_inline_templates(
+                        ir_rate_raw,
+                        assignment=assignment,
+                        shaped_params=shaped,
+                        axis_lookup=ax_lookup_dict,
+                    )
+                    # Rate IR: fully expanded, no Reduce nodes
+                    ir_rate_full = expand_reduce_pointwise(
+                        ir_rate_reduce,
+                        axes=list(axes),
+                        shaped_params=shaped,
+                        lhs_assignment=assignment,
+                        axis_coords=ax_lookup_dict,
+                    )
 
-                # Build flow IR: rate * from_state
-                from_sym = Sym(name=from_name)
-                flow_full = Apply(op="*", args=(ir_rate_full, from_sym))
-                flow_reduce = Apply(op="*", args=(ir_rate_reduce, from_sym))
+                # Build flow IR: rate * from_state. In the tpl_uniform
+                # fast-path the per-cell ``Sym(from_name)`` reference is
+                # replaced by a single shared ``Subscript`` over the
+                # from-template's wildcard axes, and the resulting
+                # ``flow_full`` / ``flow_reduce`` / negated forms are the
+                # SAME IR object for every combo of this transition.
+                if tpl_uniform:
+                    flow_full: Expr = tpl_flow_full  # type: ignore[assignment]
+                    flow_reduce: Expr = tpl_flow_reduce  # type: ignore[assignment]
+                    neg_flow_full: Expr = tpl_neg_flow_full  # type: ignore[assignment]
+                    neg_flow_reduce: Expr = tpl_neg_flow_reduce  # type: ignore[assignment]
+                else:
+                    from_sym = Sym(name=from_name)
+                    flow_full = Apply(op="*", args=(ir_rate_full, from_sym))
+                    flow_reduce = Apply(op="*", args=(ir_rate_reduce, from_sym))
+                    neg_flow_full = Apply(op="neg", args=(flow_full,))
+                    neg_flow_reduce = Apply(op="neg", args=(flow_reduce,))
 
                 # Accumulate: from_state gets -flow, to_state gets +flow.
                 # When synthesizing template-uniform IR for this transition
@@ -743,19 +838,28 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                     # whose mask-multiplied contribution is 0.
                     pass
                 else:
-                    d_ir_full[from_name].append(Apply(op="neg", args=(flow_full,)))
+                    d_ir_full[from_name].append(neg_flow_full)
                     d_ir_full[to_name].append(flow_full)
-                    d_ir_reduce[from_name].append(Apply(op="neg", args=(flow_reduce,)))
+                    d_ir_reduce[from_name].append(neg_flow_reduce)
                     d_ir_reduce[to_name].append(flow_reduce)
 
-                # Collect rate symbols (alias Syms kept unresolved)
-                all_syms |= free_symbols(ir_rate_full)
+                # Collect rate symbols (alias Syms kept unresolved). Skip
+                # in the tpl_uniform fast-path where this was hoisted out
+                # of the combo loop.
+                if not tpl_uniform:
+                    all_syms |= free_symbols(ir_rate_full)
 
-                # Build expanded transition dict for meta["transitions"]
+                # Build expanded transition dict for meta["transitions"].
+                # In the tpl_uniform fast-path the rate string is the
+                # same for every combo (axes symbolic), so reuse the
+                # pre-rendered ``tpl_rate_string`` instead of unparsing
+                # per combo.
                 tr_out: dict[str, Any] = dict(tr_valid)
                 tr_out["from"] = from_name
                 tr_out["to"] = to_name
-                tr_out["rate"] = unparse_ir(ir_rate_full)
+                tr_out["rate"] = (
+                    tpl_rate_string if tpl_uniform else unparse_ir(ir_rate_full)
+                )
                 if name_s:
                     tr_out["name"] = _apply_template_substitutions(
                         name_s,
@@ -1092,6 +1196,9 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
             shaped_params=shaped_params,
             mask_names=pinned_mask_names,
             time_axis_name=time_axis_name,
+            alias_bases={
+                parse_selector(_normalize_bracket_key(k))[0] for k in aliases_raw_map
+            },
         )
     )
     all_syms |= rate_syms

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -1022,15 +1022,37 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
         if needed > old_limit:
             sys.setrecursionlimit(old_limit)
 
-    def _sum_terms(terms: list[Expr]) -> Expr:
+    # Cells whose transition participation is identical end up with
+    # identical term lists by identity (same shared synth_to /
+    # synth_neg / flow IR objects). Dedup the outer Apply by the tuple
+    # of term ids so downstream identity-keyed memos (unparse_ir,
+    # free_symbols, inline_aliases) see one wrapper instead of one
+    # per cell. Issue #145.
+    _sum_dedup_full: dict[tuple[int, ...], Expr] = {}
+    _sum_dedup_reduce: dict[tuple[int, ...], Expr] = {}
+
+    def _sum_terms(
+        terms: list[Expr],
+        _dedup: dict[tuple[int, ...], Expr],
+    ) -> Expr:
         if not terms:
             return Literal(value=0.0)
         if len(terms) == 1:
             return terms[0]
-        return Apply(op="+", args=tuple(terms))
+        key = tuple(id(t) for t in terms)
+        cached = _dedup.get(key)
+        if cached is not None:
+            return cached
+        node: Expr = Apply(op="+", args=tuple(terms))
+        _dedup[key] = node
+        return node
 
-    equations_ir_pre = tuple(_sum_terms(d_ir_full[s]) for s in state_expanded)
-    equations_ir_reduce_pre = tuple(_sum_terms(d_ir_reduce[s]) for s in state_expanded)
+    equations_ir_pre = tuple(
+        _sum_terms(d_ir_full[s], _sum_dedup_full) for s in state_expanded
+    )
+    equations_ir_reduce_pre = tuple(
+        _sum_terms(d_ir_reduce[s], _sum_dedup_reduce) for s in state_expanded
+    )
     return equations_ir_pre, equations_ir_reduce_pre, transitions_expanded_out, all_syms
 
 
@@ -1257,6 +1279,12 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
             result_memo=alias_inline_result_memo,
         )
 
+    # Dedup the post-inline outer Apply by tuple of arg ids so cells
+    # whose inlined-term tuple is identical share one wrapper, letting
+    # downstream identity-keyed memos (e.g. unparse_ir) cache the
+    # rendered string once per unique equation. Issue #145.
+    apply_plus_dedup: dict[tuple[int, ...], Expr] = {}
+
     equations_ir_built_list: list[Expr | None] = []
     for expr in equations_ir_pre_inline:
         if expr is None:
@@ -1271,7 +1299,12 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
                 if all(n is o for n, o in zip(new_args, expr.args, strict=True)):
                     equations_ir_built_list.append(expr)
                 else:
-                    equations_ir_built_list.append(Apply(op="+", args=new_args))
+                    dedup_key = tuple(id(a) for a in new_args)
+                    cached_apply = apply_plus_dedup.get(dedup_key)
+                    if cached_apply is None:
+                        cached_apply = Apply(op="+", args=new_args)
+                        apply_plus_dedup[dedup_key] = cached_apply
+                    equations_ir_built_list.append(cached_apply)
             else:
                 equations_ir_built_list.append(_inline_one(expr))
         except (ValueError, RecursionError):

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -440,8 +440,17 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> ExprRhs:  # noqa: C901, PLR09
     time_varying_set = set(time_varying_full)
     axis_name_set = set(axis_lookup_dict)
     template_base_set = {parse_selector(k)[0] for k in template_map_all}
-    equations_strings = _derive_equation_strings(equations_ir_built)
-    aliases_strings = _derive_alias_strings(aliases_ir_map, aliases_ir_map)
+    # Share an identity-keyed unparse memo between the equation and
+    # alias rendering passes so subexpressions that recur across alias
+    # bodies and equations (e.g. coord-pinned copies of the same
+    # alias template body) are rendered only once (issue #145).
+    _unparse_memo: dict[tuple[int, int, bool], str] = {}
+    equations_strings = _derive_equation_strings(
+        equations_ir_built, _unparse_memo=_unparse_memo
+    )
+    aliases_strings = _derive_alias_strings(
+        aliases_ir_map, aliases_ir_map, _unparse_memo=_unparse_memo
+    )
 
     return ExprRhs(
         state_names=tuple(state_expanded),
@@ -1311,7 +1320,13 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
     time_varying_set = set(time_varying_full)
     axis_name_set = set(axis_lookup_dict)
     template_base_set = {parse_selector(k)[0] for k in template_map_all}
-    eqs_tuple = _derive_equation_strings(equations_ir_pre_inline)
+    # Share an identity-keyed unparse memo between the equation and
+    # alias rendering passes so subexpressions that recur across alias
+    # bodies and equations are rendered only once (issue #145).
+    _unparse_memo_final: dict[tuple[int, int, bool], str] = {}
+    eqs_tuple = _derive_equation_strings(
+        equations_ir_pre_inline, _unparse_memo=_unparse_memo_final
+    )
     # Inline aliases directly into the per-cell IR we already built in
     # ``_build_transition_equations_ir`` rather than re-parsing the
     # round-tripped equation strings. Avoids 73k x ``parse_expr_to_ir``
@@ -1387,7 +1402,9 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
     return TransitionsRhs(
         state_names=tuple(state_expanded),
         equations=eqs_tuple,
-        aliases=_derive_alias_strings(aliases_ir_map, aliases_ir_map),
+        aliases=_derive_alias_strings(
+            aliases_ir_map, aliases_ir_map, _unparse_memo=_unparse_memo_final
+        ),
         param_names=_sorted_unique(
             sym
             for sym in all_syms

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -52,6 +52,7 @@ from op_system._ir import (
     Subscript,
     Sym,
     free_symbols,
+    iter_subscripts,
     parse_expr_to_ir,
     unparse_ir,
     walk,
@@ -779,6 +780,31 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                 coords_lists = [ax_lookup_dict[ph] for ph in wildcard_axes]
                 combos = product(*coords_lists)
 
+            # For the non-fast-path combo loop, the per-combo rate IR
+            # only depends on the wildcard axes that actually appear in
+            # ``ir_rate_raw``'s subscripts; combos differing only on
+            # irrelevant axes yield identical rate IR (and identical
+            # unparsed strings). Project the assignment onto those axes
+            # and memoize ``expand_inline_templates`` /
+            # ``expand_reduce_pointwise`` / ``unparse_ir`` /
+            # ``free_symbols`` results so each unique projection pays the
+            # cost once. For alias-bearing transitions on the COVID19_USA
+            # continuum this collapses ~50k combos to a few hundred
+            # unique keys (issue #145).
+            rate_axes_used: list[str] = []
+            if wildcard_axes and not tpl_uniform:
+                wc_set_local = set(wildcard_axes)
+                seen_axes: set[str] = set()
+                for sub in iter_subscripts(ir_rate_raw):
+                    for ix in sub.indices:
+                        if ix.axis in wc_set_local and ix.axis not in seen_axes:
+                            seen_axes.add(ix.axis)
+                rate_axes_used = [a for a in wildcard_axes if a in seen_axes]
+            rate_ir_reduce_memo: dict[tuple[str, ...], Expr] = {}
+            rate_ir_full_memo: dict[tuple[str, ...], Expr] = {}
+            rate_str_memo: dict[tuple[str, ...], str] = {}
+            rate_syms_seen: set[tuple[str, ...]] = set()
+
             for combo in combos:
                 assignment = dict(zip(wildcard_axes, combo, strict=True))
                 from_name = render_selector(
@@ -806,20 +832,28 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                     ir_rate_reduce: Expr = tpl_ir_rate_reduce
                     ir_rate_full: Expr = tpl_ir_rate_full  # type: ignore[assignment]
                 else:
-                    ir_rate_reduce = expand_inline_templates(
-                        ir_rate_raw,
-                        assignment=assignment,
-                        shaped_params=shaped,
-                        axis_lookup=ax_lookup_dict,
-                    )
-                    # Rate IR: fully expanded, no Reduce nodes
-                    ir_rate_full = expand_reduce_pointwise(
-                        ir_rate_reduce,
-                        axes=list(axes),
-                        shaped_params=shaped,
-                        lhs_assignment=assignment,
-                        axis_coords=ax_lookup_dict,
-                    )
+                    rate_key = tuple(assignment[a] for a in rate_axes_used)
+                    cached_rate_reduce = rate_ir_reduce_memo.get(rate_key)
+                    if cached_rate_reduce is None:
+                        cached_rate_reduce = expand_inline_templates(
+                            ir_rate_raw,
+                            assignment=assignment,
+                            shaped_params=shaped,
+                            axis_lookup=ax_lookup_dict,
+                        )
+                        rate_ir_reduce_memo[rate_key] = cached_rate_reduce
+                    ir_rate_reduce = cached_rate_reduce
+                    cached_rate_full = rate_ir_full_memo.get(rate_key)
+                    if cached_rate_full is None:
+                        cached_rate_full = expand_reduce_pointwise(
+                            ir_rate_reduce,
+                            axes=list(axes),
+                            shaped_params=shaped,
+                            lhs_assignment=assignment,
+                            axis_coords=ax_lookup_dict,
+                        )
+                        rate_ir_full_memo[rate_key] = cached_rate_full
+                    ir_rate_full = cached_rate_full
 
                 # Build flow IR: rate * from_state. In the tpl_uniform
                 # fast-path the per-cell ``Sym(from_name)`` reference is
@@ -864,21 +898,32 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
 
                 # Collect rate symbols (alias Syms kept unresolved). Skip
                 # in the tpl_uniform fast-path where this was hoisted out
-                # of the combo loop.
-                if not tpl_uniform:
+                # of the combo loop. The set of free symbols of
+                # ``ir_rate_full`` depends only on the projected rate
+                # assignment, so visit each unique key once.
+                if not tpl_uniform and rate_key not in rate_syms_seen:
+                    rate_syms_seen.add(rate_key)
                     all_syms |= free_symbols(ir_rate_full)
 
                 # Build expanded transition dict for meta["transitions"].
                 # In the tpl_uniform fast-path the rate string is the
                 # same for every combo (axes symbolic), so reuse the
                 # pre-rendered ``tpl_rate_string`` instead of unparsing
-                # per combo.
+                # per combo. Otherwise, memoize unparsing by the rate
+                # projection key (same projected assignment -> same
+                # rate IR -> same string).
+                if tpl_uniform:
+                    rate_string: str = tpl_rate_string  # type: ignore[assignment]
+                else:
+                    cached_str = rate_str_memo.get(rate_key)
+                    if cached_str is None:
+                        cached_str = unparse_ir(ir_rate_full)
+                        rate_str_memo[rate_key] = cached_str
+                    rate_string = cached_str
                 tr_out: dict[str, Any] = dict(tr_valid)
                 tr_out["from"] = from_name
                 tr_out["to"] = to_name
-                tr_out["rate"] = (
-                    tpl_rate_string if tpl_uniform else unparse_ir(ir_rate_full)
-                )
+                tr_out["rate"] = rate_string
                 if name_s:
                     tr_out["name"] = _apply_template_substitutions(
                         name_s,

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -414,9 +414,15 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> ExprRhs:  # noqa: C901, PLR09
         aliases_ir=aliases_ir_map,
     )
     # Collect free symbols from alias bodies (alias bodies may reference
-    # params not appearing in any equation directly).
-    for alias_ir_val in aliases_ir_map.values():
-        all_syms |= free_symbols(alias_ir_val)
+    # params not appearing in any equation directly). Walk the *reduce*
+    # map (Reduce nodes still folded) rather than the fully expanded
+    # map: alias inlining is identical between the two, but the reduce
+    # form is orders of magnitude smaller for continuum specs. Share a
+    # single id-keyed memo across the per-cell entries so common
+    # subtrees are visited at most once (issue #145).
+    fs_memo: dict[int, frozenset[str]] = {}
+    for alias_ir_val in aliases_ir_reduce_map.values():
+        all_syms |= free_symbols(alias_ir_val, memo=fs_memo)
 
     _maybe_attach_initial_state(
         meta,
@@ -1156,10 +1162,14 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
     template_map_all = {**state_template_map, **alias_template_map}
 
     state_set = set(state_expanded)
-    # Collect alias symbols from IR
+    # Collect alias symbols from IR. Walk the Reduce-folded map (same
+    # inlined symbol set as the full-expansion map but vastly smaller
+    # on continuum specs) and share an id-keyed memo across per-cell
+    # entries that share subtrees by identity (issue #145).
     all_syms: set[str] = set()
-    for alias_expr in aliases_ir_map.values():
-        all_syms |= free_symbols(alias_expr)
+    fs_memo: dict[int, frozenset[str]] = {}
+    for alias_expr in aliases_ir_reduce_map.values():
+        all_syms |= free_symbols(alias_expr, memo=fs_memo)
 
     _apply_coord_shifts(
         transitions_raw=transitions_raw,

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -804,15 +804,30 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
             rate_ir_full_memo: dict[tuple[str, ...], Expr] = {}
             rate_str_memo: dict[tuple[str, ...], str] = {}
             rate_syms_seen: set[tuple[str, ...]] = set()
+            # ``render_selector`` is deterministic in the wildcard-token
+            # coords for a given (base, tokens) pair; memoize by the
+            # tuple of wildcard coords from the current assignment so
+            # combos differing only on the *other* template's wildcards
+            # share a single render (issue #145).
+            from_name_memo: dict[tuple[str, ...], str] = {}
+            to_name_memo: dict[tuple[str, ...], str] = {}
 
             for combo in combos:
                 assignment = dict(zip(wildcard_axes, combo, strict=True))
-                from_name = render_selector(
-                    frm_base, frm_tokens, assignment, axis_lookup=ax_lookup_dict
-                )
-                to_name = render_selector(
-                    to_base, to_tokens, assignment, axis_lookup=ax_lookup_dict
-                )
+                from_key = tuple(assignment[a] for a in frm_wc_axes)
+                from_name = from_name_memo.get(from_key)
+                if from_name is None:
+                    from_name = render_selector(
+                        frm_base, frm_tokens, assignment, axis_lookup=None
+                    )
+                    from_name_memo[from_key] = from_name
+                to_key = tuple(assignment[a] for a in to_wc_axes)
+                to_name = to_name_memo.get(to_key)
+                if to_name is None:
+                    to_name = render_selector(
+                        to_base, to_tokens, assignment, axis_lookup=None
+                    )
+                    to_name_memo[to_key] = to_name
                 if from_name not in state_set:
                     raise InvalidRhsSpecError(
                         detail=f"transitions[{tr_idx}].from={from_name!r} not in state"
@@ -1329,6 +1344,14 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
     # downstream identity-keyed memos (e.g. unparse_ir) cache the
     # rendered string once per unique equation. Issue #145.
     apply_plus_dedup: dict[tuple[int, ...], Expr] = {}
+    # The upstream ``_sum_dedup_full`` collapses ``equations_ir_pre_inline``
+    # to a handful of unique outer Apply objects shared across many
+    # cells (e.g. 7 unique exprs across 72,828 cells on the COVID19_USA
+    # continuum spec). Cache the per-expr inlined result by ``id(expr)``
+    # so we skip the per-term ``_inline_one`` calls entirely on cache
+    # hits -- this collapses ~1.9M memo-hit calls to ~7 real inlines
+    # plus 72k dict lookups (issue #145).
+    outer_inline_memo: dict[int, Expr] = {}
 
     equations_ir_built_list: list[Expr | None] = []
     for expr in equations_ir_pre_inline:
@@ -1338,22 +1361,28 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
         if not aliases_ir_map:
             equations_ir_built_list.append(expr)
             continue
+        cached_outer = outer_inline_memo.get(id(expr))
+        if cached_outer is not None:
+            equations_ir_built_list.append(cached_outer)
+            continue
         try:
             if isinstance(expr, Apply) and expr.op == "+":
                 new_args = tuple(_inline_one(a) for a in expr.args)
                 if all(n is o for n, o in zip(new_args, expr.args, strict=True)):
-                    equations_ir_built_list.append(expr)
+                    result_expr: Expr = expr
                 else:
                     dedup_key = tuple(id(a) for a in new_args)
                     cached_apply = apply_plus_dedup.get(dedup_key)
                     if cached_apply is None:
                         cached_apply = Apply(op="+", args=new_args)
                         apply_plus_dedup[dedup_key] = cached_apply
-                    equations_ir_built_list.append(cached_apply)
+                    result_expr = cached_apply
             else:
-                equations_ir_built_list.append(_inline_one(expr))
+                result_expr = _inline_one(expr)
         except (ValueError, RecursionError):
-            equations_ir_built_list.append(expr)
+            result_expr = expr
+        outer_inline_memo[id(expr)] = result_expr
+        equations_ir_built_list.append(result_expr)
     equations_ir_built = tuple(equations_ir_built_list)
     return TransitionsRhs(
         state_names=tuple(state_expanded),

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -25,6 +25,7 @@ compatibility.
 
 from __future__ import annotations
 
+import contextlib
 import sys
 from collections.abc import Mapping as _MappingABC
 from dataclasses import dataclass, field
@@ -32,7 +33,7 @@ from itertools import product
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
+    from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
 
 from op_system._axes import _normalize_axes, _normalize_bracket_key
 from op_system._errors import InvalidRhsSpecError, UnsupportedFeatureError
@@ -444,12 +445,12 @@ def normalize_expr_rhs(spec: Mapping[str, Any]) -> ExprRhs:  # noqa: C901, PLR09
     # alias rendering passes so subexpressions that recur across alias
     # bodies and equations (e.g. coord-pinned copies of the same
     # alias template body) are rendered only once (issue #145).
-    _unparse_memo: dict[tuple[int, int, bool], str] = {}
+    unparse_memo: dict[tuple[int, int, bool], str] = {}
     equations_strings = _derive_equation_strings(
-        equations_ir_built, _unparse_memo=_unparse_memo
+        equations_ir_built, _unparse_memo=unparse_memo
     )
     aliases_strings = _derive_alias_strings(
-        aliases_ir_map, aliases_ir_map, _unparse_memo=_unparse_memo
+        aliases_ir_map, aliases_ir_map, _unparse_memo=unparse_memo
     )
 
     return ExprRhs(
@@ -544,6 +545,249 @@ def _discover_pinned_token_masks(  # noqa: C901
     return mask_names, mask_values
 
 
+@contextlib.contextmanager
+def _raise_recursion_limit(needed: int, old_limit: int) -> Iterator[None]:
+    """Temporarily raise ``sys.setrecursionlimit`` to ``needed``.
+
+    Restores ``old_limit`` on exit. Extracted as a context manager so
+    callers can use ``with`` instead of an extra ``try`` nesting level
+    around their hot loops.
+    """
+    if needed > old_limit:
+        sys.setrecursionlimit(needed)
+    try:
+        yield
+    finally:
+        if needed > old_limit:
+            sys.setrecursionlimit(old_limit)
+
+
+def _enumerate_template_cell_names(
+    base: str,
+    template_tokens: tuple[Any, ...],
+    *,
+    cells_by_base: Mapping[str, list[str]],
+    enum_cache: dict[tuple[str, tuple[Any, ...]], list[str]],
+) -> list[str]:
+    """Return all concrete cell names matching a template.
+
+    ``cells_by_base`` (built once per call to
+    ``_build_transition_equations_ir``) already holds every concrete cell
+    name grouped by base in the canonical state-template ordering, so the
+    set of cells matching a wildcard-only template is just the bucket for
+    that base. Falls back to ``[base]`` when the template has no axis
+    tokens at all (the lookup would then equal ``[base]`` anyway, but the
+    empty/no-axes case is rare and not on the hot path). Issue #145.
+    """
+    if template_tokens:
+        cached = cells_by_base.get(base)
+        if cached is not None:
+            return cached
+        return [base]
+    cache_key = (base, template_tokens)
+    cached_full = enum_cache.get(cache_key)
+    if cached_full is not None:
+        return cached_full
+    enum_cache[cache_key] = [base]
+    return [base]
+
+
+def _memoize_unparse(
+    rate_key: tuple[str, ...],
+    memo: dict[tuple[str, ...], str],
+    ir_rate_full: Expr,
+) -> str:
+    """Return ``unparse_ir(ir_rate_full)`` caching the result by ``rate_key``."""
+    cached = memo.get(rate_key)
+    if cached is None:
+        cached = unparse_ir(ir_rate_full)
+        memo[rate_key] = cached
+    return cached
+
+
+def _rate_references_alias(ir_rate_raw: Expr, alias_base_set: Collection[str]) -> bool:
+    """Return True if any ``Sym``/``Subscript`` in ``ir_rate_raw`` names an alias."""
+    return any(
+        isinstance(node, (Sym, Subscript)) and node.name in alias_base_set
+        for node in walk(ir_rate_raw)
+    )
+
+
+def _rate_ir_for_combo(  # noqa: PLR0913
+    *,
+    rate_key: tuple[str, ...],
+    combo: tuple[str, ...],
+    wildcard_axes: Sequence[str],
+    assignment: dict[str, str] | None,
+    ir_rate_raw: Expr,
+    axes: list[dict[str, Any]],
+    shaped: Mapping[str, tuple[str, ...]],
+    ax_lookup_dict: Mapping[str, list[str]],
+    rate_ir_reduce_memo: dict[tuple[str, ...], Expr],
+    rate_ir_full_memo: dict[tuple[str, ...], Expr],
+) -> tuple[Expr, Expr, dict[str, str] | None]:
+    """Look up or build the per-combo rate IR (Reduce and full forms).
+
+    Returns:
+        ``(ir_rate_reduce, ir_rate_full, assignment)`` where ``assignment``
+        is materialized lazily on memo miss and threaded back to the caller
+        so it can be reused for subsequent renderings.
+    """
+    from op_system._ir_expand import expand_reduce_pointwise  # noqa: PLC0415
+
+    cached_rate_reduce = rate_ir_reduce_memo.get(rate_key)
+    if cached_rate_reduce is None:
+        assignment = assignment or dict(zip(wildcard_axes, combo, strict=True))
+        cached_rate_reduce = expand_inline_templates(
+            ir_rate_raw,
+            assignment=assignment,
+            shaped_params=shaped,
+            axis_lookup=ax_lookup_dict,
+        )
+        rate_ir_reduce_memo[rate_key] = cached_rate_reduce
+    cached_rate_full = rate_ir_full_memo.get(rate_key)
+    if cached_rate_full is None:
+        assignment = assignment or dict(zip(wildcard_axes, combo, strict=True))
+        cached_rate_full = expand_reduce_pointwise(
+            cached_rate_reduce,
+            axes=list(axes),
+            shaped_params=shaped,
+            lhs_assignment=assignment,
+            axis_coords=ax_lookup_dict,
+        )
+        rate_ir_full_memo[rate_key] = cached_rate_full
+    return cached_rate_reduce, cached_rate_full, assignment
+
+
+def _synthesize_template_uniform(  # noqa: PLR0913
+    *,
+    frm_base: str,
+    frm_tokens: list[Any],
+    to_base: str,
+    to_tokens: list[Any],
+    pinned_tokens_from: list[PinnedToken],
+    pinned_tokens_to: list[PinnedToken],
+    ir_rate_raw: Expr,
+    masks: Mapping[tuple[str, str], str],
+    reduce_bindings_axes: list[str],
+    axes: list[dict[str, Any]],
+    shaped: Mapping[str, tuple[str, ...]],
+    ax_lookup_dict: dict[str, list[str]],
+    cells_by_base: Mapping[str, list[str]],
+    enum_cache: dict[tuple[str, tuple[Any, ...]], list[str]],
+    d_ir_reduce: dict[str, list[Expr]],
+    d_ir_full: dict[str, list[Expr]],
+    all_syms: set[str],
+) -> None:
+    """Synthesize the template-uniform IR for one transition.
+
+    The source side installs a ``-flow`` body in every cell of the
+    from-template; the destination side installs a
+    ``Reduce(sum_over, ...)`` (or just the body when there are no
+    from-template-only axes) in every cell of the to-template. Each
+    pinned ``(axis, coord)`` selector multiplies the body by a one-hot
+    mask shaped param so that only the pinned slab contributes; the
+    mask zeroes out the non-pinned slabs before the surrounding Reduce
+    sums them away.
+
+    Mutates ``d_ir_reduce``, ``d_ir_full``, and ``all_syms`` in place.
+    """
+    from op_system._ir_expand import expand_reduce_pointwise  # noqa: PLC0415
+
+    to_names_for_synthesis = set(
+        _enumerate_template_cell_names(
+            to_base,
+            tuple(to_tokens),
+            cells_by_base=cells_by_base,
+            enum_cache=enum_cache,
+        )
+    )
+    from_names_for_synthesis = set(
+        _enumerate_template_cell_names(
+            frm_base,
+            tuple(frm_tokens),
+            cells_by_base=cells_by_base,
+            enum_cache=enum_cache,
+        )
+    )
+
+    from_subscript = Subscript(
+        name=frm_base,
+        indices=tuple(
+            AxisIndex(axis=tok.axis, coord=None)
+            for tok in frm_tokens
+            if isinstance(tok, (WildcardToken, PinnedToken))
+        ),
+    )
+
+    def _mask_sub(tok: PinnedToken) -> Subscript:
+        return Subscript(
+            name=masks[tok.axis, tok.coord],
+            indices=(AxisIndex(axis=tok.axis, coord=None),),
+        )
+
+    # To-side body: rate * from-state * from-pinned masks, all summed
+    # over reduce bindings; then multiplied by to-side pinned masks
+    # (which use to-cell coords). Rate lives inside the reduce so
+    # per-axis terms such as ``theta[imm]`` correctly bind to the
+    # reduce loop.
+    inner_to: Expr = Apply(op="*", args=(ir_rate_raw, from_subscript))
+    for tok in pinned_tokens_from:
+        inner_to = Apply(op="*", args=(inner_to, _mask_sub(tok)))
+    synth_to: Expr
+    if reduce_bindings_axes:
+        synth_to = Reduce(
+            kind="sum_over",
+            bindings=tuple((ax, ax) for ax in reduce_bindings_axes),
+            body=inner_to,
+        )
+    else:
+        synth_to = inner_to
+    for tok in pinned_tokens_to:
+        synth_to = Apply(op="*", args=(synth_to, _mask_sub(tok)))
+
+    # From-side body: rate * from-state * masks for FROM-side pinned
+    # tokens only (to-side pinned axes may not be in the from-template
+    # and would broadcast incorrectly).
+    from_body: Expr = Apply(op="*", args=(ir_rate_raw, from_subscript))
+    for tok in pinned_tokens_from:
+        from_body = Apply(op="*", args=(from_body, _mask_sub(tok)))
+    synth_neg = Apply(op="neg", args=(from_body,))
+
+    all_syms |= free_symbols(synth_to)
+    # Pointwise-expand the synthesized IR ONCE at the template level so
+    # ``d_ir_full`` (the per-cell equation IR consumed by downstream
+    # code via ``ir_to_ast_expr``) stays Reduce-free. With
+    # ``lhs_assignment={}``, only the explicit reduce bindings are
+    # enumerated; wildcard template axes remain symbolic
+    # (``AxisIndex(coord=None)``) so the resulting IR is identical
+    # across every cell of the template and can be shared by object
+    # identity (issue #145). Without this, every cell of a synthesized
+    # transition would need its own per-cell pointwise expansion and
+    # the per-cell ``inline_aliases`` would not hit the shared
+    # ``result_memo``.
+    synth_to_full = expand_reduce_pointwise(
+        synth_to,
+        axes=list(axes),
+        shaped_params=shaped,
+        lhs_assignment={},
+        axis_coords=ax_lookup_dict,
+    )
+    synth_neg_full = expand_reduce_pointwise(
+        synth_neg,
+        axes=list(axes),
+        shaped_params=shaped,
+        lhs_assignment={},
+        axis_coords=ax_lookup_dict,
+    )
+    for to_name in to_names_for_synthesis:
+        d_ir_reduce[to_name].append(synth_to)
+        d_ir_full[to_name].append(synth_to_full)
+    for from_name in from_names_for_synthesis:
+        d_ir_reduce[from_name].append(synth_neg)
+        d_ir_full[from_name].append(synth_neg_full)
+
+
 def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915
     transitions_raw: list[Mapping[str, Any]],
     *,
@@ -590,9 +834,9 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
     # state-template order, so the grouped lookup matches the result
     # of enumerating the template's wildcard combos. Issue #145.
     cells_by_base: dict[str, list[str]] = {}
-    for _name in state_expanded:
-        _base = _name.split("__", 1)[0]
-        cells_by_base.setdefault(_base, []).append(_name)
+    for cell_name in state_expanded:
+        cell_base = cell_name.split("__", 1)[0]
+        cells_by_base.setdefault(cell_base, []).append(cell_name)
     # Cache: ``(base, template_tokens) -> list[str]`` for
     # ``_enumerate_template_cell_names``. The same (base, tokens) pair is
     # queried once per (from, to) side per combo expansion, so caching cuts
@@ -603,9 +847,7 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
 
     old_limit = sys.getrecursionlimit()
     needed = max(old_limit, 10_000)
-    try:
-        if needed > old_limit:
-            sys.setrecursionlimit(needed)
+    with _raise_recursion_limit(needed, old_limit):
         for tr_idx, tr_map in enumerate(transitions_raw):
             tr_valid = _validate_transition_mapping(dict(tr_map), idx=tr_idx)
             frm_s = _get_required_str(tr_valid, idx=tr_idx, key="from")
@@ -634,17 +876,16 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                     name_s, shaped_param_names=skip_shaped
                 )
             for ph in sorted(expr_phs):
-                if ":" in ph or "=" in ph:
+                if ":" in ph or "=" in ph or ph in seen_wc:
                     continue
-                if ph not in seen_wc:
-                    if ph not in ax_lookup_dict:
-                        raise InvalidRhsSpecError(
-                            detail=(
-                                f"transition placeholder {ph!r} references unknown axis"
-                            )
+                if ph not in ax_lookup_dict:
+                    raise InvalidRhsSpecError(
+                        detail=(
+                            f"transition placeholder {ph!r} references unknown axis"
                         )
-                    wildcard_axes.append(ph)
-                    seen_wc.add(ph)
+                    )
+                wildcard_axes.append(ph)
+                seen_wc.add(ph)
 
             # Parse rate to IR once (Reduce nodes preserved for apply_along)
             ir_rate_raw = parse_expr_to_ir(rate_s, lower_helpers=True)
@@ -701,8 +942,6 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                 and pinned_masks_ok
                 and (bool(from_only_axes) or has_pinned)
             )
-            to_names_for_synthesis: set[str] = set()
-            from_names_for_synthesis: set[str] = set()
             # Template-uniform non-synth fast-path. When the from-template
             # and the to-template have the same wildcard axis set and
             # there are no pinned tokens, no destination-only axes, and
@@ -725,7 +964,11 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                 and not expr_only_axes
                 and not has_pinned
             )
-            if tpl_uniform and alias_base_set:
+            if (
+                tpl_uniform
+                and alias_base_set
+                and _rate_references_alias(ir_rate_raw, alias_base_set)
+            ):
                 # Disable the fast-path when the rate references an
                 # alias. The downstream alias-inline pass keys on
                 # fully-pinned ``Sym("alias__axis_coord")`` references
@@ -733,13 +976,7 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                 # a non-empty ``assignment``); a template-form
                 # ``Subscript("alias", (AxisIndex(coord=None), ...))``
                 # would slip through unresolved and break compilation.
-                for node in walk(ir_rate_raw):
-                    if (
-                        isinstance(node, (Sym, Subscript))
-                        and node.name in alias_base_set
-                    ):
-                        tpl_uniform = False
-                        break
+                tpl_uniform = False
             tpl_neg_flow_full: Expr | None = None
             tpl_flow_full: Expr | None = None
             tpl_neg_flow_reduce: Expr | None = None
@@ -803,11 +1040,12 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
             rate_axes_used: list[str] = []
             if wildcard_axes and not tpl_uniform:
                 wc_set_local = set(wildcard_axes)
-                seen_axes: set[str] = set()
-                for sub in iter_subscripts(ir_rate_raw):
-                    for ix in sub.indices:
-                        if ix.axis in wc_set_local and ix.axis not in seen_axes:
-                            seen_axes.add(ix.axis)
+                seen_axes = {
+                    ix.axis
+                    for sub in iter_subscripts(ir_rate_raw)
+                    for ix in sub.indices
+                    if ix.axis in wc_set_local
+                }
                 rate_axes_used = [a for a in wildcard_axes if a in seen_axes]
             rate_ir_reduce_memo: dict[tuple[str, ...], Expr] = {}
             rate_ir_full_memo: dict[tuple[str, ...], Expr] = {}
@@ -827,10 +1065,10 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
             # entirely on the hot path. The full ``assignment`` dict
             # is only materialized on memo misses or when the
             # transition has a ``name`` template (issue #145).
-            _wc_pos = {a: i for i, a in enumerate(wildcard_axes)}
-            from_key_idx = tuple(_wc_pos[a] for a in frm_wc_axes)
-            to_key_idx = tuple(_wc_pos[a] for a in to_wc_axes)
-            rate_key_idx = tuple(_wc_pos[a] for a in rate_axes_used)
+            wc_pos = {a: i for i, a in enumerate(wildcard_axes)}
+            from_key_idx = tuple(wc_pos[a] for a in frm_wc_axes)
+            to_key_idx = tuple(wc_pos[a] for a in to_wc_axes)
+            rate_key_idx = tuple(wc_pos[a] for a in rate_axes_used)
 
             for combo in combos:
                 # Build per-axis-subset keys directly from the combo
@@ -845,15 +1083,17 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                     dict(zip(wildcard_axes, combo, strict=True)) if name_s else None
                 )
                 if from_name is None:
-                    if assignment is None:
-                        assignment = dict(zip(wildcard_axes, combo, strict=True))
+                    assignment = assignment or dict(
+                        zip(wildcard_axes, combo, strict=True)
+                    )
                     from_name = render_selector(
                         frm_base, frm_tokens, assignment, axis_lookup=None
                     )
                     from_name_memo[from_key] = from_name
                 if to_name is None:
-                    if assignment is None:
-                        assignment = dict(zip(wildcard_axes, combo, strict=True))
+                    assignment = assignment or dict(
+                        zip(wildcard_axes, combo, strict=True)
+                    )
                     to_name = render_selector(
                         to_base, to_tokens, assignment, axis_lookup=None
                     )
@@ -878,31 +1118,18 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                     ir_rate_full: Expr = tpl_ir_rate_full  # type: ignore[assignment]
                 else:
                     rate_key = tuple(combo[i] for i in rate_key_idx)
-                    cached_rate_reduce = rate_ir_reduce_memo.get(rate_key)
-                    if cached_rate_reduce is None:
-                        if assignment is None:
-                            assignment = dict(zip(wildcard_axes, combo, strict=True))
-                        cached_rate_reduce = expand_inline_templates(
-                            ir_rate_raw,
-                            assignment=assignment,
-                            shaped_params=shaped,
-                            axis_lookup=ax_lookup_dict,
-                        )
-                        rate_ir_reduce_memo[rate_key] = cached_rate_reduce
-                    ir_rate_reduce = cached_rate_reduce
-                    cached_rate_full = rate_ir_full_memo.get(rate_key)
-                    if cached_rate_full is None:
-                        if assignment is None:
-                            assignment = dict(zip(wildcard_axes, combo, strict=True))
-                        cached_rate_full = expand_reduce_pointwise(
-                            ir_rate_reduce,
-                            axes=list(axes),
-                            shaped_params=shaped,
-                            lhs_assignment=assignment,
-                            axis_coords=ax_lookup_dict,
-                        )
-                        rate_ir_full_memo[rate_key] = cached_rate_full
-                    ir_rate_full = cached_rate_full
+                    ir_rate_reduce, ir_rate_full, assignment = _rate_ir_for_combo(
+                        rate_key=rate_key,
+                        combo=combo,
+                        wildcard_axes=wildcard_axes,
+                        assignment=assignment,
+                        ir_rate_raw=ir_rate_raw,
+                        axes=axes,
+                        shaped=shaped,
+                        ax_lookup_dict=ax_lookup_dict,
+                        rate_ir_reduce_memo=rate_ir_reduce_memo,
+                        rate_ir_full_memo=rate_ir_full_memo,
+                    )
 
                 # Build flow IR: rate * from_state. In the tpl_uniform
                 # fast-path the per-cell ``Sym(from_name)`` reference is
@@ -964,11 +1191,9 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                 if tpl_uniform:
                     rate_string: str = tpl_rate_string  # type: ignore[assignment]
                 else:
-                    cached_str = rate_str_memo.get(rate_key)
-                    if cached_str is None:
-                        cached_str = unparse_ir(ir_rate_full)
-                        rate_str_memo[rate_key] = cached_str
-                    rate_string = cached_str
+                    rate_string = _memoize_unparse(
+                        rate_key, rate_str_memo, ir_rate_full
+                    )
                 tr_out: dict[str, Any] = dict(tr_valid)
                 tr_out["from"] = from_name
                 tr_out["to"] = to_name
@@ -976,7 +1201,7 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                 if name_s:
                     tr_out["name"] = _apply_template_substitutions(
                         name_s,
-                        assignment=assignment,
+                        assignment=assignment or {},
                         template_map=template_map,
                         shaped_params=shaped,
                         axis_lookup=ax_lookup_dict,
@@ -986,135 +1211,27 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
             # Synthesize template-uniform IR for this transition when the
             # source-template's wildcard axes (possibly with pinned-coord
             # selectors handled by one-hot masks) admit a uniform
-            # representation. The source side installs a ``-flow`` body in
-            # every cell of the from-template; the destination side installs
-            # a ``Reduce(sum_over, ...)`` (or just the body when there are
-            # no from-template-only axes) in every cell of the to-template.
-            # Each pinned (axis, coord) selector multiplies the body by a
-            # one-hot mask shaped param so that only the pinned slab
-            # contributes; the mask zeroes out the non-pinned slabs before
-            # the surrounding Reduce sums them away.
+            # representation. See ``_synthesize_template_uniform``.
             if synthesize:
-                # Enumerate ALL cells of both templates (treating pinned
-                # axes as wildcards over their full coord ranges) so the
-                # template-uniform synthesized IR is installed in every
-                # cell. Pinned-coord selection lives inside the body via
-                # the one-hot mask multiplications below.
-                #
-                # ``cells_by_base`` (built once at the top of this function)
-                # already holds every concrete cell name grouped by base
-                # in the canonical state-template ordering, so the set
-                # of cells matching a wildcard-only template is just the
-                # bucket for that base. We only fall back to the previous
-                # ``render_selector`` enumeration when a template has no
-                # axis tokens at all (the lookup would then equal
-                # ``[base]`` anyway, but the empty/no-axes case is rare
-                # and not on the hot path). Issue #145.
-                enum_cache = enumerate_template_cell_names_cache
-
-                def _enumerate_template_cell_names(
-                    base: str,
-                    template_tokens: tuple[Any, ...],
-                    _cache: dict[tuple[str, tuple[Any, ...]], list[str]] = enum_cache,
-                ) -> list[str]:
-                    if template_tokens:
-                        cached = cells_by_base.get(base)
-                        if cached is not None:
-                            return cached
-                        return [base]
-                    cache_key = (base, template_tokens)
-                    cached_full = _cache.get(cache_key)
-                    if cached_full is not None:
-                        return cached_full
-                    _cache[cache_key] = [base]
-                    return [base]
-
-                to_names_for_synthesis = set(
-                    _enumerate_template_cell_names(to_base, tuple(to_tokens))
+                _synthesize_template_uniform(
+                    frm_base=frm_base,
+                    frm_tokens=frm_tokens,
+                    to_base=to_base,
+                    to_tokens=to_tokens,
+                    pinned_tokens_from=pinned_tokens_from,
+                    pinned_tokens_to=pinned_tokens_to,
+                    ir_rate_raw=ir_rate_raw,
+                    masks=masks,
+                    reduce_bindings_axes=reduce_bindings_axes,
+                    axes=axes,
+                    shaped=shaped,
+                    ax_lookup_dict=ax_lookup_dict,
+                    cells_by_base=cells_by_base,
+                    enum_cache=enumerate_template_cell_names_cache,
+                    d_ir_reduce=d_ir_reduce,
+                    d_ir_full=d_ir_full,
+                    all_syms=all_syms,
                 )
-                from_names_for_synthesis = set(
-                    _enumerate_template_cell_names(frm_base, tuple(frm_tokens))
-                )
-
-                from_subscript = Subscript(
-                    name=frm_base,
-                    indices=tuple(
-                        AxisIndex(axis=tok.axis, coord=None)
-                        for tok in frm_tokens
-                        if isinstance(tok, (WildcardToken, PinnedToken))
-                    ),
-                )
-
-                def _mask_sub(tok: PinnedToken) -> Subscript:
-                    return Subscript(
-                        name=masks[tok.axis, tok.coord],
-                        indices=(AxisIndex(axis=tok.axis, coord=None),),
-                    )
-
-                # To-side body: rate * from-state * from-pinned masks,
-                # all summed over reduce bindings; then multiplied by
-                # to-side pinned masks (which use to-cell coords). Rate
-                # lives inside the reduce so per-axis terms such as
-                # ``theta[imm]`` correctly bind to the reduce loop.
-                inner_to: Expr = Apply(op="*", args=(ir_rate_raw, from_subscript))
-                for tok in pinned_tokens_from:
-                    inner_to = Apply(op="*", args=(inner_to, _mask_sub(tok)))
-                synth_to: Expr
-                if reduce_bindings_axes:
-                    synth_to = Reduce(
-                        kind="sum_over",
-                        bindings=tuple((ax, ax) for ax in reduce_bindings_axes),
-                        body=inner_to,
-                    )
-                else:
-                    synth_to = inner_to
-                for tok in pinned_tokens_to:
-                    synth_to = Apply(op="*", args=(synth_to, _mask_sub(tok)))
-
-                # From-side body: rate * from-state * masks for FROM-side
-                # pinned tokens only (to-side pinned axes may not be in
-                # the from-template and would broadcast incorrectly).
-                from_body: Expr = Apply(op="*", args=(ir_rate_raw, from_subscript))
-                for tok in pinned_tokens_from:
-                    from_body = Apply(op="*", args=(from_body, _mask_sub(tok)))
-                synth_neg = Apply(op="neg", args=(from_body,))
-
-                all_syms |= free_symbols(synth_to)
-                # Pointwise-expand the synthesized IR ONCE at the template
-                # level so ``d_ir_full`` (the per-cell equation IR consumed
-                # by downstream code via ``ir_to_ast_expr``) stays Reduce-
-                # free. With ``lhs_assignment={}``, only the explicit
-                # reduce bindings are enumerated; wildcard template axes
-                # remain symbolic (``AxisIndex(coord=None)``) so the
-                # resulting IR is identical across every cell of the
-                # template and can be shared by object identity (issue
-                # #145). Without this, every cell of a synthesized
-                # transition would need its own per-cell pointwise
-                # expansion and the per-cell ``inline_aliases`` would not
-                # hit the shared ``result_memo``.
-                synth_to_full = expand_reduce_pointwise(
-                    synth_to,
-                    axes=list(axes),
-                    shaped_params=shaped,
-                    lhs_assignment={},
-                    axis_coords=ax_lookup_dict,
-                )
-                synth_neg_full = expand_reduce_pointwise(
-                    synth_neg,
-                    axes=list(axes),
-                    shaped_params=shaped,
-                    lhs_assignment={},
-                    axis_coords=ax_lookup_dict,
-                )
-                for to_name in to_names_for_synthesis:
-                    d_ir_reduce[to_name].append(synth_to)
-                    d_ir_full[to_name].append(synth_to_full)
-                for from_name in from_names_for_synthesis:
-                    d_ir_reduce[from_name].append(synth_neg)
-                    d_ir_full[from_name].append(synth_neg_full)
-    finally:
-        if needed > old_limit:
-            sys.setrecursionlimit(old_limit)
 
     # Cells whose transition participation is identical end up with
     # identical term lists by identity (same shared synth_to /
@@ -1122,30 +1239,30 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
     # of term ids so downstream identity-keyed memos (unparse_ir,
     # free_symbols, inline_aliases) see one wrapper instead of one
     # per cell. Issue #145.
-    _sum_dedup_full: dict[tuple[int, ...], Expr] = {}
-    _sum_dedup_reduce: dict[tuple[int, ...], Expr] = {}
+    sum_dedup_full: dict[tuple[int, ...], Expr] = {}
+    sum_dedup_reduce: dict[tuple[int, ...], Expr] = {}
 
     def _sum_terms(
         terms: list[Expr],
-        _dedup: dict[tuple[int, ...], Expr],
+        dedup: dict[tuple[int, ...], Expr],
     ) -> Expr:
         if not terms:
             return Literal(value=0.0)
         if len(terms) == 1:
             return terms[0]
         key = tuple(id(t) for t in terms)
-        cached = _dedup.get(key)
+        cached = dedup.get(key)
         if cached is not None:
             return cached
         node: Expr = Apply(op="+", args=tuple(terms))
-        _dedup[key] = node
+        dedup[key] = node
         return node
 
     equations_ir_pre = tuple(
-        _sum_terms(d_ir_full[s], _sum_dedup_full) for s in state_expanded
+        _sum_terms(d_ir_full[s], sum_dedup_full) for s in state_expanded
     )
     equations_ir_reduce_pre = tuple(
-        _sum_terms(d_ir_reduce[s], _sum_dedup_reduce) for s in state_expanded
+        _sum_terms(d_ir_reduce[s], sum_dedup_reduce) for s in state_expanded
     )
     return equations_ir_pre, equations_ir_reduce_pre, transitions_expanded_out, all_syms
 
@@ -1348,9 +1465,9 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
     # Share an identity-keyed unparse memo between the equation and
     # alias rendering passes so subexpressions that recur across alias
     # bodies and equations are rendered only once (issue #145).
-    _unparse_memo_final: dict[tuple[int, int, bool], str] = {}
+    unparse_memo_final: dict[tuple[int, int, bool], str] = {}
     eqs_tuple = _derive_equation_strings(
-        equations_ir_pre_inline, _unparse_memo=_unparse_memo_final
+        equations_ir_pre_inline, _unparse_memo=unparse_memo_final
     )
     # Inline aliases directly into the per-cell IR we already built in
     # ``_build_transition_equations_ir`` rather than re-parsing the
@@ -1384,7 +1501,7 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
     # downstream identity-keyed memos (e.g. unparse_ir) cache the
     # rendered string once per unique equation. Issue #145.
     apply_plus_dedup: dict[tuple[int, ...], Expr] = {}
-    # The upstream ``_sum_dedup_full`` collapses ``equations_ir_pre_inline``
+    # The upstream ``sum_dedup_full`` collapses ``equations_ir_pre_inline``
     # to a handful of unique outer Apply objects shared across many
     # cells (e.g. 7 unique exprs across 72,828 cells on the COVID19_USA
     # continuum spec). Cache the per-expr inlined result by ``id(expr)``
@@ -1428,7 +1545,7 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
         state_names=tuple(state_expanded),
         equations=eqs_tuple,
         aliases=_derive_alias_strings(
-            aliases_ir_map, aliases_ir_map, _unparse_memo=_unparse_memo_final
+            aliases_ir_map, aliases_ir_map, _unparse_memo=unparse_memo_final
         ),
         param_names=_sorted_unique(
             sym

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -842,9 +842,7 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                 # ``assignment`` is only required on memo misses or for
                 # the optional ``name`` template; lazy-build it.
                 assignment: dict[str, str] | None = (
-                    dict(zip(wildcard_axes, combo, strict=True))
-                    if name_s
-                    else None
+                    dict(zip(wildcard_axes, combo, strict=True)) if name_s else None
                 )
                 if from_name is None:
                     if assignment is None:
@@ -883,9 +881,7 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                     cached_rate_reduce = rate_ir_reduce_memo.get(rate_key)
                     if cached_rate_reduce is None:
                         if assignment is None:
-                            assignment = dict(
-                                zip(wildcard_axes, combo, strict=True)
-                            )
+                            assignment = dict(zip(wildcard_axes, combo, strict=True))
                         cached_rate_reduce = expand_inline_templates(
                             ir_rate_raw,
                             assignment=assignment,
@@ -897,9 +893,7 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                     cached_rate_full = rate_ir_full_memo.get(rate_key)
                     if cached_rate_full is None:
                         if assignment is None:
-                            assignment = dict(
-                                zip(wildcard_axes, combo, strict=True)
-                            )
+                            assignment = dict(zip(wildcard_axes, combo, strict=True))
                         cached_rate_full = expand_reduce_pointwise(
                             ir_rate_reduce,
                             axes=list(axes),

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -727,12 +727,14 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
 
                 # Accumulate: from_state gets -flow, to_state gets +flow.
                 # When synthesizing template-uniform IR for this transition
-                # (see post-loop block below), skip the per-combo append
-                # into ``d_ir_reduce[from_name]`` and ``d_ir_reduce[to_name]``
-                # — the synthesized nodes carry the same total contribution
-                # in a form the vectorizer can template-lift.
-                d_ir_full[from_name].append(Apply(op="neg", args=(flow_full,)))
-                d_ir_full[to_name].append(flow_full)
+                # (see post-loop block below), skip the per-combo appends
+                # into BOTH ``d_ir_full`` and ``d_ir_reduce``. The synthesized
+                # nodes installed after the combo loop carry the same total
+                # contribution but are SHARED across all cells of the
+                # template. Sharing collapses per-cell ``inline_aliases``
+                # work from O(n_state) to O(n_template) when the per-cell
+                # inline loop is passed a ``result_memo`` keyed on
+                # ``id(expr)`` (issue #145).
                 if synthesize:
                     # Synthesis installs template-uniform IR into ALL
                     # cells of both templates after the combo loop; the
@@ -741,6 +743,8 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                     # whose mask-multiplied contribution is 0.
                     pass
                 else:
+                    d_ir_full[from_name].append(Apply(op="neg", args=(flow_full,)))
+                    d_ir_full[to_name].append(flow_full)
                     d_ir_reduce[from_name].append(Apply(op="neg", args=(flow_reduce,)))
                     d_ir_reduce[to_name].append(flow_reduce)
 
@@ -871,10 +875,38 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                 synth_neg = Apply(op="neg", args=(from_body,))
 
                 all_syms |= free_symbols(synth_to)
+                # Pointwise-expand the synthesized IR ONCE at the template
+                # level so ``d_ir_full`` (the per-cell equation IR consumed
+                # by downstream code via ``ir_to_ast_expr``) stays Reduce-
+                # free. With ``lhs_assignment={}``, only the explicit
+                # reduce bindings are enumerated; wildcard template axes
+                # remain symbolic (``AxisIndex(coord=None)``) so the
+                # resulting IR is identical across every cell of the
+                # template and can be shared by object identity (issue
+                # #145). Without this, every cell of a synthesized
+                # transition would need its own per-cell pointwise
+                # expansion and the per-cell ``inline_aliases`` would not
+                # hit the shared ``result_memo``.
+                synth_to_full = expand_reduce_pointwise(
+                    synth_to,
+                    axes=list(axes),
+                    shaped_params=shaped,
+                    lhs_assignment={},
+                    axis_coords=ax_lookup_dict,
+                )
+                synth_neg_full = expand_reduce_pointwise(
+                    synth_neg,
+                    axes=list(axes),
+                    shaped_params=shaped,
+                    lhs_assignment={},
+                    axis_coords=ax_lookup_dict,
+                )
                 for to_name in to_names_for_synthesis:
                     d_ir_reduce[to_name].append(synth_to)
+                    d_ir_full[to_name].append(synth_to_full)
                 for from_name in from_names_for_synthesis:
                     d_ir_reduce[from_name].append(synth_neg)
+                    d_ir_full[from_name].append(synth_neg_full)
     finally:
         if needed > old_limit:
             sys.setrecursionlimit(old_limit)
@@ -1086,7 +1118,27 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
     # plus a redundant IR rebuild on large continuum specs (issue #145).
     # ``aliases_ir_map`` is already fully alias-inlined inside
     # ``_build_aliases_ir_from_raw`` so cycle detection is redundant here.
+    #
+    # The dominant cost on large specs is the per-cell ``inline_aliases``
+    # call. Because synthesized transitions install the SAME ``synth_to`` /
+    # ``synth_neg`` IR object into every cell of a template, the *terms*
+    # of the per-cell sum are shared across many cells even though the
+    # outer ``Apply(op="+", ...)`` wrapper is unique per cell. Inlining
+    # term-by-term with a shared ``result_memo`` keyed on ``id(term)``
+    # collapses the alias-substitution work from O(n_state) to
+    # O(n_unique_terms) (issue #145).
     alias_inline_memo: dict[int, frozenset[str]] = {}
+    alias_inline_result_memo: dict[int, Expr] = {}
+
+    def _inline_one(expr: Expr) -> Expr:
+        return inline_aliases(
+            expr,
+            aliases_ir_map,
+            memo=alias_inline_memo,
+            skip_cycle_check=True,
+            result_memo=alias_inline_result_memo,
+        )
+
     equations_ir_built_list: list[Expr | None] = []
     for expr in equations_ir_pre_inline:
         if expr is None:
@@ -1096,14 +1148,14 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
             equations_ir_built_list.append(expr)
             continue
         try:
-            equations_ir_built_list.append(
-                inline_aliases(
-                    expr,
-                    aliases_ir_map,
-                    memo=alias_inline_memo,
-                    skip_cycle_check=True,
-                )
-            )
+            if isinstance(expr, Apply) and expr.op == "+":
+                new_args = tuple(_inline_one(a) for a in expr.args)
+                if all(n is o for n, o in zip(new_args, expr.args, strict=True)):
+                    equations_ir_built_list.append(expr)
+                else:
+                    equations_ir_built_list.append(Apply(op="+", args=new_args))
+            else:
+                equations_ir_built_list.append(_inline_one(expr))
         except (ValueError, RecursionError):
             equations_ir_built_list.append(expr)
     equations_ir_built = tuple(equations_ir_built_list)

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -820,19 +820,42 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
             # share a single render (issue #145).
             from_name_memo: dict[tuple[str, ...], str] = {}
             to_name_memo: dict[tuple[str, ...], str] = {}
+            # Precompute positions in ``combo`` for each axis subset
+            # used downstream so we can build per-subset key tuples
+            # directly from ``combo`` (indexing into the iterator
+            # tuple) and avoid the per-combo ``dict(zip(...))`` cost
+            # entirely on the hot path. The full ``assignment`` dict
+            # is only materialized on memo misses or when the
+            # transition has a ``name`` template (issue #145).
+            _wc_pos = {a: i for i, a in enumerate(wildcard_axes)}
+            from_key_idx = tuple(_wc_pos[a] for a in frm_wc_axes)
+            to_key_idx = tuple(_wc_pos[a] for a in to_wc_axes)
+            rate_key_idx = tuple(_wc_pos[a] for a in rate_axes_used)
 
             for combo in combos:
-                assignment = dict(zip(wildcard_axes, combo, strict=True))
-                from_key = tuple(assignment[a] for a in frm_wc_axes)
+                # Build per-axis-subset keys directly from the combo
+                # tuple without materializing an ``assignment`` dict.
+                from_key = tuple(combo[i] for i in from_key_idx)
                 from_name = from_name_memo.get(from_key)
+                to_key = tuple(combo[i] for i in to_key_idx)
+                to_name = to_name_memo.get(to_key)
+                # ``assignment`` is only required on memo misses or for
+                # the optional ``name`` template; lazy-build it.
+                assignment: dict[str, str] | None = (
+                    dict(zip(wildcard_axes, combo, strict=True))
+                    if name_s
+                    else None
+                )
                 if from_name is None:
+                    if assignment is None:
+                        assignment = dict(zip(wildcard_axes, combo, strict=True))
                     from_name = render_selector(
                         frm_base, frm_tokens, assignment, axis_lookup=None
                     )
                     from_name_memo[from_key] = from_name
-                to_key = tuple(assignment[a] for a in to_wc_axes)
-                to_name = to_name_memo.get(to_key)
                 if to_name is None:
+                    if assignment is None:
+                        assignment = dict(zip(wildcard_axes, combo, strict=True))
                     to_name = render_selector(
                         to_base, to_tokens, assignment, axis_lookup=None
                     )
@@ -856,9 +879,13 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                     ir_rate_reduce: Expr = tpl_ir_rate_reduce
                     ir_rate_full: Expr = tpl_ir_rate_full  # type: ignore[assignment]
                 else:
-                    rate_key = tuple(assignment[a] for a in rate_axes_used)
+                    rate_key = tuple(combo[i] for i in rate_key_idx)
                     cached_rate_reduce = rate_ir_reduce_memo.get(rate_key)
                     if cached_rate_reduce is None:
+                        if assignment is None:
+                            assignment = dict(
+                                zip(wildcard_axes, combo, strict=True)
+                            )
                         cached_rate_reduce = expand_inline_templates(
                             ir_rate_raw,
                             assignment=assignment,
@@ -869,6 +896,10 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                     ir_rate_reduce = cached_rate_reduce
                     cached_rate_full = rate_ir_full_memo.get(rate_key)
                     if cached_rate_full is None:
+                        if assignment is None:
+                            assignment = dict(
+                                zip(wildcard_axes, combo, strict=True)
+                            )
                         cached_rate_full = expand_reduce_pointwise(
                             ir_rate_reduce,
                             axes=list(axes),

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -564,6 +564,19 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
     d_ir_reduce: dict[str, list[Expr]] = {s: [] for s in state_expanded}
     all_syms: set[str] = set()
     transitions_expanded_out: list[dict[str, Any]] = []
+    # Group ``state_expanded`` by base name once so the per-transition
+    # synthesis step can look up "all cells of this template" via a
+    # dict access instead of re-rendering every coord combo through
+    # ``render_selector`` (which dominated 3+ s on the COVID19_USA
+    # continuum spec). Every cell name is ``{base}__{axis_suffix}``
+    # (or just ``{base}`` for axis-less templates) and the transition
+    # ``state_set`` check below guarantees tokens are in the canonical
+    # state-template order, so the grouped lookup matches the result
+    # of enumerating the template's wildcard combos. Issue #145.
+    cells_by_base: dict[str, list[str]] = {}
+    for _name in state_expanded:
+        _base = _name.split("__", 1)[0]
+        cells_by_base.setdefault(_base, []).append(_name)
     # Cache: ``(base, template_tokens) -> list[str]`` for
     # ``_enumerate_template_cell_names``. The same (base, tokens) pair is
     # queried once per (from, to) side per combo expansion, so caching cuts
@@ -887,6 +900,16 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                 # template-uniform synthesized IR is installed in every
                 # cell. Pinned-coord selection lives inside the body via
                 # the one-hot mask multiplications below.
+                #
+                # ``cells_by_base`` (built once at the top of this function)
+                # already holds every concrete cell name grouped by base
+                # in the canonical state-template ordering, so the set
+                # of cells matching a wildcard-only template is just the
+                # bucket for that base. We only fall back to the previous
+                # ``render_selector`` enumeration when a template has no
+                # axis tokens at all (the lookup would then equal
+                # ``[base]`` anyway, but the empty/no-axes case is rare
+                # and not on the hot path). Issue #145.
                 enum_cache = enumerate_template_cell_names_cache
 
                 def _enumerate_template_cell_names(
@@ -894,39 +917,17 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                     template_tokens: tuple[Any, ...],
                     _cache: dict[tuple[str, tuple[Any, ...]], list[str]] = enum_cache,
                 ) -> list[str]:
-                    cache_key = (base, template_tokens)
-                    cached = _cache.get(cache_key)
-                    if cached is not None:
-                        return cached
-                    axes_and_coords = [
-                        (tok.axis, ax_lookup_dict[tok.axis])
-                        for tok in template_tokens
-                        if isinstance(tok, (WildcardToken, PinnedToken))
-                    ]
-                    if not axes_and_coords:
+                    if template_tokens:
+                        cached = cells_by_base.get(base)
+                        if cached is not None:
+                            return cached
                         return [base]
-                    tokens_as_wc = tuple(
-                        WildcardToken(axis=tok.axis)
-                        if isinstance(tok, PinnedToken)
-                        else tok
-                        for tok in template_tokens
-                    )
-                    out: list[str] = []
-                    for combo in product(*(coords for _, coords in axes_and_coords)):
-                        assign = {
-                            axis: c
-                            for (axis, _), c in zip(axes_and_coords, combo, strict=True)
-                        }
-                        out.append(
-                            render_selector(
-                                base,
-                                tokens_as_wc,
-                                assign,
-                                axis_lookup=ax_lookup_dict,
-                            )
-                        )
-                    _cache[cache_key] = out
-                    return out
+                    cache_key = (base, template_tokens)
+                    cached_full = _cache.get(cache_key)
+                    if cached_full is not None:
+                        return cached_full
+                    _cache[cache_key] = [base]
+                    return [base]
 
                 to_names_for_synthesis = set(
                     _enumerate_template_cell_names(to_base, tuple(to_tokens))

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -55,7 +55,10 @@ from op_system._ir import (
     parse_expr_to_ir,
     unparse_ir,
 )
-from op_system._ir_templates import expand_inline_templates
+from op_system._ir_templates import (
+    expand_inline_templates,
+    inline_aliases,
+)
 from op_system._normalize_chains import (
     _apply_coord_shifts,
     _apply_expr_chains,
@@ -67,7 +70,6 @@ from op_system._normalize_ir import (
     StateTemplate,
     _build_alias_templates,
     _build_aliases_ir_from_raw,
-    _build_equations_ir,
     _build_equations_ir_from_raw,
     _build_state_templates,
     _derive_alias_strings,
@@ -559,6 +561,13 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
     d_ir_reduce: dict[str, list[Expr]] = {s: [] for s in state_expanded}
     all_syms: set[str] = set()
     transitions_expanded_out: list[dict[str, Any]] = []
+    # Cache: ``(base, template_tokens) -> list[str]`` for
+    # ``_enumerate_template_cell_names``. The same (base, tokens) pair is
+    # queried once per (from, to) side per combo expansion, so caching cuts
+    # the dominant ``render_selector`` walk on continuum specs (issue #145).
+    enumerate_template_cell_names_cache: dict[
+        tuple[str, tuple[Any, ...]], list[str]
+    ] = {}
 
     old_limit = sys.getrecursionlimit()
     needed = max(old_limit, 10_000)
@@ -770,10 +779,17 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                 # template-uniform synthesized IR is installed in every
                 # cell. Pinned-coord selection lives inside the body via
                 # the one-hot mask multiplications below.
+                enum_cache = enumerate_template_cell_names_cache
+
                 def _enumerate_template_cell_names(
                     base: str,
                     template_tokens: tuple[Any, ...],
+                    _cache: dict[tuple[str, tuple[Any, ...]], list[str]] = enum_cache,
                 ) -> list[str]:
+                    cache_key = (base, template_tokens)
+                    cached = _cache.get(cache_key)
+                    if cached is not None:
+                        return cached
                     axes_and_coords = [
                         (tok.axis, ax_lookup_dict[tok.axis])
                         for tok in template_tokens
@@ -801,6 +817,7 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                                 axis_lookup=ax_lookup_dict,
                             )
                         )
+                    _cache[cache_key] = out
                     return out
 
                 to_names_for_synthesis = set(
@@ -1063,7 +1080,33 @@ def normalize_transitions_rhs(  # noqa: C901, PLR0912, PLR0914, PLR0915
     axis_name_set = set(axis_lookup_dict)
     template_base_set = {parse_selector(k)[0] for k in template_map_all}
     eqs_tuple = _derive_equation_strings(equations_ir_pre_inline)
-    equations_ir_built = _build_equations_ir(eqs_tuple, aliases_ir_map)
+    # Inline aliases directly into the per-cell IR we already built in
+    # ``_build_transition_equations_ir`` rather than re-parsing the
+    # round-tripped equation strings. Avoids 73k x ``parse_expr_to_ir``
+    # plus a redundant IR rebuild on large continuum specs (issue #145).
+    # ``aliases_ir_map`` is already fully alias-inlined inside
+    # ``_build_aliases_ir_from_raw`` so cycle detection is redundant here.
+    alias_inline_memo: dict[int, frozenset[str]] = {}
+    equations_ir_built_list: list[Expr | None] = []
+    for expr in equations_ir_pre_inline:
+        if expr is None:
+            equations_ir_built_list.append(None)
+            continue
+        if not aliases_ir_map:
+            equations_ir_built_list.append(expr)
+            continue
+        try:
+            equations_ir_built_list.append(
+                inline_aliases(
+                    expr,
+                    aliases_ir_map,
+                    memo=alias_inline_memo,
+                    skip_cycle_check=True,
+                )
+            )
+        except (ValueError, RecursionError):
+            equations_ir_built_list.append(expr)
+    equations_ir_built = tuple(equations_ir_built_list)
     return TransitionsRhs(
         state_names=tuple(state_expanded),
         equations=eqs_tuple,

--- a/src/op_system/_normalize_ir.py
+++ b/src/op_system/_normalize_ir.py
@@ -467,7 +467,7 @@ def _build_aliases_ir(
         memo: dict[int, frozenset[str]] = {}
         cycle_validated = False
         try:
-            cycle = _detect_alias_cycle(parsed)
+            cycle = _detect_alias_cycle(parsed, memo=memo)
             cycle_validated = cycle is None
         except (ValueError, RecursionError):
             cycle_validated = False
@@ -508,7 +508,7 @@ def _build_equations_ir(
         cycle_validated = False
         if aliases_ir:
             try:
-                cycle = _detect_alias_cycle(aliases_ir)
+                cycle = _detect_alias_cycle(aliases_ir, memo=memo)
                 cycle_validated = cycle is None
             except (ValueError, RecursionError):
                 cycle_validated = False
@@ -609,11 +609,8 @@ def _build_aliases_ir_from_raw(  # noqa: C901
                     axis_coords=ax_lookup,
                 )
 
-        def _inline_all(parsed: dict[str, Expr]) -> dict[str, Expr]:
+        def _inline_all(parsed: dict[str, Expr], *, cycle_ok: bool) -> dict[str, Expr]:
             memo: dict[int, frozenset[str]] = {}
-            cycle_ok = False
-            with contextlib.suppress(ValueError, RecursionError):
-                cycle_ok = _detect_alias_cycle(parsed) is None
             inlined: dict[str, Expr] = {}
             for name, expr in parsed.items():
                 try:
@@ -624,7 +621,23 @@ def _build_aliases_ir_from_raw(  # noqa: C901
                     inlined[name] = expr
             return inlined
 
-        return _inline_all(full_parsed), _inline_all(reduce_parsed), alias_template_map
+        # Cycle topology between aliases depends only on the alias names a body
+        # references, not on the coordinate substitutions performed by
+        # ``expand_inline_templates`` / ``expand_reduce_pointwise``. Detect the
+        # cycle once on the cheaper ``reduce_parsed`` map (which preserves the
+        # ``Reduce`` aggregator nodes verbatim) and reuse the result when
+        # inlining the larger ``full_parsed`` bodies. This avoids walking the
+        # 6500-node continuum alias bodies twice (issue #145).
+        cycle_memo: dict[int, frozenset[str]] = {}
+        cycle_ok = False
+        with contextlib.suppress(ValueError, RecursionError):
+            cycle_ok = _detect_alias_cycle(reduce_parsed, memo=cycle_memo) is None
+
+        return (
+            _inline_all(full_parsed, cycle_ok=cycle_ok),
+            _inline_all(reduce_parsed, cycle_ok=cycle_ok),
+            alias_template_map,
+        )
     finally:
         if needed > old_limit:
             sys.setrecursionlimit(old_limit)
@@ -699,7 +712,7 @@ def _build_equations_ir_from_raw(  # noqa: PLR0913
     alias_cycle_ok = False
     if aliases_ir:
         with contextlib.suppress(ValueError, RecursionError):
-            alias_cycle_ok = _detect_alias_cycle(aliases_ir) is None
+            alias_cycle_ok = _detect_alias_cycle(aliases_ir, memo=alias_memo) is None
 
     out_reduce: list[Expr | None] = []
     out_full: list[Expr | None] = []

--- a/src/op_system/_normalize_ir.py
+++ b/src/op_system/_normalize_ir.py
@@ -535,7 +535,97 @@ def _build_equations_ir(
             sys.setrecursionlimit(old_limit)
 
 
-def _build_aliases_ir_from_raw(  # noqa: C901
+def _parse_alias_body(  # noqa: PLR0913
+    raw_name: str,
+    expr_str: object,
+    *,
+    axes: list[dict[str, Any]],
+    shaped: Mapping[str, tuple[str, ...]],
+    ax_lookup: Mapping[str, list[str]],
+    alias_template_map: Mapping[str, Sequence[tuple[str, Mapping[str, str]]]],
+    reduce_parsed: dict[str, Expr],
+    full_parsed: dict[str, Expr],
+) -> None:
+    """Parse and expand one alias entry into ``reduce_parsed``/``full_parsed``.
+
+    Splits the per-alias work out of :func:`_build_aliases_ir_from_raw` so
+    that function stays under Ruff's local-variable budget. The template
+    expansion logic (shared Reduce-expanded body + per-coord pin) is
+    documented inline below (issue #145).
+
+    Raises:
+        InvalidRhsSpecError: If ``expr_str`` is empty or fails to parse.
+    """
+    from op_system._ir_expand import expand_reduce_pointwise  # noqa: PLC0415
+
+    canonical_name = _normalize_bracket_key(raw_name)
+    expr_s = expr_str.strip() if isinstance(expr_str, str) else ""
+    if not expr_s:
+        raise InvalidRhsSpecError(
+            detail=f"aliases[{raw_name!r}] must be a non-empty string"
+        )
+    try:
+        ir_raw = parse_expr_to_ir(expr_s, lower_helpers=True)
+    except Exception as exc:
+        raise InvalidRhsSpecError(
+            detail=f"aliases[{raw_name!r}] has invalid expression: {exc}"
+        ) from exc
+
+    if canonical_name not in alias_template_map:
+        reduce_parsed[raw_name] = ir_raw
+        full_parsed[raw_name] = expand_reduce_pointwise(
+            ir_raw,
+            axes=list(axes),
+            shaped_params=shaped,
+            lhs_assignment={},
+            axis_coords=ax_lookup,
+        )
+        return
+
+    # Build the Reduce-expanded body ONCE with empty ``lhs_assignment``:
+    # every same-axis-twice subscript that needed the LHS pin would also
+    # have been bound by an enclosing Reduce (otherwise the construct is
+    # ill-formed), so the empty pass produces a template-form body whose
+    # only unresolved positions are the LHS free-axis
+    # ``AxisIndex(coord=None)`` slots. The per-coord pin step below
+    # collapses those slots via a cheap walk through
+    # :func:`expand_inline_templates`, replacing the previous
+    # O(coords * reduce-enumeration) cost with
+    # O(reduce-enumeration + coords * pin). For the COVID19_USA
+    # continuum (21 age coords * a 6500-node alias body) this is the
+    # dominant build cost (issue #145).
+    ir_full_root = expand_reduce_pointwise(
+        ir_raw,
+        axes=list(axes),
+        shaped_params=shaped,
+        lhs_assignment={},
+        axis_coords=ax_lookup,
+    )
+    # Shared per-subtree free-axes caches: each per-coord pin call would
+    # otherwise re-walk the full body even though most subtrees never
+    # reference the pinning axis. The memo lets
+    # ``expand_inline_templates`` short-circuit unaffected subtrees on
+    # every call except the first (issue #145).
+    fa_raw_memo: dict[int, frozenset[str]] = {}
+    fa_full_memo: dict[int, frozenset[str]] = {}
+    for expanded_name, assignment in alias_template_map[canonical_name]:
+        reduce_parsed[expanded_name] = expand_inline_templates(
+            ir_raw,
+            assignment=assignment,
+            shaped_params=shaped,
+            axis_lookup=ax_lookup,
+            _free_axes_memo=fa_raw_memo,
+        )
+        full_parsed[expanded_name] = expand_inline_templates(
+            ir_full_root,
+            assignment=assignment,
+            shaped_params=shaped,
+            axis_lookup=ax_lookup,
+            _free_axes_memo=fa_full_memo,
+        )
+
+
+def _build_aliases_ir_from_raw(
     aliases_raw: Mapping[str, str],
     *,
     axes: list[dict[str, Any]],
@@ -550,12 +640,7 @@ def _build_aliases_ir_from_raw(  # noqa: C901
 
     Returns:
         ``(aliases_ir, aliases_ir_reduce, alias_template_map)``.
-
-    Raises:
-        InvalidRhsSpecError: If any alias body is an invalid expression.
     """
-    from op_system._ir_expand import expand_reduce_pointwise  # noqa: PLC0415
-
     shaped = shaped_params or {}
     ax_lookup = dict(axis_lookup or {})
 
@@ -570,73 +655,16 @@ def _build_aliases_ir_from_raw(  # noqa: C901
             sys.setrecursionlimit(needed)
 
         for raw_name, expr_str in aliases_raw.items():
-            canonical_name = _normalize_bracket_key(raw_name)
-            expr_s = expr_str.strip() if isinstance(expr_str, str) else ""
-            if not expr_s:
-                raise InvalidRhsSpecError(
-                    detail=f"aliases[{raw_name!r}] must be a non-empty string"
-                )
-            try:
-                ir_raw = parse_expr_to_ir(expr_s, lower_helpers=True)
-            except Exception as exc:
-                raise InvalidRhsSpecError(
-                    detail=f"aliases[{raw_name!r}] has invalid expression: {exc}"
-                ) from exc
-
-            if canonical_name in alias_template_map:
-                # Build the Reduce-expanded body ONCE with empty
-                # ``lhs_assignment``: every same-axis-twice subscript
-                # that needed the LHS pin would also have been bound by
-                # an enclosing Reduce (otherwise the construct is
-                # ill-formed), so the empty pass produces a template-
-                # form body whose only unresolved positions are the
-                # LHS free-axis ``AxisIndex(coord=None)`` slots. The
-                # per-coord pin step below collapses those slots via a
-                # cheap walk through :func:`expand_inline_templates`,
-                # replacing the previous O(coords * reduce-enumeration)
-                # cost with O(reduce-enumeration + coords * pin). For
-                # the COVID19_USA continuum (21 age coords * a
-                # 6500-node alias body) this is the dominant build
-                # cost (issue #145).
-                ir_full_root = expand_reduce_pointwise(
-                    ir_raw,
-                    axes=list(axes),
-                    shaped_params=shaped,
-                    lhs_assignment={},
-                    axis_coords=ax_lookup,
-                )
-                # Shared per-subtree free-axes caches: each per-coord
-                # pin call would otherwise re-walk the full body even
-                # though most subtrees never reference the pinning
-                # axis. The memo lets ``expand_inline_templates``
-                # short-circuit unaffected subtrees on every call
-                # except the first (issue #145).
-                fa_raw_memo: dict[int, frozenset[str]] = {}
-                fa_full_memo: dict[int, frozenset[str]] = {}
-                for expanded_name, assignment in alias_template_map[canonical_name]:
-                    reduce_parsed[expanded_name] = expand_inline_templates(
-                        ir_raw,
-                        assignment=assignment,
-                        shaped_params=shaped,
-                        axis_lookup=ax_lookup,
-                        _free_axes_memo=fa_raw_memo,
-                    )
-                    full_parsed[expanded_name] = expand_inline_templates(
-                        ir_full_root,
-                        assignment=assignment,
-                        shaped_params=shaped,
-                        axis_lookup=ax_lookup,
-                        _free_axes_memo=fa_full_memo,
-                    )
-            else:
-                reduce_parsed[raw_name] = ir_raw
-                full_parsed[raw_name] = expand_reduce_pointwise(
-                    ir_raw,
-                    axes=list(axes),
-                    shaped_params=shaped,
-                    lhs_assignment={},
-                    axis_coords=ax_lookup,
-                )
+            _parse_alias_body(
+                raw_name,
+                expr_str,
+                axes=axes,
+                shaped=shaped,
+                ax_lookup=ax_lookup,
+                alias_template_map=alias_template_map,
+                reduce_parsed=reduce_parsed,
+                full_parsed=full_parsed,
+            )
 
         def _inline_all(parsed: dict[str, Expr], *, cycle_ok: bool) -> dict[str, Expr]:
             memo: dict[int, frozenset[str]] = {}

--- a/src/op_system/_normalize_ir.py
+++ b/src/op_system/_normalize_ir.py
@@ -584,20 +584,39 @@ def _build_aliases_ir_from_raw(  # noqa: C901
                 ) from exc
 
             if canonical_name in alias_template_map:
+                # Build the Reduce-expanded body ONCE with empty
+                # ``lhs_assignment``: every same-axis-twice subscript
+                # that needed the LHS pin would also have been bound by
+                # an enclosing Reduce (otherwise the construct is
+                # ill-formed), so the empty pass produces a template-
+                # form body whose only unresolved positions are the
+                # LHS free-axis ``AxisIndex(coord=None)`` slots. The
+                # per-coord pin step below collapses those slots via a
+                # cheap walk through :func:`expand_inline_templates`,
+                # replacing the previous O(coords * reduce-enumeration)
+                # cost with O(reduce-enumeration + coords * pin). For
+                # the COVID19_USA continuum (21 age coords * a
+                # 6500-node alias body) this is the dominant build
+                # cost (issue #145).
+                ir_full_root = expand_reduce_pointwise(
+                    ir_raw,
+                    axes=list(axes),
+                    shaped_params=shaped,
+                    lhs_assignment={},
+                    axis_coords=ax_lookup,
+                )
                 for expanded_name, assignment in alias_template_map[canonical_name]:
-                    ir_tmpl = expand_inline_templates(
+                    reduce_parsed[expanded_name] = expand_inline_templates(
                         ir_raw,
                         assignment=assignment,
                         shaped_params=shaped,
                         axis_lookup=ax_lookup,
                     )
-                    reduce_parsed[expanded_name] = ir_tmpl
-                    full_parsed[expanded_name] = expand_reduce_pointwise(
-                        ir_tmpl,
-                        axes=list(axes),
+                    full_parsed[expanded_name] = expand_inline_templates(
+                        ir_full_root,
+                        assignment=assignment,
                         shaped_params=shaped,
-                        lhs_assignment=assignment,
-                        axis_coords=ax_lookup,
+                        axis_lookup=ax_lookup,
                     )
             else:
                 reduce_parsed[raw_name] = ir_raw

--- a/src/op_system/_normalize_ir.py
+++ b/src/op_system/_normalize_ir.py
@@ -605,18 +605,28 @@ def _build_aliases_ir_from_raw(  # noqa: C901
                     lhs_assignment={},
                     axis_coords=ax_lookup,
                 )
+                # Shared per-subtree free-axes caches: each per-coord
+                # pin call would otherwise re-walk the full body even
+                # though most subtrees never reference the pinning
+                # axis. The memo lets ``expand_inline_templates``
+                # short-circuit unaffected subtrees on every call
+                # except the first (issue #145).
+                fa_raw_memo: dict[int, frozenset[str]] = {}
+                fa_full_memo: dict[int, frozenset[str]] = {}
                 for expanded_name, assignment in alias_template_map[canonical_name]:
                     reduce_parsed[expanded_name] = expand_inline_templates(
                         ir_raw,
                         assignment=assignment,
                         shaped_params=shaped,
                         axis_lookup=ax_lookup,
+                        _free_axes_memo=fa_raw_memo,
                     )
                     full_parsed[expanded_name] = expand_inline_templates(
                         ir_full_root,
                         assignment=assignment,
                         shaped_params=shaped,
                         axis_lookup=ax_lookup,
+                        _free_axes_memo=fa_full_memo,
                     )
             else:
                 reduce_parsed[raw_name] = ir_raw

--- a/src/op_system/_normalize_ir.py
+++ b/src/op_system/_normalize_ir.py
@@ -611,11 +611,21 @@ def _build_aliases_ir_from_raw(  # noqa: C901
 
         def _inline_all(parsed: dict[str, Expr], *, cycle_ok: bool) -> dict[str, Expr]:
             memo: dict[int, frozenset[str]] = {}
+            # ``result_memo`` keyed on ``id(expr)`` lets ``inline_aliases``
+            # share the final substituted IR across alias entries that pass
+            # the same sub-IR object (e.g. the 21 per-age expansions of one
+            # templated alias share many internal Subscript subtrees by
+            # identity after ``expand_inline_templates``). Issue #145.
+            result_memo: dict[int, Expr] = {}
             inlined: dict[str, Expr] = {}
             for name, expr in parsed.items():
                 try:
                     inlined[name] = inline_aliases(
-                        expr, parsed, memo=memo, skip_cycle_check=cycle_ok
+                        expr,
+                        parsed,
+                        memo=memo,
+                        skip_cycle_check=cycle_ok,
+                        result_memo=result_memo,
                     )
                 except (ValueError, RecursionError):
                     inlined[name] = expr

--- a/src/op_system/_normalize_ir.py
+++ b/src/op_system/_normalize_ir.py
@@ -796,8 +796,16 @@ def _build_equations_ir_from_raw(  # noqa: PLR0913
 
 def _derive_equation_strings(
     equations_ir: tuple[Expr | None, ...],
+    *,
+    _unparse_memo: dict[tuple[int, int, bool], str] | None = None,
 ) -> tuple[str, ...]:
     """Render each equation's RHS directly from typed IR.
+
+    Args:
+        equations_ir: Tuple of equation IR expressions.
+        _unparse_memo: Optional identity-keyed cache to share with
+            other ``unparse_ir`` calls (e.g. alias-body rendering).
+            When omitted, a fresh dict is used internally.
 
     Returns:
         Tuple of equation strings aligned with ``equations_ir``.
@@ -813,7 +821,9 @@ def _derive_equation_strings(
         # template's synthesized ``synth_to`` / ``synth_neg`` IR object
         # installed into every cell's equation; issue #145) runs once
         # rather than once per cell.
-        unparse_memo: dict[tuple[int, int, bool], str] = {}
+        unparse_memo: dict[tuple[int, int, bool], str] = (
+            _unparse_memo if _unparse_memo is not None else {}
+        )
         rendered: list[str] = []
         for idx, ir in enumerate(equations_ir):
             if ir is None:
@@ -835,8 +845,18 @@ def _derive_equation_strings(
 def _derive_alias_strings(
     aliases_ir: Mapping[str, Expr],
     alias_order: Iterable[str],
+    *,
+    _unparse_memo: dict[tuple[int, int, bool], str] | None = None,
 ) -> dict[str, str]:
     """Render each alias body directly from typed IR.
+
+    Args:
+        aliases_ir: Mapping of alias name to typed IR body.
+        alias_order: Iterable of alias names defining output order.
+        _unparse_memo: Optional identity-keyed cache shared across
+            multiple ``unparse_ir`` calls so substructure repeated
+            across alias bodies (e.g. coord-pinned copies of the same
+            template body) is rendered once (issue #145).
 
     Returns:
         New alias mapping with IR-derived bodies.
@@ -856,7 +876,7 @@ def _derive_alias_strings(
                     detail=f"alias {name!r} is missing typed IR during rendering"
                 )
             try:
-                out[name] = unparse_ir(ir)
+                out[name] = unparse_ir(ir, _memo=_unparse_memo)
             except (ValueError, RecursionError) as exc:
                 raise InvalidRhsSpecError(
                     detail=f"alias {name!r} could not be rendered from typed IR"

--- a/src/op_system/_normalize_ir.py
+++ b/src/op_system/_normalize_ir.py
@@ -780,6 +780,11 @@ def _derive_equation_strings(
     old_limit = sys.getrecursionlimit()
     sys.setrecursionlimit(max(old_limit, 10_000))
     try:
+        # Identity-keyed memo so rendering shared sub-IR (e.g. one
+        # template's synthesized ``synth_to`` / ``synth_neg`` IR object
+        # installed into every cell's equation; issue #145) runs once
+        # rather than once per cell.
+        unparse_memo: dict[tuple[int, int, bool], str] = {}
         rendered: list[str] = []
         for idx, ir in enumerate(equations_ir):
             if ir is None:
@@ -787,7 +792,7 @@ def _derive_equation_strings(
                     detail=f"equations[{idx}] is missing typed IR during rendering"
                 )
             try:
-                rendered.append(unparse_ir(ir))
+                rendered.append(unparse_ir(ir, _memo=unparse_memo))
             except (ValueError, RecursionError) as exc:
                 raise InvalidRhsSpecError(
                     detail=f"equations[{idx}] could not be rendered from typed IR"

--- a/src/op_system/_normalize_ir.py
+++ b/src/op_system/_normalize_ir.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import re
-    from collections.abc import Iterable, Mapping, Sequence
+    from collections.abc import Iterable, Iterator, Mapping, Sequence
 
 from op_system._axes import _normalize_bracket_key
 from op_system._errors import InvalidRhsSpecError
@@ -33,6 +33,23 @@ from op_system._templates import (
     expand_selector,
     parse_selector,
 )
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _raise_recursion_limit(needed: int, old_limit: int) -> Iterator[None]:
+    """Temporarily raise ``sys.setrecursionlimit`` to ``needed``."""
+    if needed > old_limit:
+        sys.setrecursionlimit(needed)
+    try:
+        yield
+    finally:
+        if needed > old_limit:
+            sys.setrecursionlimit(old_limit)
+
 
 # ---------------------------------------------------------------------------
 # StateTemplate dataclass
@@ -458,9 +475,7 @@ def _build_aliases_ir(
     """
     old_limit = sys.getrecursionlimit()
     needed = max(old_limit, 10_000)
-    try:
-        if needed > old_limit:
-            sys.setrecursionlimit(needed)
+    with _raise_recursion_limit(needed, old_limit):
         parsed: dict[str, Expr] = {}
         for name, body in aliases.items():
             parsed[name] = parse_expr_to_ir(body, lower_helpers=lower_helpers)
@@ -483,9 +498,6 @@ def _build_aliases_ir(
             except (ValueError, RecursionError):
                 inlined[name] = expr
         return inlined
-    finally:
-        if needed > old_limit:
-            sys.setrecursionlimit(old_limit)
 
 
 def _build_equations_ir(
@@ -501,9 +513,7 @@ def _build_equations_ir(
     """
     old_limit = sys.getrecursionlimit()
     needed = max(old_limit, 10_000)
-    try:
-        if needed > old_limit:
-            sys.setrecursionlimit(needed)
+    with _raise_recursion_limit(needed, old_limit):
         memo: dict[int, frozenset[str]] = {}
         cycle_validated = False
         if aliases_ir:
@@ -530,9 +540,6 @@ def _build_equations_ir(
             except (ValueError, RecursionError):
                 out.append(expr)
         return tuple(out)
-    finally:
-        if needed > old_limit:
-            sys.setrecursionlimit(old_limit)
 
 
 def _parse_alias_body(  # noqa: PLR0913
@@ -650,10 +657,7 @@ def _build_aliases_ir_from_raw(
     full_parsed: dict[str, Expr] = {}
     old_limit = sys.getrecursionlimit()
     needed = max(old_limit, 10_000)
-    try:
-        if needed > old_limit:
-            sys.setrecursionlimit(needed)
-
+    with _raise_recursion_limit(needed, old_limit):
         for raw_name, expr_str in aliases_raw.items():
             _parse_alias_body(
                 raw_name,
@@ -705,9 +709,6 @@ def _build_aliases_ir_from_raw(
             _inline_all(reduce_parsed, cycle_ok=cycle_ok),
             alias_template_map,
         )
-    finally:
-        if needed > old_limit:
-            sys.setrecursionlimit(old_limit)
 
 
 def _lookup_cell_expr(
@@ -786,9 +787,7 @@ def _build_equations_ir_from_raw(  # noqa: PLR0913
     all_syms: set[str] = set()
     old_limit = sys.getrecursionlimit()
     needed = max(old_limit, 10_000)
-    try:
-        if needed > old_limit:
-            sys.setrecursionlimit(needed)
+    with _raise_recursion_limit(needed, old_limit):
         for cell in state_expanded:
             raw_expr = cell_to_expr[cell]
             assignment = cell_to_assignment.get(cell, {})
@@ -822,9 +821,6 @@ def _build_equations_ir_from_raw(  # noqa: PLR0913
             all_syms |= free_symbols(ir_inlined)
             out_full.append(ir_inlined)
         return tuple(out_full), tuple(out_reduce), all_syms
-    finally:
-        if needed > old_limit:
-            sys.setrecursionlimit(old_limit)
 
 
 # ---------------------------------------------------------------------------
@@ -853,8 +849,8 @@ def _derive_equation_strings(
             rendered back to source.
     """
     old_limit = sys.getrecursionlimit()
-    sys.setrecursionlimit(max(old_limit, 10_000))
-    try:
+    needed = max(old_limit, 10_000)
+    with _raise_recursion_limit(needed, old_limit):
         # Identity-keyed memo so rendering shared sub-IR (e.g. one
         # template's synthesized ``synth_to`` / ``synth_neg`` IR object
         # installed into every cell's equation; issue #145) runs once
@@ -875,9 +871,6 @@ def _derive_equation_strings(
                     detail=f"equations[{idx}] could not be rendered from typed IR"
                 ) from exc
         return tuple(rendered)
-    finally:
-        with contextlib.suppress(ValueError, RecursionError):
-            sys.setrecursionlimit(old_limit)
 
 
 def _derive_alias_strings(
@@ -904,8 +897,8 @@ def _derive_alias_strings(
             back to source.
     """
     old_limit = sys.getrecursionlimit()
-    sys.setrecursionlimit(max(old_limit, 10_000))
-    try:
+    needed = max(old_limit, 10_000)
+    with _raise_recursion_limit(needed, old_limit):
         out: dict[str, str] = {}
         for name in alias_order:
             ir = aliases_ir.get(name)
@@ -920,6 +913,3 @@ def _derive_alias_strings(
                     detail=f"alias {name!r} could not be rendered from typed IR"
                 ) from exc
         return out
-    finally:
-        with contextlib.suppress(ValueError, RecursionError):
-            sys.setrecursionlimit(old_limit)

--- a/src/op_system/_templates.py
+++ b/src/op_system/_templates.py
@@ -60,7 +60,7 @@ _APPLY_TPL_PREPARSE_CACHE: dict[
     int,
     tuple[
         object,
-        tuple[tuple[str, str, tuple["WildcardToken", ...], "re.Pattern[str]"], ...],
+        tuple[tuple[str, str, tuple[WildcardToken, ...], re.Pattern[str]], ...],
     ],
 ] = {}
 # Matches any "[...]" fragment to extract placeholder names from rate exprs.
@@ -457,6 +457,59 @@ def _render_template_or_literal(name_s: str, assignment: Mapping[str, str]) -> s
     return _render_template_name(base, [wt.axis for wt in wildcards], assignment)
 
 
+def _prepare_template_substitutions(
+    template_map: Mapping[str, list[tuple[str, dict[str, str]]]],
+    *,
+    shaped: Mapping[str, tuple[str, ...]],
+) -> tuple[tuple[str, str, tuple[WildcardToken, ...], re.Pattern[str]], ...]:
+    """Build the per-``template_map`` prepared substitution table.
+
+    Filters out keys with no wildcards and keys whose base collides with
+    a shaped param, and precompiles the literal regex used by
+    ``_apply_template_substitutions``.
+
+    Returns:
+        Tuple of ``(template_key, base, wildcards, compiled_pattern)``
+        rows for every templatable key in ``template_map``.
+    """
+    prepared_list: list[
+        tuple[str, str, tuple[WildcardToken, ...], re.Pattern[str]]
+    ] = []
+    for template_key in template_map:
+        base, tokens = parse_selector(template_key)
+        if base in shaped:
+            continue
+        wildcards = tuple(t for t in tokens if isinstance(t, WildcardToken))
+        if not wildcards:
+            continue
+        prepared_list.append((
+            template_key,
+            base,
+            wildcards,
+            re.compile(re.escape(template_key)),
+        ))
+    return tuple(prepared_list)
+
+
+def _render_shaped_inline(  # noqa: PLR0913
+    inner_base: str,
+    phs: list[str],
+    *,
+    assignment: Mapping[str, str],
+    shaped: Mapping[str, tuple[str, ...]],
+    axis_lookup: Mapping[str, list[str]] | None,
+    fallback: str,
+) -> str:
+    registered = shaped[inner_base]
+    if tuple(phs) != registered or axis_lookup is None:
+        return fallback
+    try:
+        idxs = [axis_lookup[ax].index(assignment[ax]) for ax in registered]
+    except (KeyError, ValueError):
+        return fallback
+    return f"{inner_base}[{', '.join(str(i) for i in idxs)}]"
+
+
 def _apply_template_substitutions(
     expr_s: str,
     *,
@@ -483,33 +536,15 @@ def _apply_template_substitutions(
     expr_out = expr_s
     shaped = shaped_params or {}
 
-    # Pre-parse template keys once per ``template_map`` identity: we
-    # filter out keys with no wildcards and keys whose base collides
-    # with a shaped param, and precompile the literal regex used by
-    # ``re.sub`` below. This collapses O(cells * |template_map|)
-    # ``parse_selector`` calls to O(|template_map|) per normalize call
-    # (issue #145).
+    # Pre-parse template keys once per ``template_map`` identity (see
+    # ``_prepare_template_substitutions``). Collapses O(cells *
+    # |template_map|) ``parse_selector`` calls to O(|template_map|) per
+    # normalize call (issue #145).
     cache_entry = _APPLY_TPL_PREPARSE_CACHE.get(id(template_map))
     if cache_entry is not None and cache_entry[0] is template_map:
         prepared = cache_entry[1]
     else:
-        prepared_list: list[
-            tuple[str, str, tuple[WildcardToken, ...], re.Pattern[str]]
-        ] = []
-        for template_key in template_map:
-            base, tokens = parse_selector(template_key)
-            if base in shaped:
-                continue
-            wildcards = tuple(t for t in tokens if isinstance(t, WildcardToken))
-            if not wildcards:
-                continue
-            prepared_list.append((
-                template_key,
-                base,
-                wildcards,
-                re.compile(re.escape(template_key)),
-            ))
-        prepared = tuple(prepared_list)
+        prepared = _prepare_template_substitutions(template_map, shaped=shaped)
         _APPLY_TPL_PREPARSE_CACHE[id(template_map)] = (template_map, prepared)
 
     for template_key, base, wildcards, pat in prepared:
@@ -530,17 +565,14 @@ def _apply_template_substitutions(
         if not phs or any(ph not in assignment for ph in phs):
             return match.group(0)
         if inner_base in shaped:
-            registered = shaped[inner_base]
-            if tuple(phs) != registered:
-                # Different ordering or axes — leave for downstream to flag.
-                return match.group(0)
-            if axis_lookup is None:
-                return match.group(0)
-            try:
-                idxs = [axis_lookup[ax].index(assignment[ax]) for ax in registered]
-            except (KeyError, ValueError):
-                return match.group(0)
-            return f"{inner_base}[{', '.join(str(i) for i in idxs)}]"
+            return _render_shaped_inline(
+                inner_base,
+                phs,
+                assignment=assignment,
+                shaped=shaped,
+                axis_lookup=axis_lookup,
+                fallback=match.group(0),
+            )
         return _render_template_name(inner_base, phs, assignment)
 
     return _INLINE_TEMPLATE_RE.sub(_inline_replacer, expr_out)

--- a/src/op_system/_templates.py
+++ b/src/op_system/_templates.py
@@ -90,7 +90,17 @@ def _sanitize_fragment(val: object) -> str:
     Returns:
         Identifier-safe string fragment.
     """
-    return re.sub(r"[^A-Za-z0-9_]", "_", str(val))
+    s = val if type(val) is str else str(val)
+    cached = _SANITIZE_CACHE.get(s)
+    if cached is not None:
+        return cached
+    result = _SANITIZE_RE.sub("_", s)
+    _SANITIZE_CACHE[s] = result
+    return result
+
+
+_SANITIZE_RE = re.compile(r"[^A-Za-z0-9_]")
+_SANITIZE_CACHE: dict[str, str] = {}
 
 
 def build_axis_lookup(axes: list[dict[str, Any]]) -> dict[str, list[str]]:

--- a/src/op_system/_templates.py
+++ b/src/op_system/_templates.py
@@ -50,6 +50,19 @@ from op_system._errors import InvalidRhsSpecError
 _STATE_TEMPLATE_RE = re.compile(r"\s*([A-Za-z_][A-Za-z0-9_]*)\[(.+)\]\s*")
 # Matches any "Name[...]" token inside an expression string.
 _INLINE_TEMPLATE_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\[(.*?)\]")
+
+# Per-``template_map`` cache of pre-parsed, filtered, regex-compiled
+# template keys used by ``_apply_template_substitutions``. Built lazily
+# on first use and keyed by ``id(template_map)`` so batch substitution
+# over many cells against the same mapping pays the parse cost once
+# rather than per cell (issue #145).
+_APPLY_TPL_PREPARSE_CACHE: dict[
+    int,
+    tuple[
+        object,
+        tuple[tuple[str, str, tuple["WildcardToken", ...], "re.Pattern[str]"], ...],
+    ],
+] = {}
 # Matches any "[...]" fragment to extract placeholder names from rate exprs.
 _PLACEHOLDER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\[(.*?)\]")
 
@@ -444,20 +457,41 @@ def _apply_template_substitutions(
     expr_out = expr_s
     shaped = shaped_params or {}
 
-    # Explicit template keys from the template map. Skip any whose base
-    # collides with a registered shaped parameter — those are rewritten by
-    # the inline replacer below.
-    for template_key in template_map:
-        base, tokens = parse_selector(template_key)
-        if base in shaped:
+    # Pre-parse template keys once per ``template_map`` identity: we
+    # filter out keys with no wildcards and keys whose base collides
+    # with a shaped param, and precompile the literal regex used by
+    # ``re.sub`` below. This collapses O(cells * |template_map|)
+    # ``parse_selector`` calls to O(|template_map|) per normalize call
+    # (issue #145).
+    cache_entry = _APPLY_TPL_PREPARSE_CACHE.get(id(template_map))
+    if cache_entry is not None and cache_entry[0] is template_map:
+        prepared = cache_entry[1]
+    else:
+        prepared_list: list[
+            tuple[str, str, tuple[WildcardToken, ...], re.Pattern[str]]
+        ] = []
+        for template_key in template_map:
+            base, tokens = parse_selector(template_key)
+            if base in shaped:
+                continue
+            wildcards = tuple(t for t in tokens if isinstance(t, WildcardToken))
+            if not wildcards:
+                continue
+            prepared_list.append(
+                (template_key, base, wildcards, re.compile(re.escape(template_key)))
+            )
+        prepared = tuple(prepared_list)
+        _APPLY_TPL_PREPARSE_CACHE[id(template_map)] = (template_map, prepared)
+
+    for template_key, base, wildcards, pat in prepared:
+        if any(wt.axis not in assignment for wt in wildcards):
             continue
-        wildcards = [t for t in tokens if isinstance(t, WildcardToken)]
-        if not wildcards or any(wt.axis not in assignment for wt in wildcards):
+        if template_key not in expr_out:
             continue
         rendered = _render_template_name(
             base, [wt.axis for wt in wildcards], assignment
         )
-        expr_out = re.sub(re.escape(template_key), rendered, expr_out)
+        expr_out = pat.sub(rendered, expr_out)
 
     # Inline placeholder syntax without an explicit template map entry.
     def _inline_replacer(match: re.Match[str]) -> str:

--- a/src/op_system/_templates.py
+++ b/src/op_system/_templates.py
@@ -477,9 +477,12 @@ def _apply_template_substitutions(
             wildcards = tuple(t for t in tokens if isinstance(t, WildcardToken))
             if not wildcards:
                 continue
-            prepared_list.append(
-                (template_key, base, wildcards, re.compile(re.escape(template_key)))
-            )
+            prepared_list.append((
+                template_key,
+                base,
+                wildcards,
+                re.compile(re.escape(template_key)),
+            ))
         prepared = tuple(prepared_list)
         _APPLY_TPL_PREPARSE_CACHE[id(template_map)] = (template_map, prepared)
 

--- a/src/op_system/_templates.py
+++ b/src/op_system/_templates.py
@@ -114,6 +114,32 @@ def _sanitize_fragment(val: object) -> str:
 
 _SANITIZE_RE = re.compile(r"[^A-Za-z0-9_]")
 _SANITIZE_CACHE: dict[str, str] = {}
+# Cache for the full ``f"{axis}_{sanitize(coord)}"`` fragment used by
+# ``render_selector``. The hot loop renders the same (axis, coord) pair
+# millions of times during the per-cell transition build, so caching the
+# already-formatted fragment removes a function call, a cache lookup,
+# and an f-string format per render (issue #145).
+_TOKEN_FRAGMENT_CACHE: dict[tuple[str, str], str] = {}
+
+
+def _token_fragment(axis: str, coord: object) -> str:
+    """Return cached ``"{axis}_{sanitize(coord)}"`` for selector rendering.
+
+    Returns:
+        Identifier-safe ``axis_coord`` fragment.
+    """
+    s = coord if type(coord) is str else str(coord)
+    key = (axis, s)
+    cached = _TOKEN_FRAGMENT_CACHE.get(key)
+    if cached is not None:
+        return cached
+    sanitized = _SANITIZE_CACHE.get(s)
+    if sanitized is None:
+        sanitized = _SANITIZE_RE.sub("_", s)
+        _SANITIZE_CACHE[s] = sanitized
+    fragment = f"{axis}_{sanitized}"
+    _TOKEN_FRAGMENT_CACHE[key] = fragment
+    return fragment
 
 
 def build_axis_lookup(axes: list[dict[str, Any]]) -> dict[str, list[str]]:
@@ -251,7 +277,7 @@ def render_selector(
                     )
                     + "]"
                 )
-            parts.append(f"{tok.axis}_{_sanitize_fragment(assignment[tok.axis])}")
+            parts.append(_token_fragment(tok.axis, assignment[tok.axis]))
         else:  # PinnedToken
             if axis_lookup is not None:
                 if tok.axis not in axis_lookup:
@@ -267,7 +293,7 @@ def render_selector(
                             f"axis {tok.axis!r} coords"
                         )
                     )
-            parts.append(f"{tok.axis}_{_sanitize_fragment(tok.coord)}")
+            parts.append(_token_fragment(tok.axis, tok.coord))
 
     return base + "__" + "__".join(parts)
 

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -891,12 +891,31 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
 
     # Vectorize aliases (in declaration order — best-effort dependency order).
     alias_codes: list[tuple[str, CodeType, tuple[int, ...]]] = []
-    for buf in alias_buffers:
-        try:
-            if buf.axes:
-                tree = _rewrite_cell_to_vector(
-                    expr_ir=rhs.aliases_ir.get(buf.expanded_names[0]),
-                    expr_ir_reduce=rhs.aliases_ir_reduce.get(buf.expanded_names[0]),
+
+    def _build_alias_tree(buf: _BufferTemplate) -> ast.Expression | None:
+        """Rewrite an alias buffer into a single AST or ``None`` on mismatch.
+
+        Returns:
+            The rewritten AST for the buffer, or ``None`` when the
+            first/last cell trees disagree.
+        """
+        if buf.axes:
+            tree = _rewrite_cell_to_vector(
+                expr_ir=rhs.aliases_ir.get(buf.expanded_names[0]),
+                expr_ir_reduce=rhs.aliases_ir_reduce.get(buf.expanded_names[0]),
+                target_axes=buf.axes,
+                name_to_template=name_to_template,
+                axis_index=axis_index,
+                reducible_axes=reducible_axes,
+                axis_weights=axis_weights,
+                axis_coords=axis_coords,
+                axis_types=axis_types,
+                shaped_param_axes=shaped_param_axes,
+            )
+            if len(buf.expanded_names) > 1:
+                last_tree = _rewrite_cell_to_vector(
+                    expr_ir=rhs.aliases_ir.get(buf.expanded_names[-1]),
+                    expr_ir_reduce=rhs.aliases_ir_reduce.get(buf.expanded_names[-1]),
                     target_axes=buf.axes,
                     name_to_template=name_to_template,
                     axis_index=axis_index,
@@ -906,42 +925,32 @@ def _build_vector_plan_inner(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
                     axis_types=axis_types,
                     shaped_param_axes=shaped_param_axes,
                 )
-                if len(buf.expanded_names) > 1:
-                    last_tree = _rewrite_cell_to_vector(
-                        expr_ir=rhs.aliases_ir.get(buf.expanded_names[-1]),
-                        expr_ir_reduce=rhs.aliases_ir_reduce.get(
-                            buf.expanded_names[-1]
-                        ),
-                        target_axes=buf.axes,
-                        name_to_template=name_to_template,
-                        axis_index=axis_index,
-                        reducible_axes=reducible_axes,
-                        axis_weights=axis_weights,
-                        axis_coords=axis_coords,
-                        axis_types=axis_types,
-                        shaped_param_axes=shaped_param_axes,
-                    )
-                    if ast.dump(tree) != ast.dump(last_tree):
-                        _bail(
-                            f"alias {buf.base!r}: first/last cell trees differ"
-                            " after rewriting"
-                        )
-                        return None
-            else:
-                # Scalar alias: rewrite so referenced templated state cells
-                # become buffer-index accesses.
-                tree = _rewrite_cell_to_vector(
-                    expr_ir=rhs.aliases_ir.get(buf.expanded_names[0]),
-                    expr_ir_reduce=rhs.aliases_ir_reduce.get(buf.expanded_names[0]),
-                    target_axes=(),
-                    name_to_template=name_to_template,
-                    axis_index=axis_index,
-                    reducible_axes=reducible_axes,
-                    axis_weights=axis_weights,
-                    axis_coords=axis_coords,
-                    axis_types=axis_types,
-                    shaped_param_axes=shaped_param_axes,
+                if ast.dump(tree) != ast.dump(last_tree):
+                    return None
+            return tree
+        # Scalar alias: rewrite so referenced templated state cells
+        # become buffer-index accesses.
+        return _rewrite_cell_to_vector(
+            expr_ir=rhs.aliases_ir.get(buf.expanded_names[0]),
+            expr_ir_reduce=rhs.aliases_ir_reduce.get(buf.expanded_names[0]),
+            target_axes=(),
+            name_to_template=name_to_template,
+            axis_index=axis_index,
+            reducible_axes=reducible_axes,
+            axis_weights=axis_weights,
+            axis_coords=axis_coords,
+            axis_types=axis_types,
+            shaped_param_axes=shaped_param_axes,
+        )
+
+    for buf in alias_buffers:
+        try:
+            tree = _build_alias_tree(buf)
+            if tree is None:
+                _bail(
+                    f"alias {buf.base!r}: first/last cell trees differ after rewriting"
                 )
+                return None
             code = compile(tree, filename="<op_system_vec>", mode="eval")
         except (ValueError, RuntimeError, TypeError, SyntaxError) as exc:
             _bail(

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -302,12 +302,20 @@ def test_shaped_param_in_transitions_rate() -> None:
     out = normalize_rhs(spec)
     assert dict(out.shaped_params) == {"theta": ("imm",)}
     expanded = out.meta["transitions"]
+    # Alias-free template-uniform transitions emit a single shared
+    # template-form rate IR for every combo (issue #145). The per-cell
+    # ``from`` / ``to`` are still pinned, but the ``rate`` string is the
+    # template body with the shaped-param index left symbolic
+    # (``theta[imm]``); the vectorizer evaluates it at each cell's
+    # ``imm`` coord at runtime.
     rates = sorted(tr["rate"] for tr in expanded)
     assert rates == [
-        "theta[0] * I__imm_x0",
-        "theta[1] * I__imm_x1",
-        "theta[2] * I__imm_x2",
+        "theta[imm] * I[imm]",
+        "theta[imm] * I[imm]",
+        "theta[imm] * I[imm]",
     ]
+    froms = sorted(tr["from"] for tr in expanded)
+    assert froms == ["S__imm_x0", "S__imm_x1", "S__imm_x2"]
 
 
 def test_shaped_param_eval_end_to_end_scalar_backend() -> None:

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -1052,7 +1052,15 @@ def test_transitions_template_expansion_over_axes() -> None:
 
 
 def test_transitions_template_endpoint_pinning_expands_correctly() -> None:
-    """Endpoint pinning keeps pinned axis fixed while expanding other axes."""
+    """Endpoint pinning keeps pinned axis fixed while expanding other axes.
+
+    Synthesized transitions emit *template-uniform* IR for every cell of
+    the from/to templates (issue #145). The per-cell ``equations`` string
+    is therefore the same template body for every cell of the same
+    template, with template axis names (``[age, imm]``) rather than
+    cell-pinned coordinates. The vectorizer / compiler consume this
+    shared IR per template rather than per-cell.
+    """
     spec = {
         "kind": "transitions",
         "axes": [
@@ -1073,11 +1081,35 @@ def test_transitions_template_endpoint_pinning_expands_correctly() -> None:
 
     assert "X__age_u65__imm_X1" in out.state_names
     assert "X__age_o65__imm_X1" in out.state_names
-    assert any("-" in eq and "I__age_u65__imm_X0" in eq for eq in out.equations)
-    assert any(
-        "I__age_u65__imm_X0" in eq and "I__age_u65__imm_X1" in eq
-        for eq in out.equations
-    )
+
+    eqs = dict(zip(out.state_names, out.equations, strict=True))
+
+    # Every from-cell carries the template-form negative flow.
+    for cell in (
+        "I__age_u65__imm_X0",
+        "I__age_u65__imm_X1",
+        "I__age_o65__imm_X0",
+        "I__age_o65__imm_X1",
+    ):
+        assert "-" in eqs[cell]
+        assert "waning[imm]" in eqs[cell]
+        assert "I[age, imm]" in eqs[cell]
+
+    # Every to-cell carries the same template-form pointwise-expanded
+    # flow times the endpoint-pinned mask (``imm=X1``). The mask zeros
+    # the contribution for cells not on the pinned slab; the IR itself
+    # is shared. The Reduce over ``imm`` is pointwise-expanded into a
+    # sum over the imm coords (``waning__imm_X0 * I__imm_X0[age] + ...``).
+    for cell in (
+        "X__age_u65__imm_X0",
+        "X__age_u65__imm_X1",
+        "X__age_o65__imm_X0",
+        "X__age_o65__imm_X1",
+    ):
+        eq = eqs[cell]
+        assert "waning__imm_X0 * I__imm_X0[age]" in eq
+        assert "waning__imm_X1 * I__imm_X1[age]" in eq
+        assert "__op_system_mask__imm__" in eq
 
 
 def test_transitions_chain_helper_supports_templated_chain_names() -> None:


### PR DESCRIPTION
This pull request introduces several performance optimizations and correctness improvements to the IR parsing, unparsing, expansion, and alias inlining logic. The main changes focus on adding memoization to avoid redundant computation, improving the efficiency of common operations, and ensuring that IR object identity is leveraged for caching.

**Performance optimizations via memoization:**

* Added memoization to `parse_expr_to_ir` in `src/op_system/_ir.py` to cache parsed IR trees by input string and options, preventing redundant parsing work. [[1]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R439-R441) [[2]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R453-R464)
* Added optional memoization to `unparse_ir` and its helpers, allowing repeated rendering of shared IR subtrees to be cached and reused, which is especially beneficial when the same IR is rendered many times (e.g., in templates). [[1]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6L636-R684) [[2]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R744-R845)
* Introduced caches for `_split_name_suffix` and `_emit_suffix` in `src/op_system/_ir_expand.py` to avoid recomputing suffix parsing and emission for the same arguments. [[1]](diffhunk://#diff-25062aa0c5e9a062541974dda57b653efba7443731f13203d8fc923e68dc93f1R426-R444) [[2]](diffhunk://#diff-25062aa0c5e9a062541974dda57b653efba7443731f13203d8fc923e68dc93f1L457-R499)
* Added identity-keyed cache for alias body references in `inline_aliases` in `src/op_system/_ir_templates.py`, so repeated inlining against the same alias mapping is much faster. Also added a cache for fully inlined results. [[1]](diffhunk://#diff-b41bfad43521ade515b277c6ef147f3d30c84f577a6602ef41f828c6e6b72017R44-R52) [[2]](diffhunk://#diff-b41bfad43521ade515b277c6ef147f3d30c84f577a6602ef41f828c6e6b72017L348-R377) [[3]](diffhunk://#diff-b41bfad43521ade515b277c6ef147f3d30c84f577a6602ef41f828c6e6b72017R402-R406) [[4]](diffhunk://#diff-b41bfad43521ade515b277c6ef147f3d30c84f577a6602ef41f828c6e6b72017R417-R420) [[5]](diffhunk://#diff-b41bfad43521ade515b277c6ef147f3d30c84f577a6602ef41f828c6e6b72017R436-R461)

**Correctness and efficiency improvements:**

* Updated IR expansion and substitution logic to avoid recreating `Apply` or `Reduce` nodes when their children are unchanged, reducing unnecessary allocations and preserving object identity. [[1]](diffhunk://#diff-25062aa0c5e9a062541974dda57b653efba7443731f13203d8fc923e68dc93f1L105-R105) [[2]](diffhunk://#diff-25062aa0c5e9a062541974dda57b653efba7443731f13203d8fc923e68dc93f1L116-R117) [[3]](diffhunk://#diff-25062aa0c5e9a062541974dda57b653efba7443731f13203d8fc923e68dc93f1R126-R127) [[4]](diffhunk://#diff-25062aa0c5e9a062541974dda57b653efba7443731f13203d8fc923e68dc93f1L245-R247) [[5]](diffhunk://#diff-25062aa0c5e9a062541974dda57b653efba7443731f13203d8fc923e68dc93f1L258-R261) [[6]](diffhunk://#diff-25062aa0c5e9a062541974dda57b653efba7443731f13203d8fc923e68dc93f1R286-R287)
* Updated `_detect_alias_cycle` and its call sites to accept and use a shared free-symbols memo, ensuring that free-symbol computations are not repeated across related calls. [[1]](diffhunk://#diff-b41bfad43521ade515b277c6ef147f3d30c84f577a6602ef41f828c6e6b72017L311-R341) [[2]](diffhunk://#diff-1e17709f3010c4b5dfe0e8ef8f00f547282481295cfc68b691359fa21b6c675cL470-R470) [[3]](diffhunk://#diff-1e17709f3010c4b5dfe0e8ef8f00f547282481295cfc68b691359fa21b6c675cL511-R511)

These changes collectively improve the performance and scalability of IR operations, especially in workloads with many repeated or shared IR structures.