### PR TITLE
fix(ir_lower,provider): pinned-mask shape correctness; provider skips synth constants

### DIFF
--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -194,6 +194,12 @@ class OpSystemSystem(SystemABC, module="flepimop2.system.op_system"):  # noqa: D
         # Names provided by the compiled-RHS runtime environment, not by config
         # (numpy/jax namespace, simulation time, and built-in summation helpers).
         builtin_names = {"np", "t", "sum_state", "sum_prefix"}
+        # Normalize-time synthesized constants (e.g. one-hot masks for pinned
+        # transition selectors) are injected into ``params`` by ``compile_rhs``
+        # and must not be requested from configuration.
+        synth_const_names = set(
+            (self._compiled_rhs.meta.get("op_system_synth_constants") or {}).keys()
+        )
 
         # Non-time-varying shaped parameters first.  ``shaped_params`` in
         # meta carries reduced (non-time) axes for tv params, but tv names
@@ -203,6 +209,8 @@ class OpSystemSystem(SystemABC, module="flepimop2.system.op_system"):  # noqa: D
         time_varying_names = {name for name, _ in time_varying_meta}
         for shaped_name, shaped_axes in shaped_meta:
             if shaped_name in mixing_kernel_names or shaped_name in builtin_names:
+                continue
+            if shaped_name in synth_const_names:
                 continue
             if shaped_name in time_varying_names:
                 continue
@@ -221,7 +229,12 @@ class OpSystemSystem(SystemABC, module="flepimop2.system.op_system"):  # noqa: D
             requests[tv_name] = ParameterRequest(name=tv_name, axes=tuple(tv_axes))
 
         for name in self._compiled_rhs.param_names:
-            if name in mixing_kernel_names or name in builtin_names or name in requests:
+            if (
+                name in mixing_kernel_names
+                or name in builtin_names
+                or name in synth_const_names
+                or name in requests
+            ):
                 continue
             requests[name] = ParameterRequest(name=name)
         init_map = (self.options or {}).get("initial_state") or {}

--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -504,6 +504,34 @@ def test_requested_parameters_excludes_mixing_kernels() -> None:
     assert "contact" not in requested
 
 
+def test_requested_parameters_excludes_synth_mask_constants() -> None:
+    """Synth-constant masks (e.g. pinned-coord one-hot masks) are not config inputs.
+
+    ``compile_rhs`` injects values for any name listed in
+    ``meta['op_system_synth_constants']`` at eval time, so the provider must
+    not declare them in ``requested_parameters`` — otherwise the simulator
+    would error trying to resolve them from configuration.
+    """
+    spec: dict[str, object] = {
+        "kind": "transitions",
+        "axes": [{"name": "vax", "coords": ["u", "v"]}],
+        "state": ["S[vax]", "I[vax]"],
+        # A pinned-coord selector on the destination side triggers mask synthesis.
+        "transitions": [
+            {"from": "S[vax=u]", "to": "I[vax=u]", "rate": "beta"},
+        ],
+    }
+    sys = OpSystemSystem(spec=spec)
+    # Sanity: the compiled spec actually synthesized at least one mask.
+    synth = sys._compiled_rhs.meta.get("op_system_synth_constants") or {}  # type: ignore[attr-defined]  # noqa: SLF001
+    assert synth, "expected pinned-coord mask synthesis for this spec"
+    requested = set(sys.requested_parameters(AxisCollection()).keys())
+    for name in synth:
+        assert name not in requested, (
+            f"synth-injected constant {name!r} must not appear in requested_parameters"
+        )
+
+
 def test_model_state_is_empty_specification(sir_spec: dict[str, object]) -> None:
     """model_state returns an empty ModelStateSpecification (engine assembles state)."""
     sys = OpSystemSystem(spec=sir_spec)

--- a/src/op_system/_ir_lower.py
+++ b/src/op_system/_ir_lower.py
@@ -898,10 +898,37 @@ def _lower_reduce(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915
             elts=[ast.Constant(value=p) for p in reduce_positions],
             ctx=ast.Load(),
         )
