### PR TITLE
Perf/template primary ir

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,7 @@ jobs:
           persist-credentials: false
       - name: 'install just'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
       - name: 'setup uv'
         uses: 'astral-sh/setup-uv@v7'
         with:
@@ -43,8 +42,7 @@ jobs:
           persist-credentials: false
       - name: 'install just'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
       - name: 'setup uv'
         uses: 'astral-sh/setup-uv@v7'
         with:
@@ -65,8 +63,7 @@ jobs:
           persist-credentials: false
       - name: 'install just'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
       - name: 'setup uv'
         uses: 'astral-sh/setup-uv@v7'
         with:
@@ -97,8 +94,7 @@ jobs:
           persist-credentials: false
       - name: 'install just'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
       - name: 'setup uv with python ${{ matrix.python-version }}'
         uses: 'astral-sh/setup-uv@v7'
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,9 @@ jobs:
         with:
           persist-credentials: false
       - name: 'install just'
-        uses: 'extractions/setup-just@v3'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y just
       - name: 'setup uv'
         uses: 'astral-sh/setup-uv@v7'
         with:
@@ -40,7 +42,9 @@ jobs:
         with:
           persist-credentials: false
       - name: 'install just'
-        uses: 'extractions/setup-just@v3'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y just
       - name: 'setup uv'
         uses: 'astral-sh/setup-uv@v7'
         with:
@@ -60,7 +64,9 @@ jobs:
         with:
           persist-credentials: false
       - name: 'install just'
-        uses: 'extractions/setup-just@v3'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y just
       - name: 'setup uv'
         uses: 'astral-sh/setup-uv@v7'
         with:
@@ -90,7 +96,9 @@ jobs:
         with:
           persist-credentials: false
       - name: 'install just'
-        uses: 'extractions/setup-just@v3'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y just
       - name: 'setup uv with python ${{ matrix.python-version }}'
         uses: 'astral-sh/setup-uv@v7'
         with:

--- a/src/op_system/_ir_lower.py
+++ b/src/op_system/_ir_lower.py
@@ -898,14 +898,30 @@ def _lower_reduce(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915
             elts=[ast.Constant(value=p) for p in reduce_positions],
             ctx=ast.Load(),
         )
-    # Use ``keepdims=True`` so any reduced axis that also appears in
-    # ``target_axes`` (e.g. ``sum_over(... vax=vax) * mask[vax]`` emitted
-    # by the pinned-token mask synthesis in ``_normalize``) stays as a
-    # size-1 broadcast slot rather than collapsing the rank below
-    # ``len(target_axes)``. Reduced axes that are *not* in ``target_axes``
-    # (purely-bound extras appended to ``extended_target``) are then
-    # squeezed back out so the result rank matches ``target_axes``
-    # exactly.
+    # Fast path: when none of the bound axes also appear in
+    # ``target_axes``, every reduced dim is a trailing "extra" position
+    # that ``np.sum`` (``keepdims=False``) collapses for free, leaving a
+    # result whose rank already matches ``target_axes``. This is the
+    # common case (every ordinary ``apply_along``/``sum_over``) and
+    # avoids two extra reshape ops per reduction in the lowered XLA.
+    #
+    # Slow path (``keepdims=True`` + ``squeeze``) is reserved for the
+    # pinned-token mask synthesis emitted by ``_normalize``, where a
+    # reduced axis also appears in ``target_axes`` (e.g.
+    # ``sum_over(... * mask_from[vax], vax=vax) * mask_to[vax]``). In
+    # that case ``keepdims=True`` preserves the in-target reduced axis
+    # as a size-1 broadcast slot, and the trailing purely-bound
+    # "extras" are squeezed off so the result rank matches
+    # ``target_axes``.
+    n_extra = len(extended_target) - len(target_axes)
+    target_axis_collapsed = n_extra < len(bound_labels)
+    if not target_axis_collapsed:
+        sum_call = ast.Call(
+            func=ast.Attribute(value=_name("np"), attr="sum", ctx=ast.Load()),
+            args=[body_ast],
+            keywords=[ast.keyword(arg="axis", value=axis_arg)],
+        )
+        return sum_call
     sum_call = ast.Call(
         func=ast.Attribute(value=_name("np"), attr="sum", ctx=ast.Load()),
         args=[body_ast],
@@ -914,7 +930,6 @@ def _lower_reduce(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915
             ast.keyword(arg="keepdims", value=ast.Constant(value=True)),
         ],
     )
