### PR TITLE
feat(slice-c): shape-polymorphic pytree_eval_fn + fix TV param_axis_pos

### DIFF
--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -127,6 +127,7 @@ class OpSystemSystem(SystemABC, module="flepimop2.system.op_system"):  # noqa: D
             "operators": operators,
             "operator_axis": operator_axis,
             "factorize_axes": compiled.factorize_axes,
+            "block_axes": compiled.block_axes,
             "template_shapes": compiled.template_shapes,
             "pytree_stepper_fn": None,  # updated below if pytree path available
         }

--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -21,7 +21,7 @@ import pytest
 from flepimop2.axis import AxisCollection
 from flepimop2.parameter.abc import ModelStateSpecification, ParameterRequest
 from flepimop2.typing import SystemProtocol
-from op_system import OperatorDescriptor
+from op_system import BlockAxisInfo, OperatorDescriptor
 
 from flepimop2.system.op_system import OpSystemSystem
 
@@ -724,3 +724,37 @@ def test_pytree_stepper_and_flat_stepper_agree() -> None:
     )
     pytree_flat = np.concatenate([pytree_result[b].reshape(-1) for b in shapes])
     np.testing.assert_allclose(pytree_flat, flat_result, rtol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# block_axes option (#164)
+# ---------------------------------------------------------------------------
+
+
+def test_option_block_axes_default_empty(sir_spec: dict[str, object]) -> None:
+    """block_axes is an empty tuple when no factorize_axes are declared."""
+    sys = OpSystemSystem(spec=sir_spec)
+    assert sys.option("block_axes", ()) == ()
+
+
+def test_option_block_axes_from_spec() -> None:
+    """block_axes contains one BlockAxisInfo entry per factorize_axes element."""
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "axes": [
+            {"name": "age", "coords": ["y", "o"]},
+            {"name": "loc", "coords": ["a", "b"]},
+        ],
+        "state": ["S[age, loc]"],
+        "equations": {"S[age, loc]": "-S[age, loc]"},
+        "factorize_axes": ["loc"],
+    }
+    sys = OpSystemSystem(spec=spec)
+    block_axes = sys.option("block_axes", ())
+    assert len(block_axes) == 1
+    (info,) = block_axes
+    assert isinstance(info, BlockAxisInfo)
+    assert info.name == "loc"
+    assert info.size == 2
+    assert "S" in info.state_axis_pos
+    assert info.state_axis_pos["S"] == 1  # loc is the second axis in S[age, loc]

--- a/src/op_system/_block_axes.py
+++ b/src/op_system/_block_axes.py
@@ -47,12 +47,16 @@ class BlockAxisInfo:
         state_axis_pos: Maps each state-template base name to the integer
             position of this axis within that template's shape tuple.
             Only templates that carry this axis appear in the dict.
-        param_axis_pos: Maps each *shaped* parameter name (including
-            time-varying ones, with the time axis already stripped) to
-            the integer position of this axis within the post-interpolation
-            parameter shape, or ``None`` if the parameter does not carry
-            this axis (broadcast).  Parameters that are entirely scalar
-            (not shaped) do not appear in this dict and are always broadcast.
+        param_axis_pos: Maps each *shaped* parameter name to the integer
+            position of this axis within the *actual runtime array* that the
+            engine passes to the eval function, or ``None`` if the parameter
+            does not carry this axis (broadcast).  For non-time-varying shaped
+            parameters the position is the index in the parameter's axis tuple.
+            For time-varying parameters the runtime array has time prepended at
+            index 0, so the position equals the index of the block axis in the
+            full ``(time, *spatial_axes)`` tuple.  Parameters that are entirely
+            scalar (not shaped) do not appear in this dict and are always
+            broadcast.
 
     Note:
         ``BlockAxisInfo`` uses ``dict`` fields and therefore cannot be used
@@ -83,6 +87,10 @@ class BlockAxisInfo:
     size: int
     state_axis_pos: dict[str, int]
     param_axis_pos: dict[str, int | None]
+    # Note: for time-varying parameters the position stored here is the
+    # index of the block axis in the *actual runtime array* (which has
+    # time prepended at index 0).  For non-time-varying shaped parameters
+    # the position is simply the index in the parameter's axis tuple.
 
 
 # ---------------------------------------------------------------------------
