### PR TITLE
Feat/156 operator descriptor

### DIFF
--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 import functools
 import sys
 from collections.abc import Mapping
-from types import MappingProxyType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -61,6 +60,8 @@ if TYPE_CHECKING:
 
     from flepimop2.axis import AxisCollection
     from flepimop2.typing import Float64NDArray
+
+    from op_system._operators import OperatorDescriptor
 
 
 class _AxesMeta(NamedTuple):
@@ -274,31 +275,27 @@ class OpSystemSystem(SystemABC, module="flepimop2.system.op_system"):  # noqa: D
                 raise ValueError(msg)
         # Operator velocity/rate fields are consumed by engine plugins (not by
         # the compiled rhs eval_fn), but still need to be in the params dict.
-        for op in self._compiled_rhs.meta.get("operators") or ():
+        for op in self._compiled_rhs.operators:
             self._collect_operator_param_requests(op, requests)
         return requests
 
     @staticmethod
     def _collect_operator_param_requests(
-        op: object,
+        op: OperatorDescriptor,
         requests: dict[IdentifierString, ParameterRequest],
     ) -> None:
         """Add velocity/rate/kernel-param names referenced by `op` to `requests`."""
-        if not isinstance(op, Mapping):
-            return
-        for field in ("velocity", "rate"):
-            value = op.get(field)
+        for value in (op.velocity, op.rate):
             if (
-                isinstance(value, str)
+                value is not None
                 and value.isidentifier()
                 and value != "t"
                 and value not in requests
             ):
                 requests[value] = ParameterRequest(name=value)
-        kernel = op.get("kernel")
-        if not isinstance(kernel, Mapping):
+        if op.kernel is None:
             return
-        kernel_params = kernel.get("params")
+        kernel_params = op.kernel.get("params")
         if not isinstance(kernel_params, Mapping):
             return
         for value in kernel_params.values():
@@ -364,16 +361,13 @@ class OpSystemSystem(SystemABC, module="flepimop2.system.op_system"):  # noqa: D
     @staticmethod
     def _extract_operators(
         compiled: CompiledRhs,
-    ) -> tuple[MappingProxyType[str, Any], ...] | None:
-        """Extract operator metadata from compiled spec as immutable mappings.
+    ) -> tuple[OperatorDescriptor, ...]:
+        """Return the typed operator descriptors from the compiled spec.
 
         Returns:
-            Tuple of read-only operator dicts, or ``None`` if no operators.
+            Tuple of :class:`OperatorDescriptor` instances (empty if none declared).
         """
-        ops = compiled.meta.get("operators")
-        if not ops:
-            return None
-        return tuple(MappingProxyType(op) for op in ops)
+        return compiled.operators
 
     @staticmethod
     def _extract_operator_axis(compiled: CompiledRhs) -> str | None:
@@ -382,12 +376,11 @@ class OpSystemSystem(SystemABC, module="flepimop2.system.op_system"):  # noqa: D
         Returns:
             Shared axis name, or ``None`` if there are zero or multiple axes.
         """
-        ops = compiled.meta.get("operators")
-        if not ops:
+        if not compiled.operators:
             return None
-        axes = {op.get("axis") for op in ops}
+        axes = {op.axis for op in compiled.operators}
         if len(axes) == 1:
-            return str(next(iter(axes)))
+            return next(iter(axes))
         return None
 
     def _build_mixing_kernels(

--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -16,13 +16,12 @@
 
 """Tests for the flepimop2 op_system adapter System."""
 
-from types import MappingProxyType
-
 import numpy as np
 import pytest
 from flepimop2.axis import AxisCollection
 from flepimop2.parameter.abc import ModelStateSpecification, ParameterRequest
 from flepimop2.typing import SystemProtocol
+from op_system import OperatorDescriptor
 
 from flepimop2.system.op_system import OpSystemSystem
 
@@ -228,35 +227,36 @@ def multi_operator_spec() -> dict[str, object]:
 
 
 def test_option_operators_none_when_absent(sir_spec: dict[str, object]) -> None:
-    """A spec without operators returns None for the operators option."""
+    """A spec without operators returns an empty tuple for the operators option."""
     sys = OpSystemSystem(spec=sir_spec)
-    assert sys.option("operators", "missing") is None
+    assert sys.option("operators", "missing") == ()
 
 
 def test_option_operators_present(
     sir_with_operators_spec: dict[str, object],
 ) -> None:
-    """A spec with operators exposes them via the operators option."""
+    """A spec with operators exposes them as typed OperatorDescriptor instances."""
     sys = OpSystemSystem(spec=sir_with_operators_spec)
     ops = sys.option("operators", None)
     assert ops is not None
     assert len(ops) == 1
-    assert ops[0]["kind"] == "diffusion"
-    assert ops[0]["axis"] == "loc"
-    assert ops[0]["bc"] == "neumann"
+    assert isinstance(ops[0], OperatorDescriptor)
+    assert ops[0].axis == "loc"
+    assert ops[0].velocity is None
+    assert ops[0].rate is None
 
 
 def test_option_operators_returns_immutable(
     sir_with_operators_spec: dict[str, object],
 ) -> None:
-    """Operator dicts returned by option() are immutable MappingProxy objects."""
+    """Operators returned by option() are frozen OperatorDescriptor instances."""
     sys = OpSystemSystem(spec=sir_with_operators_spec)
     ops = sys.option("operators", None)
     assert ops is not None
     assert isinstance(ops, tuple)
-    assert isinstance(ops[0], MappingProxyType)
-    with pytest.raises(TypeError):
-        ops[0]["kind"] = "advection"  # type: ignore[index]
+    assert isinstance(ops[0], OperatorDescriptor)
+    with pytest.raises((TypeError, AttributeError)):
+        ops[0].axis = "other"  # type: ignore[misc]
 
 
 def test_option_operator_axis_single(
@@ -286,13 +286,13 @@ def test_option_operator_axis_none_when_mixed(
 def test_option_operators_multi_axis(
     multi_operator_spec: dict[str, object],
 ) -> None:
-    """Multi-operator spec surfaces both operators."""
+    """Multi-operator spec surfaces both operators as OperatorDescriptor instances."""
     sys = OpSystemSystem(spec=multi_operator_spec)
     ops = sys.option("operators", None)
     assert ops is not None
     assert len(ops) == 2
-    kinds = {op["kind"] for op in ops}
-    assert kinds == {"diffusion", "advection"}
+    axes = {op.axis for op in ops}
+    assert axes == {"loc", "age"}
 
 
 def test_option_operators_independent_of_mixing_kernels(

--- a/src/op_system/__init__.py
+++ b/src/op_system/__init__.py
@@ -12,6 +12,7 @@ Primary user entrypoints:
 Core data structures:
 - `NormalizedRhs`
 - `CompiledRhs`
+- `OperatorDescriptor`
 
 Design guarantees:
 - No dependency on provider/adapters (eg flepimop2).
@@ -26,6 +27,7 @@ from importlib.metadata import version
 from typing import Final, Literal
 
 from op_system._identifer_string import IdentifierString
+from op_system._operators import OperatorDescriptor
 from op_system._state_string import StateString
 from op_system._typing import Array
 
@@ -116,6 +118,7 @@ __all__ = [
     "ExpressionString",
     "IdentifierString",
     "NormalizedRhs",
+    "OperatorDescriptor",
     "StateString",
     "TransitionsRhs",
     "__version__",

--- a/src/op_system/_operators.py
+++ b/src/op_system/_operators.py
@@ -1,0 +1,44 @@
+"""op_system._operators — typed operator descriptor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorDescriptor:
+    """Typed description of a spatial operator declared in an op_system RHS spec.
+
+    Captures the model-level description of an operator that is known at
+    compile time: which axis it acts on, and the names of any runtime
+    parameters (velocity, rate) it consumes.  Grid geometry, CN matrix
+    construction, and solver staging remain downstream concerns handled by
+    the engine.
+
+    Attributes:
+        axis: Name of the axis the operator acts on (e.g. ``"loc"``).
+        velocity: Parameter name for an advection velocity, or ``None``.
+        rate: Parameter name for a diffusion rate/coefficient, or ``None``.
+        kernel: Mixing-kernel sub-specification, or ``None``.
+
+    Examples:
+        >>> od = OperatorDescriptor(axis="loc")
+        >>> od.axis
+        'loc'
+        >>> od.velocity is None
+        True
+        >>> od2 = OperatorDescriptor(axis="loc", velocity="v_advec", rate="diff_r")
+        >>> od2.velocity
+        'v_advec'
+        >>> od2.rate
+        'diff_r'
+    """
+
+    axis: str
+    velocity: str | None = None
+    rate: str | None = None
+    kernel: Mapping[str, Any] | None = None

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -41,6 +41,7 @@ from numpy.typing import NDArray
 from op_system._errors import InvalidExpressionError
 from op_system._ir import Expr, extract_common_subexpressions, ir_to_ast_expr
 from op_system._normalize import ExprRhs, TransitionsRhs
+from op_system._operators import OperatorDescriptor
 from op_system._symbols import parse_expression_string
 
 if TYPE_CHECKING:
@@ -218,6 +219,7 @@ class CompiledRhs:
     param_names: tuple[str, ...]
     eval_fn: EvalFn
     meta: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+    operators: tuple[OperatorDescriptor, ...] = field(default_factory=tuple)
     # Private: source spec retained for pickling. ``compile_rhs`` populates
     # this; direct constructions without ``_rhs`` are not picklable (the
     # ``eval_fn`` closure cannot be serialized) and will raise from
@@ -276,6 +278,7 @@ class CompiledRhs:
         object.__setattr__(self, "param_names", rebuilt.param_names)
         object.__setattr__(self, "eval_fn", rebuilt.eval_fn)
         object.__setattr__(self, "meta", rebuilt.meta)
+        object.__setattr__(self, "operators", rebuilt.operators)
         object.__setattr__(self, "_rhs", rhs)
 
 
@@ -799,6 +802,43 @@ def _wrap_eval_fn_for_time_varying(
     return wrapped
 
 
+def _parse_operator_descriptors(
+    meta: Mapping[str, Any],
+) -> tuple[OperatorDescriptor, ...]:
+    """Parse raw ``meta["operators"]`` into typed :class:`OperatorDescriptor` instances.
+
+    Returns:
+        Tuple of :class:`OperatorDescriptor` instances, empty if no operators.
+    """
+    ops = meta.get("operators")
+    if not ops:
+        return ()
+    result: list[OperatorDescriptor] = []
+    for op in ops:
+        if not isinstance(op, _MappingABC):
+            continue
+        axis_raw = op.get("axis")
+        if not isinstance(axis_raw, str) or not axis_raw:
+            continue
+        velocity_raw = op.get("velocity")
+        rate_raw = op.get("rate")
+        kernel_raw = op.get("kernel")
+        kernel = (
+            MappingProxyType(dict(kernel_raw))
+            if isinstance(kernel_raw, _MappingABC)
+            else None
+        )
+        result.append(
+            OperatorDescriptor(
+                axis=axis_raw,
+                velocity=velocity_raw if isinstance(velocity_raw, str) else None,
+                rate=rate_raw if isinstance(rate_raw, str) else None,
+                kernel=kernel,
+            )
+        )
+    return tuple(result)
+
+
 def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
     """Compile a normalized RHS into a runnable evaluation function.
 
@@ -893,5 +933,6 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
         param_names=tuple(rhs.param_names),
         eval_fn=eval_fn,
         meta=rhs.meta,
+        operators=_parse_operator_descriptors(rhs.meta),
         _rhs=rhs,
     )


### PR DESCRIPTION
This pull request introduces a new `OperatorDescriptor` dataclass to provide a typed, immutable representation of operator metadata in `op_system`. It updates the core system and tests to use this new type, ensuring operators are consistently exposed as strongly-typed objects rather than generic mappings. The changes also update the compilation pipeline to populate and surface these descriptors, improving type safety and clarity throughout the codebase.

**Core API and Type System Improvements:**
* Added the `OperatorDescriptor` dataclass in `src/op_system/_operators.py`, providing a frozen, typed representation of operator metadata, including axis, velocity, rate, and kernel information.
* Updated `src/op_system/compile.py` to parse and expose operators as `OperatorDescriptor` instances via the new `_parse_operator_descriptors` function and the `operators` attribute on `CompiledRhs`. [[1]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R44) [[2]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R222) [[3]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R281) [[4]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R805-R841) [[5]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R936)

**System Integration:**
* Refactored `flepimop2-op_system/src/flepimop2/system/op_system/__init__.py` to use `OperatorDescriptor` throughout, replacing previous usages of generic mappings. This includes operator extraction, parameter requests, and axis handling. [[1]](diffhunk://#diff-88aacd0c414c630ca19a4a7c70d9b02f3196123051eb784dab60d0e4f5219bbcR64-R65) [[2]](diffhunk://#diff-88aacd0c414c630ca19a4a7c70d9b02f3196123051eb784dab60d0e4f5219bbcL277-R298) [[3]](diffhunk://#diff-88aacd0c414c630ca19a4a7c70d9b02f3196123051eb784dab60d0e4f5219bbcL367-R370) [[4]](diffhunk://#diff-88aacd0c414c630ca19a4a7c70d9b02f3196123051eb784dab60d0e4f5219bbcL385-R383)

**Testing and Documentation:**
* Updated tests in `flepimop2-op_system/tests/test_system.py` to expect and validate `OperatorDescriptor` instances, ensuring immutability and correct attribute access. [[1]](diffhunk://#diff-d5e4ccdad1aa6db779c09df62a963453f8b9414a46e5642e54b2603f8552d2a1L19-R24) [[2]](diffhunk://#diff-d5e4ccdad1aa6db779c09df62a963453f8b9414a46e5642e54b2603f8552d2a1L231-R259) [[3]](diffhunk://#diff-d5e4ccdad1aa6db779c09df62a963453f8b9414a46e5642e54b2603f8552d2a1L289-R295)
* Updated documentation and `__all__` exports to include `OperatorDescriptor` in `src/op_system/__init__.py`. [[1]](diffhunk://#diff-2cf5cbdc728c64834ab5618986671e86ab9591ee37c08c34eaaa386cfdb415c4R15) [[2]](diffhunk://#diff-2cf5cbdc728c64834ab5618986671e86ab9591ee37c08c34eaaa386cfdb415c4R30) [[3]](diffhunk://#diff-2cf5cbdc728c64834ab5618986671e86ab9591ee37c08c34eaaa386cfdb415c4R121)