-    n_extra = len(extended_target) - len(target_axes)
     if n_extra == 0:
         return sum_call
     squeeze_positions = tuple(range(len(target_axes), len(extended_target)))

--- a/src/op_system/_ir_lower.py
+++ b/src/op_system/_ir_lower.py
@@ -916,12 +916,11 @@ def _lower_reduce(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915
     n_extra = len(extended_target) - len(target_axes)
     target_axis_collapsed = n_extra < len(bound_labels)
     if not target_axis_collapsed:
-        sum_call = ast.Call(
+        return ast.Call(
             func=ast.Attribute(value=_name("np"), attr="sum", ctx=ast.Load()),
             args=[body_ast],
             keywords=[ast.keyword(arg="axis", value=axis_arg)],
         )
-        return sum_call
     sum_call = ast.Call(
         func=ast.Attribute(value=_name("np"), attr="sum", ctx=ast.Load()),
         args=[body_ast],

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -871,8 +871,21 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
         inner_eval_fn = eval_fn
 
         def eval_fn(t: object, y: object, **params: object) -> Float64Array:
+            # Cast synth-mask values to ``y``'s namespace and dtype so they
+            # don't promote a float32 state buffer to float64 (or vice
+            # versa). Downstream shaped-param assembly does
+            # ``xp.asarray(bare)`` without a dtype, which would otherwise
+            # pick the namespace's default float and trigger
+            # incompatible-dtype scatter errors in JAX integrators.
+            xp = _namespace_of(y)
+            y_dtype = getattr(y, "dtype", None)
             for k, v in synth_const_values.items():
-                params.setdefault(k, v)
+                if k in params:
+                    continue
+                if y_dtype is not None:
+                    params[k] = xp.asarray(v, dtype=y_dtype)
+                else:
+                    params[k] = xp.asarray(v)
             return inner_eval_fn(t, y, **params)
 
     return CompiledRhs(

--- a/tests/op_system/test_jax_native.py
+++ b/tests/op_system/test_jax_native.py
@@ -234,21 +234,23 @@ def test_synth_mask_constants_match_y_dtype() -> None:
     assert compiled.meta["op_system_synth_constants"]
 
     prev_x64 = jax.config.read("jax_enable_x64")
-    jax.config.update("jax_enable_x64", True)
+    enable_x64 = True
+    jax.config.update("jax_enable_x64", enable_x64)
     try:
         # Float32 y0 with x64 ENABLED is the bug-surfacing case: the
         # default ``jnp.asarray((1.0, 0.0))`` would yield float64 and
         # promote the float32 state to float64 in the eval output.
-        y0 = jnp.asarray([0.9, 0.5, 0.05, 0.0], dtype=jnp.float32)
-        out = compiled.eval_fn(0.0, y0)
+        out = compiled.eval_fn(
+            0.0, jnp.asarray([0.9, 0.5, 0.05, 0.0], dtype=jnp.float32)
+        )
         assert out.dtype == jnp.float32, (
             f"eval output dtype {out.dtype} should match input dtype "
             "float32: synth-mask constants must not promote precision."
         )
-
         # And the float64 path still works.
-        y0_64 = jnp.asarray([0.9, 0.5, 0.05, 0.0], dtype=jnp.float64)
-        out_64 = compiled.eval_fn(0.0, y0_64)
+        out_64 = compiled.eval_fn(
+            0.0, jnp.asarray([0.9, 0.5, 0.05, 0.0], dtype=jnp.float64)
+        )
         assert out_64.dtype == jnp.float64
     finally:
         jax.config.update("jax_enable_x64", prev_x64)

--- a/tests/op_system/test_jax_native.py
+++ b/tests/op_system/test_jax_native.py
@@ -195,3 +195,60 @@ def test_vectorized_path_is_jax_native_too() -> None:
     out = jax.jit(lambda y: compiled.eval_fn(0.0, y, beta=1.0, gamma=0.2))(y0)
     assert out.__array_namespace__() is jnp
     assert out.shape == (6,)
+
+
+def test_synth_mask_constants_match_y_dtype() -> None:
+    """Synth-mask constants must be cast to ``y``'s dtype, not promoted.
+
+    Regression: pinned-coord transition selectors trigger
+    ``_discover_pinned_token_masks`` which stashes one-hot mask values
+    as ``tuple[float, ...]`` under ``meta["op_system_synth_constants"]``.
+    The compile-time auto-inject closure must cast those tuples to
+    ``y``'s dtype at call time so a float32 state buffer doesn't get
+    promoted to float64 — otherwise downstream diffrax integrators see
+    a scatter-dtype mismatch (float64 stage value into a float32
+    accumulator buffer).
+
+    The mixed-precision case (``jax_enable_x64=True`` + float32 ``y0``)
+    is exercised explicitly here because that is the configuration that
+    triggers the original failure in COVID19_USA's diffrax engine
+    plugin: the harness enables x64 (so the default ``jnp.asarray``
+    promotes Python-float tuples to float64), but the plugin keeps the
+    state vector in float32 for memory/throughput.
+    """
+    jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
+
+    spec: dict[str, object] = {
+        "kind": "transitions",
+        "axes": [{"name": "vax", "coords": ["v0", "v1"]}],
+        "state": ["S[vax]", "I[vax]"],
+        "transitions": [
+            # Pinned ``to`` selector triggers synth-mask creation.
+            {"from": "S[vax]", "to": "I[vax=v0]", "rate": "0.1"},
+        ],
+    }
+    compiled = compile_spec(spec)
+    # Compiled metadata advertises a synth-mask payload.
+    assert "op_system_synth_constants" in compiled.meta
+    assert compiled.meta["op_system_synth_constants"]
+
+    prev_x64 = jax.config.read("jax_enable_x64")
+    jax.config.update("jax_enable_x64", True)
+    try:
+        # Float32 y0 with x64 ENABLED is the bug-surfacing case: the
+        # default ``jnp.asarray((1.0, 0.0))`` would yield float64 and
+        # promote the float32 state to float64 in the eval output.
+        y0 = jnp.asarray([0.9, 0.5, 0.05, 0.0], dtype=jnp.float32)
+        out = compiled.eval_fn(0.0, y0)
+        assert out.dtype == jnp.float32, (
+            f"eval output dtype {out.dtype} should match input dtype "
+            "float32: synth-mask constants must not promote precision."
+        )
+
+        # And the float64 path still works.
+        y0_64 = jnp.asarray([0.9, 0.5, 0.05, 0.0], dtype=jnp.float64)
+        out_64 = compiled.eval_fn(0.0, y0_64)
+        assert out_64.dtype == jnp.float64
+    finally:
+        jax.config.update("jax_enable_x64", prev_x64)


### PR DESCRIPTION
This pull request addresses a regression related to type promotion of synthesized mask constants in JAX-based model compilation and evaluation. The main change ensures that synthesized mask constants are cast to match the dtype of the input state vector (`y`), preventing unintended promotion (e.g., from float32 to float64) which previously caused downstream errors in JAX integrators. It also refines the reduction logic in the IR lowering pass and adds a regression test to cover the fixed behavior.

**Bug fix: Synth-mask constants dtype handling**
* [`src/op_system/compile.py`](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R874-R888): Synthesized mask constants are now explicitly cast to the dtype and namespace of `y` during evaluation, preventing accidental dtype promotion and ensuring compatibility with JAX integrators.

**Testing: Regression coverage**
* [`tests/op_system/test_jax_native.py`](diffhunk://#diff-ea61aed839fb12afd8b39c9cbe36c6006ec75419ba9508b22559b69d3dee2efdR198-R256): Added a regression test to verify that synthesized mask constants match the dtype of `y`, including explicit coverage of the mixed-precision case (`jax_enable_x64=True` with float32 state vector).

**IR lowering: Reduction logic refinement**
* [`src/op_system/_ir_lower.py`](diffhunk://#diff-972bd1d88a010cec7d13f086705a2dd6f19f85bcbd8ce19cda35f08eb771f9e3L901-R923): Refactored the reduction logic to use a fast path when no reduced axes overlap with target axes, avoiding unnecessary reshape operations. The slow path (with `keepdims=True` and `squeeze`) is now used only when required by pinned-token mask synthesis. [[1]](diffhunk://#diff-972bd1d88a010cec7d13f086705a2dd6f19f85bcbd8ce19cda35f08eb771f9e3L901-R923) [[2]](diffhunk://#diff-972bd1d88a010cec7d13f086705a2dd6f19f85bcbd8ce19cda35f08eb771f9e3L917)