@@ -177,6 +185,42 @@ def _check_expr_separable(
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
+
+
+def _build_param_axis_pos(
+    rhs: NormalizedRhs,
+    axis_name: str,
+) -> dict[str, int | None]:
+    """Return the runtime array axis position for each shaped param.
+
+    For non-time-varying params the position equals the index in the
+    parameter's reduced axis tuple.  For time-varying params the engine
+    receives arrays with ``time`` prepended at index 0, so the position
+    is looked up in the full ``(time, *spatial_axes)`` tuple stored in
+    ``rhs.time_varying_params``.
+
+    Args:
+        rhs: Normalized RHS containing shaped and TV param metadata.
+        axis_name: Block axis whose position is being computed.
+
+    Returns:
+        Mapping from param name to the integer axis position in the
+        *actual* runtime array, or ``None`` if the param does not carry
+        this axis.
+    """
+    tv_full: dict[str, tuple[str, ...]] = dict(rhs.time_varying_params)
+    param_axis_pos: dict[str, int | None] = {}
+    for param_name, reduced_axes in rhs.shaped_params:
+        if param_name in tv_full:
+            full = tv_full[param_name]
+            param_axis_pos[param_name] = (
+                full.index(axis_name) if axis_name in full else None
+            )
+        else:
+            param_axis_pos[param_name] = (
+                reduced_axes.index(axis_name) if axis_name in reduced_axes else None
+            )
+    return param_axis_pos
 
 
 def analyze_block_axes(rhs: NormalizedRhs) -> tuple[BlockAxisInfo, ...]:
@@ -308,13 +352,7 @@ def analyze_block_axes(rhs: NormalizedRhs) -> tuple[BlockAxisInfo, ...]:
         }
 
         # --- param_axis_pos ------------------------------------------------------
-        # ``rhs.shaped_params`` uses the *reduced* axes (time axis already stripped
-        # for time-varying params), so positions here match the post-interpolation
-        # array shape that the engine actually passes to eval_fn.
-        param_axis_pos: dict[str, int | None] = {
-            param_name: (axes.index(axis_name) if axis_name in axes else None)
-            for param_name, axes in rhs.shaped_params
-        }
+        param_axis_pos = _build_param_axis_pos(rhs, axis_name)
 
         result.append(
             BlockAxisInfo(

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -1265,7 +1265,7 @@ def make_pytree_eval_fn(plan: _VectorPlan) -> PytreeEvalFn:  # noqa: C901, PLR09
                 except (NameError, ValueError, TypeError, ArithmeticError) as exc:
                     msg = f"equation {grp.base!r} evaluation failed: {exc!r}"
                     raise ValueError(msg) from exc
-                arr = xp.broadcast_to(xp.asarray(val), grp.vec_shape)
+                arr = xp.broadcast_to(xp.asarray(val), y[grp.base].shape)
                 bin_results.append(arr)
 
             if not grp.unroll_axes:

--- a/tests/op_system/test_block_axes.py
+++ b/tests/op_system/test_block_axes.py
@@ -299,6 +299,40 @@ def test_analyze_rejects_operator_on_block_axis() -> None:
         analyze_block_axes(rhs)
 
 
+def test_tv_param_axis_pos_uses_runtime_position() -> None:
+    """Time-varying param's block-axis position accounts for the time dimension.
+
+    A time-varying param ``beta[time, loc]`` has shape ``(n_time, n_loc)`` at
+    runtime (time prepended).  The block axis ``loc`` is therefore at index 1
+    in the actual array, not index 0 in the reduced axes.
+    """
+    spec: dict[str, object] = {
+        "kind": "transitions",
+        "state": ["S[age,loc]", "I[age,loc]", "R[age,loc]"],
+        "transitions": [
+            {
+                "from": "S[age,loc]",
+                "to": "I[age,loc]",
+                # beta is time-varying: declared with time axis
+                "rate": "beta[time, loc] * I[age,loc]",
+            },
+            {"from": "I[age,loc]", "to": "R[age,loc]", "rate": "gamma"},
+        ],
+        "axes": [
+            {"name": "time", "type": "categorical", "coords": ["t0", "t1"]},
+            {"name": "age", "type": "categorical", "coords": ["y", "o"]},
+            {"name": "loc", "type": "categorical", "coords": ["a", "b"]},
+        ],
+        "factorize_axes": ["loc"],
+    }
+    rhs = normalize_rhs(spec)
+    infos = analyze_block_axes(rhs)
+    assert len(infos) == 1
+    info = infos[0]
+    # beta[time, loc] → runtime shape (n_time, n_loc); loc is at index 1
+    assert info.param_axis_pos["beta"] == 1
+
+
 # ---------------------------------------------------------------------------
 # Axis position correctness
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #166. Depends on #165 (Slice B).

### Changes

#### `src/op_system/_vectorize.py`
- **Make `pytree_eval_fn` shape-polymorphic**: replace the hardcoded `grp.vec_shape` in `broadcast_to` with `y[grp.base].shape` so the function works correctly when called with sliced state arrays (e.g., a single block-axis slice from `jax.vmap`).  For full-shape inputs the behaviour is identical to before.

#### `src/op_system/_block_axes.py`
- **Fix `param_axis_pos` for time-varying params**: previously, the position was computed from the stripped (no-time) reduced axes, giving axis 0 for `beta[time, loc]` when it should be 1 (time is prepended at index 0 in the runtime array).  Fixed by looking up positions in `rhs.time_varying_params` which carries the full `(time, *spatial)` tuple.
- **Extract `_build_param_axis_pos`** helper so that `analyze_block_axes` stays within the McCabe complexity limit (≤ 10).

#### `tests/op_system/test_block_axes.py`
- Add `test_tv_param_axis_pos_uses_runtime_position`: spec with `beta[time, loc]`, asserts `info.param_axis_pos["beta"] == 1`.

### Testing
All 17 tests pass (16 existing + 1 new); full `just ci` green.