### PR TITLE
fix(ir_expand): resolve bare axis-label binding vars in apply_along

### DIFF
--- a/src/op_system/_ir_expand.py
+++ b/src/op_system/_ir_expand.py
@@ -185,6 +185,7 @@ def _expand_one_reduce(
         for ax_name, _var, filt in bindings
     ]
 
+    var_to_axis: dict[str, str] = {var: ax for ax, var, _ in bindings}
     terms: list[Expr] = []
     for combo in product(*axis_options):
         var_to_coord: dict[str, str] = {}
@@ -197,6 +198,7 @@ def _expand_one_reduce(
         replaced = _substitute_in_body(
             expr.body,
             var_to_coord=var_to_coord,
+            var_to_axis=var_to_axis,
             bound=bound,
             axis_order=axis_order,
             shaped_params=shaped_params,
@@ -219,6 +221,7 @@ def _substitute_in_body(  # noqa: PLR0911, PLR0913
     body: Expr,
     *,
     var_to_coord: Mapping[str, str],
+    var_to_axis: Mapping[str, str],
     bound: Mapping[str, str],
     axis_order: Sequence[str],
     shaped_params: Mapping[str, tuple[str, ...]],
@@ -248,6 +251,7 @@ def _substitute_in_body(  # noqa: PLR0911, PLR0913
             _substitute_in_body(
                 a,
                 var_to_coord=var_to_coord,
+                var_to_axis=var_to_axis,
                 bound=bound,
                 axis_order=axis_order,
                 shaped_params=shaped_params,
@@ -263,6 +267,7 @@ def _substitute_in_body(  # noqa: PLR0911, PLR0913
         return _rewrite_subscript(
             body,
             var_to_coord=var_to_coord,
+            var_to_axis=var_to_axis,
             bound=bound,
             axis_order=axis_order,
             shaped_params=shaped_params,
@@ -274,9 +279,13 @@ def _substitute_in_body(  # noqa: PLR0911, PLR0913
         outer_var_to_coord = {
             k: v for k, v in var_to_coord.items() if k not in inner_vars
         }
+        outer_var_to_axis = {
+            k: v for k, v in var_to_axis.items() if k not in inner_vars
+        }
         new_inner = _substitute_in_body(
             body.body,
             var_to_coord=outer_var_to_coord,
+            var_to_axis=outer_var_to_axis,
             bound=bound,
             axis_order=axis_order,
             shaped_params=shaped_params,
@@ -295,10 +304,11 @@ def _substitute_in_body(  # noqa: PLR0911, PLR0913
     return body  # pragma: no cover - exhaustive over Expr union
 
 
-def _rewrite_subscript(  # noqa: C901, PLR0912, PLR0913
+def _rewrite_subscript(  # noqa: C901, PLR0912, PLR0913, PLR0915
     sub: Subscript,
     *,
     var_to_coord: Mapping[str, str],
+    var_to_axis: Mapping[str, str],
     bound: Mapping[str, str],
     axis_order: Sequence[str],
     shaped_params: Mapping[str, tuple[str, ...]],
@@ -366,6 +376,11 @@ def _rewrite_subscript(  # noqa: C901, PLR0912, PLR0913
             c = bound[idx.axis]
             resolved_full.append((idx.axis, c))
             consumed.append((idx.axis, c))
+        elif idx.axis in var_to_axis:
+            real_axis = var_to_axis[idx.axis]
+            c = var_to_coord[idx.axis]
+            resolved_full.append((real_axis, c))
+            consumed.append((real_axis, c))
         else:
             resolved_full.append((idx.axis, None))
             remaining.append(idx)

--- a/src/op_system/_ir_lower.py
+++ b/src/op_system/_ir_lower.py
@@ -693,11 +693,14 @@ def _lower_reduce(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915
 
     Same-axis-twice (e.g. a shaped contact kernel ``K[age, age:ap]``
     inside ``apply_along(..., age=ap)`` whose target also carries
-    ``age``) is supported by relabeling the bound position to a
-    synthetic axis name ``f"{axis}#{binding}"``: the synthetic label is
-    appended to ``extended_target`` as a distinct broadcast position,
-    while ``axis_weights`` / ``axis_coords`` / ``axis_types`` lookups
-    continue to resolve via the original axis name.
+    ``age``) is supported by using the binding variable itself (``ap``)
+    as a synthetic axis label: the label is appended to
+    ``extended_target`` as a distinct broadcast position, while
+    ``axis_weights`` / ``axis_coords`` / ``axis_types`` lookups continue
+    to resolve via the original axis name.  Crucially, the binding
+    variable is also added to ``body_axis_names``, so bare ``I[ap, ...]``
+    subscripts — where the spec uses the variable as an axis label
+    rather than the ``coord=`` form — classify as FREE without rewriting.
 
     Returns:
         An ``ast.expr`` invoking ``np.sum`` on the (possibly
@@ -736,10 +739,11 @@ def _lower_reduce(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915
     # index and a coord=binding index (e.g. ``K[age, age:ap]`` where
     # ``age`` is the outer-free position and ``age:ap`` is the bound
     # inner position on a duplicate-axis shaped parameter). When
-    # synthesized, **every** Subscript index with ``coord=binding`` on
-    # the axis is relabeled to the synthetic label — the bound
-    # iteration's broadcast position is the synthetic slot, not the
-    # real axis position.
+    # synthesized, the binding variable itself (e.g. ``ap``) is used as
+    # the label — it is already unique within the scope and is added to
+    # ``body_axis_names`` so that bare ``I[ap, ...]`` subscripts (where
+    # the spec uses the binding variable as an axis label rather than
+    # the ``coord=`` syntax) also classify as FREE without any rewriting.
     bound_axes_seen: set[str] = set()
     binding_label: dict[str, str] = {}  # var -> label (synthetic or real)
     axis_relabel: dict[str, str] = {}  # real axis -> synthetic label
@@ -754,7 +758,7 @@ def _lower_reduce(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915
         needs_synthetic = _binding_collides_with_free_index(
             expr.body, axis=axis, binding_var=binding
         )
-        label = f"{axis}#{binding}" if needs_synthetic else axis
+        label = binding if needs_synthetic else axis
         if needs_synthetic:
             axis_relabel[axis] = label
         binding_label[binding] = label
@@ -1040,9 +1044,9 @@ def _rebind_subscript_indices(  # noqa: PLR0911
     FREE index is taken from ``axis_relabel.get(original_axis,
     original_axis)``. This is used by :func:`_lower_reduce` to give
     same-axis-twice bound positions a distinct synthetic axis label
-    (e.g. ``age#ap``) so the broadcast-by-label pipeline can
-    disambiguate the outer-free and inner-bound positions of a
-    duplicate-axis shaped param such as ``K[age, age:ap]``.
+    (the binding variable itself, e.g. ``ap``) so the broadcast-by-label
+    pipeline can disambiguate the outer-free and inner-bound positions of
+    a duplicate-axis shaped param such as ``K[age, age:ap]``.
 
     Returns:
         A new IR expression with matching Subscript indices rewritten to

--- a/tests/op_system/test_op_system_vectorize.py
+++ b/tests/op_system/test_op_system_vectorize.py
@@ -817,10 +817,10 @@ def _same_axis_twice_apply_along_spec() -> dict[str, object]:
     The S-equation contains ``apply_along(K[age, age:ap] * I[age:ap],
     age=ap)`` — a same-axis-twice contraction representing
     ``sum_{ap} K[age, ap] * I[ap]`` (an age-structured force-of-infection
-    matvec). Stage 1c lowers this via the IR fast path by synthesizing a
-    ``age#ap`` axis label for the bound iteration so ``K_buf``
-    broadcasts as ``(N_age, N_age#ap)`` while ``I_buf`` broadcasts as
-    ``(1, N_age#ap)``.
+    matvec). Stage 1c lowers this via the IR fast path by using the
+    binding variable ``ap`` itself as a synthetic axis label so ``K_buf``
+    broadcasts as ``(N_age, N_ap)`` while ``I_buf`` broadcasts as
+    ``(1, N_ap)``.
 
     Returns:
         A spec dict suitable for ``normalize_rhs``.
@@ -873,5 +873,74 @@ def test_same_axis_twice_apply_along_ir_fast_path() -> None:
 def test_same_axis_twice_apply_along_numerical_parity() -> None:
     """Same-axis-twice apply_along eval matches the scalar reference."""
     spec = _same_axis_twice_apply_along_spec()
+    k_mat = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+    _eval_equal(spec, beta=0.3, gamma=0.1, K=k_mat)
+
+
+def _same_axis_twice_bare_label_spec() -> dict[str, object]:
+    """Same-axis-twice spec using the binding variable as a bare axis label.
+
+    Identical semantics to :func:`_same_axis_twice_apply_along_spec` but
+    writes ``I[ap]`` (bare axis-label form) instead of ``I[age:ap]``
+    (coord form) inside the ``apply_along`` body.  This exercises the
+    branch added in issue #153: a ``Subscript`` index with ``coord=None``
+    whose ``axis`` is a binding variable must be treated as a FREE axis
+    reference once the binding variable is added to ``body_axis_names``.
+
+    Returns:
+        A spec dict suitable for ``normalize_rhs``.
+    """
+    return {
+        "kind": "expr",
+        "axes": [{"name": "age", "coords": ["a1", "a2", "a3"]}],
+        "state": ["S[age]", "I[age]", "R[age]"],
+        "params": [
+            "beta",
+            "gamma",
+            {"name": "K", "axes": ["age", "age"]},
+        ],
+        "equations": {
+            "S[age]": ("-beta * S[age] * apply_along(K[age, age:ap] * I[ap], age=ap)"),
+            "I[age]": (
+                "beta * S[age] * apply_along(K[age, age:ap] * I[ap], age=ap)"
+                " - gamma * I[age]"
+            ),
+            "R[age]": "gamma * I[age]",
+        },
+    }
+
+
+def test_same_axis_twice_bare_label_ir_fast_path() -> None:
+    """Bare-label ``I[ap]`` same-axis-twice contraction uses the IR fast path.
+
+    Regression for issue #153: when the spec uses the binding variable
+    as a bare axis label (``I[ap]``) rather than the ``coord=`` form
+    (``I[age:ap]``), the vectorizer must still succeed and must not fall
+    back to per-cell scalar expansion.
+    """
+    rhs = normalize_rhs(_same_axis_twice_bare_label_spec())
+    plan = build_vector_plan(rhs)
+    assert plan is not None, (
+        f"vectorizer fell back to scalar path; bail reason: "
+        f"{last_vector_plan_bail_reason()}"
+    )
+    s_group = next(g for g in plan.eq_groups if g.base == "S")
+    code = s_group.codes[0]
+    names = set(code.co_names)
+    assert not any("__" in n for n in names), (
+        f"per-cell names leaked into reduce-lowered code: "
+        f"{sorted(n for n in names if '__' in n)}"
+    )
+    assert "K_buf" in names, f"expected K_buf in {sorted(names)}"
+    assert "I_buf" in names, f"expected I_buf in {sorted(names)}"
+    assert "sum" in names, f"expected np.sum in {sorted(names)}"
+
+
+def test_same_axis_twice_bare_label_numerical_parity() -> None:
+    """Bare-label ``I[ap]`` same-axis-twice eval matches the scalar reference.
+
+    Regression for issue #153.
+    """
+    spec = _same_axis_twice_bare_label_spec()
     k_mat = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
     _eval_equal(spec, beta=0.3, gamma=0.1, K=k_mat)


### PR DESCRIPTION
This pull request improves the handling of "same-axis-twice" reductions in the vectorization pipeline, specifically when the binding variable is used as a bare axis label (e.g., `I[ap]`) rather than the `coord=` form (e.g., `I[age:ap]`). The changes ensure that such cases are correctly recognized and vectorized, addressing a regression (issue #153) where the vectorizer would incorrectly fall back to scalar expansion. The update also includes new tests to verify both the IR lowering path and numerical correctness for this pattern.

Key changes:

**Core logic changes:**

* Updated the IR expansion and substitution logic in `_expand_one_reduce`, `_substitute_in_body`, and `_rewrite_subscript` in `src/op_system/_ir_expand.py` to correctly track and substitute axis labels when the binding variable is used as an axis label, ensuring proper handling of same-axis-twice contractions with bare labels. [[1]](diffhunk://#diff-25062aa0c5e9a062541974dda57b653efba7443731f13203d8fc923e68dc93f1R188) [[2]](diffhunk://#diff-25062aa0c5e9a062541974dda57b653efba7443731f13203d8fc923e68dc93f1R201) [[3]](diffhunk://#diff-25062aa0c5e9a062541974dda57b653efba7443731f13203d8fc923e68dc93f1R224) [[4]](diffhunk://#diff-25062aa0c5e9a062541974dda57b653efba7443731f13203d8fc923e68dc93f1R254) [[5]](diffhunk://#diff-25062aa0c5e9a062541974dda57b653efba7443731f13203d8fc923e68dc93f1R270) [[6]](diffhunk://#diff-25062aa0c5e9a062541974dda57b653efba7443731f13203d8fc923e68dc93f1R282-R288) [[7]](diffhunk://#diff-25062aa0c5e9a062541974dda57b653efba7443731f13203d8fc923e68dc93f1L298-R311) [[8]](diffhunk://#diff-25062aa0c5e9a062541974dda57b653efba7443731f13203d8fc923e68dc93f1R379-R383)

* Changed the synthetic axis labeling convention in `src/op_system/_ir_lower.py` so that the binding variable itself (e.g., `ap`) is used as the synthetic axis label, rather than the previous `axis#binding` format. This ensures that both `I[ap]` and `I[age:ap]` are classified as FREE axes in the vectorizer. [[1]](diffhunk://#diff-972bd1d88a010cec7d13f086705a2dd6f19f85bcbd8ce19cda35f08eb771f9e3L696-R703) [[2]](diffhunk://#diff-972bd1d88a010cec7d13f086705a2dd6f19f85bcbd8ce19cda35f08eb771f9e3L739-R746) [[3]](diffhunk://#diff-972bd1d88a010cec7d13f086705a2dd6f19f85bcbd8ce19cda35f08eb771f9e3L757-R761) [[4]](diffhunk://#diff-972bd1d88a010cec7d13f086705a2dd6f19f85bcbd8ce19cda35f08eb771f9e3L1043-R1049)

**Testing and regression coverage:**

* Added new tests in `tests/op_system/test_op_system_vectorize.py` to cover the bare-label same-axis-twice contraction case, verifying both that the IR fast path is taken and that numerical results match the scalar reference.

* Updated existing test specs and comments to reflect the new synthetic axis labeling convention and clarify the expected broadcast shapes.

These changes ensure robust support for same-axis-twice reductions, whether the binding variable is used as a bare axis label or with the `coord=` syntax, and prevent regressions in the vectorization pipeline.

Closes #153