### PR TITLE
fix(ir_lower): vectorize bare binding label I[ap] without same-axis-twice (#152)

### DIFF
--- a/src/op_system/_ir_lower.py
+++ b/src/op_system/_ir_lower.py
@@ -995,21 +995,34 @@ def _weight_constant_for_axis(
 def _binding_collides_with_free_index(
     expr: Expr, *, axis: str, binding_var: str
 ) -> bool:
-    """Return ``True`` if Subscript has FREE + coord=var both on ``axis``.
+    """Return ``True`` if a synthetic axis label is needed for ``binding_var``.
 
-    This identifies the same-axis-twice case where the binding's coord
-    occupies one position of a duplicate-axis shaped param (e.g.
-    ``K[age, age:ap]``) while another position on the same axis is
-    free-broadcast. In that case :func:`_lower_reduce` must synthesize
-    a distinct axis label for the bound position so the broadcast
-    pipeline can carry the two slots as separate dimensions.
+    Two cases require the binding variable to become a synthetic axis label
+    in :func:`_lower_reduce`:
+
+    1. **Same-axis-twice**: a ``Subscript`` has both a FREE index and a
+       ``coord=binding_var`` index on the same ``axis`` (e.g.
+       ``K[age, age:ap]`` inside ``apply_along(..., age=ap)``).  The bound
+       position must be renamed so the broadcast pipeline can carry both
+       the outer-free and inner-bound slots as distinct dimensions.
+
+    2. **Bare binding label**: a ``Subscript`` uses ``binding_var`` itself
+       as a bare axis label (e.g. ``I[ap]``) rather than the ``coord=``
+       form.  This appears in low-rank factored specs such as
+       ``apply_along(H[rank, age:ap] * I[ap], age=ap)`` where there is no
+       same-axis-twice collision but the binding variable still needs to be
+       a recognized axis name in ``body_axis_names`` for the index to
+       classify as FREE.
     """
     if isinstance(expr, Subscript):
         has_free = any(idx.axis == axis and idx.coord is None for idx in expr.indices)
         has_bound = any(
             idx.axis == axis and idx.coord == binding_var for idx in expr.indices
         )
-        return has_free and has_bound
+        has_bare_binding = any(
+            idx.axis == binding_var and idx.coord is None for idx in expr.indices
+        )
+        return (has_free and has_bound) or has_bare_binding
     if isinstance(expr, Apply):
         return any(
             _binding_collides_with_free_index(a, axis=axis, binding_var=binding_var)

--- a/tests/op_system/test_op_system_vectorize.py
+++ b/tests/op_system/test_op_system_vectorize.py
@@ -944,3 +944,120 @@ def test_same_axis_twice_bare_label_numerical_parity() -> None:
     spec = _same_axis_twice_bare_label_spec()
     k_mat = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
     _eval_equal(spec, beta=0.3, gamma=0.1, K=k_mat)
+
+
+# ---------------------------------------------------------------------------
+# Low-rank factored kernel with bare binding label (issue #152)
+#
+# A separable contact kernel  K[age, ap] = sum_r F[r, age] * H[r, ap]  can
+# be expressed as nested ``apply_along`` with factor arrays F and H and a
+# non-state ``rank`` axis.  The inner apply_along body uses ``I[ap]`` (bare
+# binding-variable label) rather than ``I[age:ap]`` (coord form).  Without
+# the extension to ``_binding_collides_with_free_index``, the binding
+# variable ``ap`` never enters ``body_axis_names``, causing it to classify
+# as COORD_SYMBOL → ``UnsupportedIRLoweringError`` → scalar fallback.
+# ---------------------------------------------------------------------------
+
+
+def _low_rank_bare_label_spec() -> dict[str, object]:
+    """Low-rank factored SIR using bare-label ``I[ap]`` (no same-axis-twice).
+
+    The force-of-infection is ``sum_r F[r, age] * (sum_ap H[r, ap] * I[ap])``
+    — a rank-R approximation to a dense contact kernel.  The inner
+    ``apply_along`` uses the binding variable ``ap`` as a bare axis label on
+    ``I`` (rather than the ``coord=`` form ``I[age:ap]``), which is the
+    natural way to write a pure summation index.
+
+    Returns:
+        A spec dict suitable for ``normalize_rhs``.
+    """
+    return {
+        "kind": "expr",
+        "axes": [
+            {"name": "age", "coords": ["a1", "a2", "a3"]},
+            {"name": "rank", "coords": ["r1", "r2"]},
+        ],
+        "state": ["S[age]", "I[age]"],
+        "params": [
+            {"name": "F", "axes": ["rank", "age"]},
+            {"name": "H", "axes": ["rank", "age"]},
+            "beta",
+            "gamma",
+        ],
+        "equations": {
+            "S[age]": (
+                "-beta * S[age] * apply_along("
+                "F[rank, age]"
+                " * apply_along(H[rank, age:ap] * I[ap], age=ap, kernel=sum),"
+                " rank=c, kernel=sum)"
+            ),
+            "I[age]": (
+                "beta * S[age] * apply_along("
+                "F[rank, age]"
+                " * apply_along(H[rank, age:ap] * I[ap], age=ap, kernel=sum),"
+                " rank=c, kernel=sum)"
+                " - gamma * I[age]"
+            ),
+        },
+    }
+
+
+def test_low_rank_bare_label_ir_fast_path() -> None:
+    """Low-rank bare-label ``I[ap]`` nested apply_along uses the IR fast path.
+
+    Regression for issue #152: without the ``has_bare_binding`` extension to
+    ``_binding_collides_with_free_index``, the binding variable ``ap`` is
+    never added to ``body_axis_names`` in the no-same-axis-twice case, so
+    ``I[ap]`` classifies as COORD_SYMBOL and the vectorizer falls back to the
+    scalar path.  Post-fix the plan must be non-None and must not contain any
+    per-cell ``__`` names.
+    """
+    rhs = normalize_rhs(_low_rank_bare_label_spec())
+    plan = build_vector_plan(rhs)
+    assert plan is not None, (
+        f"vectorizer fell back to scalar path; bail reason: "
+        f"{last_vector_plan_bail_reason()}"
+    )
+    all_codes: list[CodeType] = [c for _, c in plan.cse_codes]
+    for grp in plan.eq_groups:
+        all_codes.extend(grp.codes)
+    all_names: set[str] = set()
+    for code in all_codes:
+        all_names.update(code.co_names)
+    assert not any("__" in n for n in all_names), (
+        f"per-cell names leaked into vectorized code: "
+        f"{sorted(n for n in all_names if '__' in n)}"
+    )
+    assert "F_buf" in all_names, f"expected F_buf in {sorted(all_names)}"
+    assert "H_buf" in all_names, f"expected H_buf in {sorted(all_names)}"
+    assert "I_buf" in all_names, f"expected I_buf in {sorted(all_names)}"
+    assert "sum" in all_names, f"expected np.sum in {sorted(all_names)}"
+
+
+def test_low_rank_bare_label_numerical_parity() -> None:
+    """Low-rank bare-label ``I[ap]`` vectorized output matches numpy reference.
+
+    The scalar-path eval cannot resolve ``F__rank_r1[age]``-style partial
+    expansions for non-state shaped axes, so the parity check is performed
+    against a direct numpy reference computation instead of ``_eval_equal``.
+    The reference collapses the low-rank factored kernel to a dense matrix
+    ``K[i, j] = sum_r F[r, i] * H[r, j]`` (i.e. ``F.T @ H``), then
+    evaluates the standard force-of-infection matvec.
+    """
+    rhs = normalize_rhs(_low_rank_bare_label_spec())
+    c = compile_rhs(rhs)
+    rng = np.random.RandomState(0)
+    y = rng.rand(len(rhs.state_names))
+    f_mat = np.array([[1.0, 2.0, 0.5], [0.3, 0.7, 1.2]])
+    h_mat = np.array([[0.6, 0.4, 0.8], [1.1, 0.9, 0.2]])
+    out = c.eval_fn(0.0, y, beta=0.3, gamma=0.1, F=f_mat, H=h_mat)
+    s_vec, i_vec = y[:3], y[3:]
+    k_dense = f_mat.T @ h_mat  # (n_age, n_age)
+    foi = k_dense @ i_vec
+    expected = np.concatenate([
+        -0.3 * s_vec * foi,
+        0.3 * s_vec * foi - 0.1 * i_vec,
+    ])
+    assert np.allclose(out, expected, atol=1e-12, rtol=0.0), (
+        f"max abs diff = {np.max(np.abs(out - expected))}"
+    )


### PR DESCRIPTION
## Summary

Extends `_binding_collides_with_free_index` to return `True` when any `Subscript` in an `apply_along` body uses the binding variable as a **bare axis label** (e.g. `I[ap]`) rather than the `coord=` form (`I[age:ap]`).

## Root cause

Previously `needs_synthetic` was only `True` for the same-axis-twice case (`K[age, age:ap]`). In the low-rank pattern `apply_along(H[rank, age:ap] * I[ap], age=ap)` there is no same-axis-twice collision, so `label = axis = 'age'` and `'ap'` was never added to `body_axis_names`. As a result `I[ap]` classified as `COORD_SYMBOL`, `lower_to_vector_ast` raised `UnsupportedIRLoweringError`, and the vectorizer fell back to the per-cell expanded-IR path. That path produces cell-specific integer-indexed trees (`F[0,0]`, `F[0,2]` etc.) which differ for first vs last cell, causing the `'no candidate unroll subset'` bail.

## Fix

Add a `has_bare_binding` check — when `idx.axis == binding_var` and `idx.coord is None`, also synthesize a label. With `needs_synthetic=True`:
- `label = binding` (`'ap'`)
- `axis_relabel = {'age': 'ap'}`
- `child_axis_alias = {'ap': 'age'}`
- `body_axis_names` includes `'ap'`

`I[ap]` then classifies as FREE, `H[rank, age:ap]` rewrites to `H[rank, ap]`, and `lower_subscript_to_buffer` resolves `'ap'` → `'age'` via `child_axis_alias`.

## Result

The low-rank factored kernel pattern from issue #152 now vectorizes via the IR fast path with **no N×N intermediate**:

```
apply_along(
    F[rank, age] * apply_along(H[rank, age:ap] * I[ap], age=ap, kernel=sum),
    rank=c, kernel=sum
)
```

For 63 age bins × rank-6: intermediates are at most `(6, 63)` = 378 elements vs the dense `(63, 63)` = 3969 — the targeted 92% memory reduction.

## Tests added

- `_low_rank_bare_label_spec()` — nested `apply_along` with `F[rank, age]`, `H[rank, age:ap]`, `I[ap]`, and a non-state `rank` axis
- `test_low_rank_bare_label_ir_fast_path` — plan non-None, no `__` per-cell names, `F_buf`/`H_buf`/`I_buf`/`sum` present
- `test_low_rank_bare_label_numerical_parity` — vectorized output matches dense equivalent `K = F.T @ H` reference

Closes #152