-    return ast.Call(
+    # Use ``keepdims=True`` so any reduced axis that also appears in
+    # ``target_axes`` (e.g. ``sum_over(... vax=vax) * mask[vax]`` emitted
+    # by the pinned-token mask synthesis in ``_normalize``) stays as a
+    # size-1 broadcast slot rather than collapsing the rank below
+    # ``len(target_axes)``. Reduced axes that are *not* in ``target_axes``
+    # (purely-bound extras appended to ``extended_target``) are then
+    # squeezed back out so the result rank matches ``target_axes``
+    # exactly.
+    sum_call = ast.Call(
         func=ast.Attribute(value=_name("np"), attr="sum", ctx=ast.Load()),
         args=[body_ast],
-        keywords=[ast.keyword(arg="axis", value=axis_arg)],
+        keywords=[
+            ast.keyword(arg="axis", value=axis_arg),
+            ast.keyword(arg="keepdims", value=ast.Constant(value=True)),
+        ],
+    )
+    n_extra = len(extended_target) - len(target_axes)
+    if n_extra == 0:
+        return sum_call
+    squeeze_positions = tuple(range(len(target_axes), len(extended_target)))
+    if len(squeeze_positions) == 1:
+        squeeze_axis_arg: ast.expr = ast.Constant(value=squeeze_positions[0])
+    else:
+        squeeze_axis_arg = ast.Tuple(
+            elts=[ast.Constant(value=p) for p in squeeze_positions],
+            ctx=ast.Load(),
+        )
+    return ast.Call(
+        func=ast.Attribute(value=_name("np"), attr="squeeze", ctx=ast.Load()),
+        args=[sum_call],
+        keywords=[ast.keyword(arg="axis", value=squeeze_axis_arg)],
     )
 
 

--- a/tests/op_system/test_op_system_ir_lower.py
+++ b/tests/op_system/test_op_system_ir_lower.py
@@ -440,6 +440,71 @@ def test_lower_uniform_apply_along_unchanged_when_weights_absent() -> None:
     assert got == pytest.approx(6.0)
 
 
+def test_lower_reduce_keeps_target_axis_dim_for_outer_broadcast() -> None:
+    """Reduced axis that remains in ``target_axes`` is preserved as size 1.
+
+    Regression: the pinned-token mask synthesis in
+    :func:`op_system._normalize._synthesize_template_uniform` emits
+    ``sum_over(... * mask_from[vax], vax=vax) * mask_to[vax]`` whose
+    ``target_axes`` still include the reduced ``vax``. Without
+    ``keepdims=True`` on the lowered ``np.sum``, the result drops the
+    ``vax`` dim and broadcasting against the outer ``mask_to[vax]``
+    fails (rank mismatch). The lowerer must therefore keep reduced
+    target-axis dims as size-1 broadcast slots.
+    """
+    inner = Apply(
+        op="*",
+        args=(
+            Subscript(
+                name="X",
+                indices=(
+                    AxisIndex(axis="age", kind=AxisKind.FREE),
+                    AxisIndex(axis="vax", kind=AxisKind.FREE),
+                ),
+            ),
+            Subscript(
+                name="mask_from",
+                indices=(AxisIndex(axis="vax", kind=AxisKind.FREE),),
+            ),
+        ),
+    )
+    reduce_node = Reduce(kind="sum_over", bindings=(("vax", "vax"),), body=inner)
+    expr = Apply(
+        op="*",
+        args=(
+            reduce_node,
+            Subscript(
+                name="mask_to",
+                indices=(AxisIndex(axis="vax", kind=AxisKind.FREE),),
+            ),
+        ),
+    )
+    node = lower_to_vector_ast(
+        expr,
+        target_axes=("age", "vax"),
+        buffer_axes={"X": ("age", "vax"), "mask_from": ("vax",), "mask_to": ("vax",)},
+        axis_names=frozenset({"age", "vax"}),
+        reducible_axes=frozenset({"age", "vax"}),
+    )
+    x_buf = np.array([[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]])  # (age=3, vax=2)
+    mask_from_buf = np.array([1.0, 0.0])  # pin from-coord vax=0
+    mask_to_buf = np.array([0.0, 1.0])  # pin to-coord vax=1
+    got = _eval(
+        node,
+        {
+            "X_buf": x_buf,
+            "mask_from_buf": mask_from_buf,
+            "mask_to_buf": mask_to_buf,
+            "np": np,
+        },
+    )
+    # Per (age,): inner sum picks x_buf[:, 0]; outer scatter places it at vax=1.
+    expected = np.zeros_like(x_buf)
+    expected[:, 1] = x_buf[:, 0]
+    assert got.shape == expected.shape
+    assert np.array_equal(got, expected)
+
+
 def test_lower_apply_along_with_categorical_filter() -> None:
     """A categorical filter restricts the sum to the listed coords."""
     body = Subscript(


### PR DESCRIPTION
## Summary

Two related fixes uncovered while integrating op_system into flepimop2 via the COVID19_USA configs:

1. **`_ir_lower._lower_reduce`** — emit `np.sum(..., keepdims=True)` (and squeeze only the purely-bound extras appended to `extended_target`). Reduced axes that remain in `target_axes` now stay as size-1 broadcast slots instead of collapsing the rank below `len(target_axes)`.

   The pinned-token mask synthesis in `_normalize._synthesize_template_uniform` emits
   \`sum_over(... * mask_from[vax], vax=vax) * mask_to[vax]\`
   with \`target_axes\` still containing \`vax\`. Previously the inner sum dropped the \`vax\` dim, and the outer \`mask_to[vax]\` broadcast against the lower-rank result produced a runtime shape error (observed end-to-end on COVID19_USA SEIR-with-vax configs: \`(4, 51, 11)\` vs \`(1, 2, 1, 1)\`).

2. **\`flepimop2-op_system\` provider** — \`requested_parameters\` now filters out names listed in \`meta['op_system_synth_constants']\`. \`compile_rhs\` already \`setdefault\`s these synth-injected mask constants at eval time, so the provider must not declare them — otherwise the engine errors trying to resolve them from configuration.

## Tests

- New regression \`test_lower_reduce_keeps_target_axis_dim_for_outer_broadcast\` in \`tests/op_system/test_op_system_ir_lower.py\` covers the bug pattern at the lowering level.
- New \`test_requested_parameters_excludes_synth_constants\` in the provider test suite covers the requested-parameters filtering.
- \`just test\` (386 + 39 root/provider) green; \`just ruff\` and \`just mypy\` clean.
- End-to-end COVID19_USA \`config_SEIR_no_vax_alpha\` now evaluates the RHS to a finite vector.

## Notes

- No new public API.
- No change to the IR or the synth-mask machinery itself; just keeps the lowered shape consistent with \`target_axes\`.
- The keepdims+squeeze pair is shape-equivalent to the previous \`np.sum(..., axis=...)\` in the common case where no bound axis is in \`target_axes\`.