### PR TITLE
feat(#168): block-stripped RHS + block_pytree_eval_fn

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,8 +20,9 @@ jobs:
         with:
           persist-credentials: false
       - name: 'install just'
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
+        uses: 'taiki-e/install-action@v2'
+        with:
+          tool: 'just'
       - name: 'setup uv'
         uses: 'astral-sh/setup-uv@v7'
         with:
@@ -41,8 +42,9 @@ jobs:
         with:
           persist-credentials: false
       - name: 'install just'
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
+        uses: 'taiki-e/install-action@v2'
+        with:
+          tool: 'just'
       - name: 'setup uv'
         uses: 'astral-sh/setup-uv@v7'
         with:
@@ -62,8 +64,9 @@ jobs:
         with:
           persist-credentials: false
       - name: 'install just'
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
+        uses: 'taiki-e/install-action@v2'
+        with:
+          tool: 'just'
       - name: 'setup uv'
         uses: 'astral-sh/setup-uv@v7'
         with:
@@ -93,8 +96,9 @@ jobs:
         with:
           persist-credentials: false
       - name: 'install just'
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
+        uses: 'taiki-e/install-action@v2'
+        with:
+          tool: 'just'
       - name: 'setup uv with python ${{ matrix.python-version }}'
         uses: 'astral-sh/setup-uv@v7'
         with:

--- a/docs/development/issue-168-block-stripped-rhs-plan.md
+++ b/docs/development/issue-168-block-stripped-rhs-plan.md
@@ -1,0 +1,144 @@
+# Issue #168 — Block-stripped `pytree_eval_fn` for `factorize_axes` vmap
+
+**Repo**: ACCIDDA/op_system
+**Branch convention**: `feat/168-<slug>`
+**Filed**: 2026-05-28
+**Depends on**: PRs from #162 / #158 / #156 already merged on main.
+
+---
+
+## Problem
+
+`pytree_eval_fn` is rank-rigid. Its lowered body contains literal axis indices
+(`np.transpose(buf, (2, 0, 1))`, `np.sum(buf, axis=k)`, alias-buffer reshapes).
+When `diffrax_engine` wraps it in `jax.vmap(in_axes=<block_axis_pos>)`, vmap
+traces it on per-block slices where the block axis is missing → `axis k out of
+bounds for array of dimension k-1` from inside an alias body.
+
+`analyze_block_axes` already proves the block axis is separable, so stripping
+it is well-defined.
+
+## Decision
+
+Add a **second** compiled function `block_pytree_eval_fn` on `CompiledRhs` that
+operates on block-stripped state. Engine swaps to it under vmap. Stripping
+logic lives in op_system, not the engine.
+
+---
+
+## Slices (each ≤ ~500 LOC)
+
+### Slice 1 — `feat/168-strip-block-axis-ir`
+**Goal**: IR-level "strip a block axis" primitive + unit tests.
+
+- New `src/op_system/_normalize_block.py`:
+  - `strip_block_axis(rhs: ExprRhs | TransitionsRhs, axis_name: str) -> ExprRhs | TransitionsRhs`
+  - Walks `equations_ir`, `aliases_ir`, `state_templates`, `shaped_params`, `time_varying_params`.
+  - Deletes `axis_name` from every shape tuple; rebuilds `axis_order`.
+  - Strips coord-pinned subscripts on `axis_name` (`[loc:l]` → bare scalar slice).
+  - Drops `Reduce` nodes whose axis is `axis_name` (already proven absent by `analyze_block_axes`; assert).
+  - Refuses if `axis_name` is not in the spec axes.
+- Tests in `tests/op_system/test_block_axes.py`:
+  - `test_strip_block_axis_removes_axis_from_template_shapes`
+  - `test_strip_block_axis_removes_axis_from_alias_bodies`
+  - `test_strip_block_axis_strips_tv_param_axes`  (`beta[time, loc]` → `beta[time]`)
+  - `test_strip_block_axis_raises_on_unknown_axis`
+
+**Files**: `_normalize_block.py` (new), `tests/op_system/test_block_axes.py`
+**Dependencies**: none.
+**Budget**: ~250 LOC.
+
+---
+
+### Slice 2 — `feat/168-block-compile-pass`
+**Goal**: Wire stripping into `compile_rhs`; surface `block_pytree_eval_fn` + `block_template_shapes`.
+
+- `src/op_system/_vectorize.py`:
+  - After existing flat + pytree compile, if `compiled.block_axes` is non-empty AND `pytree_eval_fn is not None`:
+    1. `stripped = strip_block_axis(rhs, block_axes[0].name)`
+    2. Run `_lower_to_pytree_eval_fn(stripped, ...)` → `block_pytree_eval_fn`
+    3. Compute `block_template_shapes` from stripped `state_templates`.
+  - Attach both to `CompiledRhs` (new fields, default `None`).
+- `src/op_system/compile.py`:
+  - `@dataclass` add `block_pytree_eval_fn: PytreeEvalFn | None = None`
+  - `@dataclass` add `block_template_shapes: dict[str, tuple[int, ...]] | None = None`
+- `tests/op_system/test_block_axes.py`:
+  - `test_compile_emits_block_pytree_eval_fn_when_block_axes_nonempty`
+  - `test_block_pytree_eval_fn_matches_monolithic_at_each_block_coord`
+    - Compile SIR-like spec with `factorize_axes: [loc]`.
+    - Pick random `y_full` shape `(age, vax, loc)`.
+    - For each `i`: `vmap(block_eval, in_axes=loc_pos)(y_full)[base][i]` ≈
+      `pytree_eval_fn(y_full)[base][..., i, ...]` (within 1e-12).
+  - `test_compile_no_block_axes_leaves_block_fields_none`
+
+**Files**: `_vectorize.py`, `compile.py`, `tests/op_system/test_block_axes.py`
+**Dependencies**: Slice 1 merged.
+**Budget**: ~300 LOC.
+
+---
+
+### Slice 3 — `feat/168-engine-uses-block-fn`
+**Goal**: Switch `diffrax_engine` to use `block_pytree_eval_fn`; delete the engine-side stripping helper.
+
+This slice lands in **ACCIDDA/COVID19_USA**, not op_system.
+
+- `model_input/plugins/diffrax_engine.py`:
+  - In `_solve_one_block`: call `compiled.block_pytree_eval_fn` instead of `pytree_eval_fn`.
+  - In `_prepare_call`: when picking `block_axis`, also bind `block_template_shapes` for shape computations.
+  - Delete `_build_operator_terms_pytree_block` (its job is now done at compile time).
+- `tests/test_diffrax_engine.py`:
+  - Update existing 4 tests to assert the block path uses `block_pytree_eval_fn` (mock or attribute check).
+  - Add `test_block_path_runs_for_alias_with_reduce_over_non_block_axis` — the original failing config-style alias (`N_total[loc]: sum over (age, vax)`).
+- Also: surface `block_template_shapes` on the flepimop2 connector if needed (read of `stepper.option("block_template_shapes")`).
+
+**Files**: COVID19_USA `model_input/plugins/diffrax_engine.py`, `tests/test_diffrax_engine.py`
+**Dependencies**: Slice 2 released (op_system version bump).
+**Budget**: ~150 LOC of net deletes + ~80 LOC of new tests.
+
+---
+
+### Slice 4 — `feat/168-flepimop2-shim-block-fields`
+**Goal**: Surface new fields through `flepimop2-op_system` connector.
+
+- `flepimop2-op_system/src/flepimop2/system/op_system/__init__.py`:
+  - Add `"block_pytree_eval_fn"` and `"block_template_shapes"` to `self.options` (None when unused).
+- `flepimop2-op_system/tests/test_system.py`:
+  - Extend round-trip test for `factorize_axes: [loc]` to assert both new options are populated.
+
+**Files**: shim + tests.
+**Dependencies**: Slice 2 merged.
+**Budget**: ~50 LOC.
+Can be combined with Slice 2 if the connector is bumped at the same time.
+
+---
+
+## Work Order
+
+```
+1 (strip-block-axis-ir, op_system)
+  → 2 (block-compile-pass, op_system)
+    → 4 (flepimop2 shim)
+    → 3 (engine swap, COVID19_USA)        ← end-to-end gate
+```
+
+Slice 3 is the user-visible fix; everything before it is plumbing.
+
+## Acceptance gate (end of Slice 3)
+
+```bash
+cd /home/jcmacdo/Documents/GitHub/ACCIDDA/COVID19_USA
+PYTHONPATH=$PWD conda run -n dev --no-capture-output --cwd $PWD \
+  flepimop2 process configs/SMH_R19_op_system_hierarchical.yml -t prior_predictive
+```
+must complete and produce a non-empty `.nc` + `.pdf`.
+
+## Files to delete after all slices
+
+- COVID19_USA `model_input/plugins/diffrax_engine.py`: `_build_operator_terms_pytree_block` (~80 LOC).
+- The `_axis_dim` helper inside `_build_operator_terms_pytree` can be simplified to the per-base axis-position lookup already used elsewhere.
+
+## Open questions
+
+1. Multi-block-axis support — leave as out-of-scope for #168; add `factorize_axes: [a, b]` support in a follow-up if it lands as a real use case.
+2. Should `block_pytree_eval_fn` accept a `block_coord: int` arg (for debug) or stay vmap-shaped? Decision: stay vmap-shaped (cheaper; matches how engine calls it).
+3. Where do we put the assertion that `analyze_block_axes` approved the axis? Inside `strip_block_axis` — refuse silently-undefined stripping.

--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -129,7 +129,9 @@ class OpSystemSystem(SystemABC, module="flepimop2.system.op_system"):  # noqa: D
             "factorize_axes": compiled.factorize_axes,
             "block_axes": compiled.block_axes,
             "template_shapes": compiled.template_shapes,
+            "block_template_shapes": compiled.block_template_shapes,
             "pytree_stepper_fn": None,  # updated below if pytree path available
+            "block_pytree_stepper_fn": None,  # updated below if block path available
         }
 
         def _stepper(
@@ -170,6 +172,26 @@ class OpSystemSystem(SystemABC, module="flepimop2.system.op_system"):  # noqa: D
             self.options["pytree_stepper_fn"] = _stepper_pytree
         else:
             self._stepper_pytree = None
+
+        # Expose block PyTree stepper when block_pytree_eval_fn is available.
+        # The engine calls this function with a per-block-coord state dict
+        # (block axis removed) and vmaps it over the block axis.
+        if compiled.block_pytree_eval_fn is not None:
+            block_pytree_eval_fn = compiled.block_pytree_eval_fn
+
+            def _stepper_block_pytree(
+                time: np.float64,
+                state_dict: dict[str, Any],
+                **kwargs: Any,  # noqa: ANN401
+            ) -> dict[str, Any]:
+                params = dict(mixing_kernels)
+                params.update(kwargs)
+                return block_pytree_eval_fn(time, state_dict, **params)
+
+            self._stepper_block_pytree: Any = _stepper_block_pytree
+            self.options["block_pytree_stepper_fn"] = _stepper_block_pytree
+        else:
+            self._stepper_block_pytree = None
 
         self._compiled_rhs = compiled  # handy for debugging/adapters
 

--- a/src/op_system/_normalize_block.py
+++ b/src/op_system/_normalize_block.py
@@ -1,0 +1,357 @@
+"""op_system._normalize_block.
+
+Block-axis stripping: produce a :class:`~op_system._normalize.NormalizedRhs`
+with one block axis removed so the vectorizer can compile a per-block-coord
+eval function.
+
+The strategy is to keep the *original* expanded cell names (e.g.
+``S__age_y__loc_a``) in the stripped templates but with the block axis removed
+from the ``axes`` and ``shape`` tuples, and to include only the cells whose
+``coord_assignments[i][axis_name]`` equals the *first* coordinate of the block
+axis.  This lets :func:`~op_system._ir_lower.lift_cell_ir_to_template` map the
+original ``Sym`` leaves to their stripped templates without any renaming.
+
+Public API
+----------
+- :func:`strip_block_axis` - remove a single block axis from a
+  :class:`~op_system._normalize.NormalizedRhs`.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any
+
+from op_system._errors import UnsupportedFeatureError
+from op_system._ir import Apply, Literal, Reduce, Subscript, Sym
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from op_system._ir import Expr
+    from op_system._normalize import NormalizedRhs
+    from op_system._normalize_ir import StateTemplate
+
+
+def _strip_axis_from_ir(expr: Expr, axis_name: str) -> Expr:  # noqa: PLR0911
+    """Recursively remove *axis_name* from all Subscript index lists.
+
+    Transitions-kind specs lift state references to template-form
+    ``Subscript`` nodes during normalization.  After the block axis is
+    stripped from the templates, the ``Subscript`` nodes still carry that
+    axis in their ``indices`` tuple.  This function removes those
+    ``AxisIndex`` entries so the downstream vectorizer sees a consistent
+    picture: templates with ``(age,)`` axes and subscripts with only an
+    ``age`` index.
+
+    Args:
+        expr: IR expression to rewrite.
+        axis_name: Axis name to remove from all ``Subscript`` index lists.
+
+    Returns:
+        A new IR expression with the axis stripped; structurally equal to
+        ``expr`` when no stripping occurs.
+    """
+    if isinstance(expr, (Literal, Sym)):
+        return expr
+    if isinstance(expr, Subscript):
+        new_indices = tuple(idx for idx in expr.indices if idx.axis != axis_name)
+        if new_indices == expr.indices:
+            return expr
+        return Subscript(name=expr.name, indices=new_indices)
+    if isinstance(expr, Apply):
+        new_args = tuple(_strip_axis_from_ir(a, axis_name) for a in expr.args)
+        if new_args == expr.args:
+            return expr
+        return Apply(op=expr.op, args=new_args)
+    if isinstance(expr, Reduce):
+        new_body = _strip_axis_from_ir(expr.body, axis_name)
+        if new_body is expr.body:
+            return expr
+        return Reduce(
+            kind=expr.kind,
+            bindings=expr.bindings,
+            body=new_body,
+            filters=expr.filters,
+            kernel=expr.kernel,
+        )
+    return expr
+
+
+def _strip_template(
+    tpl: StateTemplate,
+    axis_name: str,
+    ref_coord: str,
+) -> StateTemplate:
+    """Return a copy of *tpl* with *axis_name* removed.
+
+    Only the cells whose ``coord_assignments[i][axis_name] == ref_coord``
+    are retained in the stripped template.  The original expanded cell
+    names are preserved verbatim so ``lift_cell_ir_to_template`` can
+    locate them by name.
+
+    Args:
+        tpl: Original :class:`~op_system._normalize_ir.StateTemplate`.
+        axis_name: Name of the axis to strip.
+        ref_coord: Coordinate value to keep (all cells with other values
+            along *axis_name* are dropped).
+
+    Returns:
+        A new :class:`~op_system._normalize_ir.StateTemplate` with
+        *axis_name* removed from ``axes``/``shape``/``coord_assignments``
+        and with ``expanded_names`` narrowed to the reference slice.
+    """
+    # Lazy import avoids circular dependency at module level.
+    from op_system._normalize_ir import StateTemplate  # noqa: PLC0415
+
+    if axis_name not in tpl.axes:
+        return tpl
+
+    axis_idx = tpl.axes.index(axis_name)
+    new_axes = tpl.axes[:axis_idx] + tpl.axes[axis_idx + 1 :]
+    new_shape = tpl.shape[:axis_idx] + tpl.shape[axis_idx + 1 :]
+
+    # Select cells matching ref_coord on axis_name.
+    keep_indices = [
+        i
+        for i, ca in enumerate(tpl.coord_assignments)
+        if ca.get(axis_name) == ref_coord
+    ]
+
+    new_names = tuple(tpl.expanded_names[i] for i in keep_indices)
+    new_coord_assignments: tuple[Mapping[str, str], ...] = tuple(
+        MappingProxyType({
+            k: v for k, v in tpl.coord_assignments[i].items() if k != axis_name
+        })
+        for i in keep_indices
+    )
+
+    return StateTemplate(
+        base=tpl.base,
+        axes=new_axes,
+        shape=new_shape,
+        expanded_names=new_names,
+        coord_assignments=new_coord_assignments,
+        offset=0,  # will be patched in _assign_offsets
+    )
+
+
+def _assign_offsets(templates: tuple[StateTemplate, ...]) -> tuple[StateTemplate, ...]:
+    """Return *templates* with corrected ``offset`` values.
+
+    Args:
+        templates: Tuple of :class:`~op_system._normalize_ir.StateTemplate`
+            instances (``offset`` values may be stale).
+
+    Returns:
+        A new tuple with each template's ``offset`` field set to the
+        cumulative count of expanded cells from previous templates.
+    """
+    out: list[StateTemplate] = []
+    cursor = 0
+    for tpl in templates:
+        out.append(dataclasses.replace(tpl, offset=cursor))
+        cursor += len(tpl.expanded_names)
+    return tuple(out)
+
+
+def strip_block_axis(rhs: NormalizedRhs, axis_name: str) -> NormalizedRhs:  # noqa: PLR0914
+    """Return a copy of *rhs* with *axis_name* removed.
+
+    The stripped :class:`~op_system._normalize.NormalizedRhs` covers only
+    the first coordinate of *axis_name*, keeping the original per-cell
+    names so the downstream vectorizer can compile a per-block-coord eval
+    function via :func:`~op_system._ir_lower.lift_cell_ir_to_template`.
+
+    Args:
+        rhs: Source :class:`~op_system._normalize.NormalizedRhs`.  Must
+            have ``factorize_axes`` in its ``meta`` and *axis_name* must
+            be listed there.
+        axis_name: Name of the axis to strip.  Must appear in
+            ``rhs.meta["factorize_axes"]``.
+
+    Returns:
+        A new :class:`~op_system._normalize.NormalizedRhs` with *axis_name*
+        removed from all templates, coordinate lists, shaped/TV param axes,
+        and ``meta`` entries.
+
+    Raises:
+        UnsupportedFeatureError: If *axis_name* is not listed in
+            ``rhs.meta["factorize_axes"]``.
+
+    Examples:
+        >>> from op_system.specs import normalize_rhs
+        >>> from op_system._normalize_block import strip_block_axis
+        >>> spec = {
+        ...     "kind": "transitions",
+        ...     "state": ["S[age,loc]", "I[age,loc]", "R[age,loc]"],
+        ...     "transitions": [
+        ...         {
+        ...             "from": "S[age,loc]",
+        ...             "to": "I[age,loc]",
+        ...             "rate": "beta * I[age,loc]",
+        ...         },
+        ...         {"from": "I[age,loc]", "to": "R[age,loc]", "rate": "gamma"},
+        ...     ],
+        ...     "axes": [
+        ...         {"name": "age", "type": "categorical", "coords": ["y", "o"]},
+        ...         {"name": "loc", "type": "categorical", "coords": ["a", "b"]},
+        ...     ],
+        ...     "factorize_axes": ["loc"],
+        ... }
+        >>> full = normalize_rhs(spec)
+        >>> stripped = strip_block_axis(full, "loc")
+        >>> [t.axes for t in stripped.state_templates]
+        [('age',), ('age',), ('age',)]
+        >>> len(stripped.state_names)
+        6
+    """
+    # ------------------------------------------------------------------
+    # 1. Validate axis_name is in factorize_axes
+    # ------------------------------------------------------------------
+    factorize_axes: list[str] = list(rhs.meta.get("factorize_axes") or [])
+    if axis_name not in factorize_axes:
+        raise UnsupportedFeatureError(
+            feature=f"strip_block_axis({axis_name!r})",
+            detail=(
+                f"Axis {axis_name!r} is not in rhs.meta['factorize_axes'] "
+                f"({factorize_axes!r}); cannot strip it."
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # 2. Determine the reference coordinate (first coord of axis_name)
+    # ------------------------------------------------------------------
+    axes_meta: tuple[Mapping[str, Any], ...] = tuple(rhs.meta.get("axes") or ())
+    ref_coord: str | None = None
+    for ax in axes_meta:
+        if ax.get("name") == axis_name:
+            coords = ax.get("coords")
+            if coords:
+                ref_coord = str(coords[0])
+            break
+    if ref_coord is None:
+        raise UnsupportedFeatureError(
+            feature=f"strip_block_axis({axis_name!r})",
+            detail=(
+                f"Axis {axis_name!r} not found in rhs.meta['axes'] or has no coords."
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # 3. Strip state templates and rebuild offsets
+    # ------------------------------------------------------------------
+    stripped_state_templates = _assign_offsets(
+        tuple(_strip_template(tpl, axis_name, ref_coord) for tpl in rhs.state_templates)
+    )
+    new_state_names: tuple[str, ...] = tuple(
+        name for tpl in stripped_state_templates for name in tpl.expanded_names
+    )
+
+    # ------------------------------------------------------------------
+    # 4. Compute which equation indices to keep (first-coord cells)
+    # ------------------------------------------------------------------
+    # The original state_names order is how equations are indexed.
+    # Build a set of cell names that are in the stripped templates.
+    keep_cells: frozenset[str] = frozenset(new_state_names)
+
+    # Build index into original rhs.state_names for the kept cells.
+    original_state_index: dict[str, int] = {
+        name: i for i, name in enumerate(rhs.state_names)
+    }
+    eq_keep_indices = [original_state_index[n] for n in new_state_names]
+
+    def _maybe_strip(ir: Expr | None) -> Expr | None:
+        return _strip_axis_from_ir(ir, axis_name) if ir is not None else None
+
+    new_equations = tuple(rhs.equations[i] for i in eq_keep_indices)
+    new_equations_ir = tuple(_maybe_strip(rhs.equations_ir[i]) for i in eq_keep_indices)
+    new_equations_ir_reduce = tuple(
+        _maybe_strip(rhs.equations_ir_reduce[i]) for i in eq_keep_indices
+    )
+
+    # ------------------------------------------------------------------
+    # 5. Strip alias templates and alias IR dicts
+    # ------------------------------------------------------------------
+    stripped_alias_templates = _assign_offsets(
+        tuple(_strip_template(tpl, axis_name, ref_coord) for tpl in rhs.alias_templates)
+    )
+
+    # Collect the alias cell names that are in the first-coord slice.
+    alias_keep_cells: frozenset[str] = frozenset(
+        name for tpl in stripped_alias_templates for name in tpl.expanded_names
+    )
+
+    new_aliases_ir: dict[str, Any] = {
+        k: _strip_axis_from_ir(v, axis_name)
+        for k, v in rhs.aliases_ir.items()
+        if k in alias_keep_cells
+    }
+    new_aliases_ir_reduce: dict[str, Any] = {
+        k: _strip_axis_from_ir(v, axis_name)
+        for k, v in rhs.aliases_ir_reduce.items()
+        if k in alias_keep_cells
+    }
+
+    # ------------------------------------------------------------------
+    # 6. Strip the string-form aliases dict
+    #    The keys of rhs.aliases are per-cell expanded names (e.g.
+    #    "I_total__loc_a"), same as aliases_ir.  Keep only first-coord.
+    # ------------------------------------------------------------------
+    new_aliases: dict[str, str] = {
+        k: v for k, v in rhs.aliases.items() if k in alias_keep_cells
+    }
+
+    # ------------------------------------------------------------------
+    # 7. Strip shaped_params and time_varying_params
+    # ------------------------------------------------------------------
+    new_shaped_params = tuple(
+        (name, tuple(ax for ax in axes if ax != axis_name))
+        for name, axes in rhs.shaped_params
+    )
+    new_time_varying_params = tuple(
+        (name, tuple(ax for ax in axes if ax != axis_name))
+        for name, axes in rhs.time_varying_params
+    )
+
+    # ------------------------------------------------------------------
+    # 8. Strip meta: remove axis_name from factorize_axes and axes list
+    # ------------------------------------------------------------------
+    meta: dict[str, Any] = dict(rhs.meta)
+    meta["factorize_axes"] = [a for a in factorize_axes if a != axis_name]
+    new_axes_meta = [ax for ax in axes_meta if ax.get("name") != axis_name]
+    meta["axes"] = new_axes_meta
+    # shaped_params entry in meta mirrors rhs.shaped_params
+    meta["shaped_params"] = new_shaped_params
+    meta["time_varying_params"] = new_time_varying_params
+
+    # ------------------------------------------------------------------
+    # 9. Reassemble param_names / all_symbols from stripped state/alias sets
+    # ------------------------------------------------------------------
+    # We keep the existing param_names / all_symbols: removing the block
+    # axis doesn't introduce or remove parameters — the stripped RHS still
+    # references the same parameter names as the original.
+    #
+    # However we need to ensure state cell names that were dropped are
+    # removed from all_symbols so the vectorizer doesn't try to map them.
+    dropped_state_cells = frozenset(rhs.state_names) - keep_cells
+    dropped_alias_cells = frozenset(rhs.aliases_ir.keys()) - alias_keep_cells
+    new_all_symbols = rhs.all_symbols - dropped_state_cells - dropped_alias_cells
+
+    return dataclasses.replace(
+        rhs,
+        state_names=new_state_names,
+        equations=new_equations,
+        aliases=new_aliases,
+        all_symbols=new_all_symbols,
+        meta=MappingProxyType(meta),
+        state_templates=stripped_state_templates,
+        shaped_params=new_shaped_params,
+        time_varying_params=new_time_varying_params,
+        aliases_ir=new_aliases_ir,
+        equations_ir=new_equations_ir,
+        aliases_ir_reduce=new_aliases_ir_reduce,
+        equations_ir_reduce=new_equations_ir_reduce,
+        alias_templates=stripped_alias_templates,
+    )

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -263,6 +263,21 @@ class CompiledRhs:
     template_shapes: dict[str, tuple[int, ...]] | None = field(
         default=None, repr=False, compare=False, hash=False
     )
+    # ``block_pytree_eval_fn`` is the PyTree eval fn compiled against the
+    # block-stripped RHS (with the first declared factorize_axis removed).
+    # Engines can vmap this over the block axis instead of calling the
+    # monolithic ``pytree_eval_fn`` with axis-indexed state slices.
+    # ``None`` when there are no factorize_axes or no pytree_eval_fn.
+    block_pytree_eval_fn: PytreeEvalFn | None = field(
+        default=None, repr=False, compare=False, hash=False
+    )
+    # ``block_template_shapes`` maps each state-template base name to its
+    # per-block shape (block axis removed).  Mirrors ``template_shapes`` but
+    # for the stripped compile.  ``None`` when ``block_pytree_eval_fn`` is
+    # ``None``.
+    block_template_shapes: dict[str, tuple[int, ...]] | None = field(
+        default=None, repr=False, compare=False, hash=False
+    )
     # Private: source spec retained for pickling. ``compile_rhs`` populates
     # this; direct constructions without ``_rhs`` are not picklable (the
     # ``eval_fn`` closure cannot be serialized) and will raise from
@@ -326,6 +341,8 @@ class CompiledRhs:
         object.__setattr__(self, "block_axes", rebuilt.block_axes)
         object.__setattr__(self, "pytree_eval_fn", rebuilt.pytree_eval_fn)
         object.__setattr__(self, "template_shapes", rebuilt.template_shapes)
+        object.__setattr__(self, "block_pytree_eval_fn", rebuilt.block_pytree_eval_fn)
+        object.__setattr__(self, "block_template_shapes", rebuilt.block_template_shapes)
         object.__setattr__(self, "_rhs", rhs)
 
 
@@ -1019,7 +1036,7 @@ def _wrap_pytree_eval_fn_for_synth_consts(
     return wrapped
 
 
-def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
+def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:  # noqa: C901, PLR0914
     """Compile a normalized RHS into a runnable evaluation function.
 
     Always uses the vectorized eval path that operates on shaped buffers
@@ -1156,6 +1173,40 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
                 pytree_eval_fn, synth_const_values
             )
 
+    block_axes = analyze_block_axes(rhs)
+
+    # ------------------------------------------------------------------
+    # Block-stripped compile: produce a per-block-coord pytree_eval_fn by
+    # stripping the first factorize axis from the RHS and re-running the
+    # vectorizer.  Engines can jax.vmap this over the block axis instead
+    # of baking literal axis indices that break under vmap.
+    # ------------------------------------------------------------------
+    block_pytree_eval_fn: PytreeEvalFn | None = None
+    block_template_shapes: dict[str, tuple[int, ...]] | None = None
+    if pytree_eval_fn is not None and block_axes:
+        from op_system._normalize_block import strip_block_axis  # noqa: PLC0415
+
+        stripped = strip_block_axis(rhs, block_axes[0].name)
+        stripped_plan = vec.build_vector_plan(stripped)
+        if stripped_plan is not None:
+            raw_block_fn: PytreeEvalFn = vec.make_pytree_eval_fn(stripped_plan)
+            block_template_shapes = {
+                tpl.base: tpl.shape for tpl in stripped_plan.state_templates
+            }
+            stripped_time_axis = str(stripped.meta.get("time_axis", "time"))
+            stripped_axes_meta = tuple(stripped.meta.get("axes") or ())
+            raw_block_fn = _wrap_pytree_eval_fn_for_time_varying(
+                raw_block_fn,
+                time_varying_params=stripped.time_varying_params,
+                time_axis_name=stripped_time_axis,
+                axes_meta=stripped_axes_meta,
+            )
+            if isinstance(synth_consts, _MappingABC) and synth_consts:
+                raw_block_fn = _wrap_pytree_eval_fn_for_synth_consts(
+                    raw_block_fn, dict(synth_consts)
+                )
+            block_pytree_eval_fn = raw_block_fn
+
     return CompiledRhs(
         state_names=rhs.state_names,
         param_names=tuple(rhs.param_names),
@@ -1163,8 +1214,10 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
         meta=rhs.meta,
         operators=_parse_operator_descriptors(rhs.meta),
         factorize_axes=_parse_factorize_axes(rhs.meta),
-        block_axes=analyze_block_axes(rhs),
+        block_axes=block_axes,
         pytree_eval_fn=pytree_eval_fn,
         template_shapes=template_shapes,
+        block_pytree_eval_fn=block_pytree_eval_fn,
+        block_template_shapes=block_template_shapes,
         _rhs=rhs,
     )

--- a/tests/op_system/test_block_axes.py
+++ b/tests/op_system/test_block_axes.py
@@ -388,3 +388,166 @@ def test_analyze_multiple_factorize_axes() -> None:
     vax_info = next(i for i in infos if i.name == "vax")
     assert loc_info.state_axis_pos["S"] == 1
     assert vax_info.state_axis_pos["S"] == 2
+
+
+# ---------------------------------------------------------------------------
+# strip_block_axis: unit tests
+# ---------------------------------------------------------------------------
+
+
+from op_system._normalize_block import strip_block_axis  # noqa: E402
+
+
+def test_strip_block_axis_removes_axis_from_template_shapes() -> None:
+    """strip_block_axis removes the block axis from all state template shapes."""
+    rhs = normalize_rhs(_sep_spec(factorize=["loc"]))
+    stripped = strip_block_axis(rhs, "loc")
+    # Each template should now have only age axis (size 2)
+    for tpl in stripped.state_templates:
+        assert "loc" not in tpl.axes
+        assert tpl.shape == (2,)
+    # Only first-loc cells remain: 3 states x 2 age coords = 6
+    assert len(stripped.state_names) == 6
+
+
+def test_strip_block_axis_state_names_use_ref_coord() -> None:
+    """Stripped state names correspond to the first loc coordinate ('a')."""
+    rhs = normalize_rhs(_sep_spec(factorize=["loc"]))
+    stripped = strip_block_axis(rhs, "loc")
+    # All expanded names should contain '__loc_a' (first coord)
+    for name in stripped.state_names:
+        assert "__loc_a" in name, f"Expected '__loc_a' in {name!r}"
+
+
+def test_strip_block_axis_equation_count_matches_state_names() -> None:
+    """Number of equations equals number of state names after stripping."""
+    rhs = normalize_rhs(_sep_spec(factorize=["loc"]))
+    stripped = strip_block_axis(rhs, "loc")
+    assert len(stripped.equations) == len(stripped.state_names)
+    assert len(stripped.equations_ir) == len(stripped.state_names)
+    assert len(stripped.equations_ir_reduce) == len(stripped.state_names)
+
+
+def test_strip_block_axis_strips_tv_param_axes() -> None:
+    """strip_block_axis removes the block axis from time_varying_params axes."""
+    spec: dict[str, object] = {
+        "kind": "transitions",
+        "state": ["S[age,loc]", "I[age,loc]", "R[age,loc]"],
+        "transitions": [
+            {
+                "from": "S[age,loc]",
+                "to": "I[age,loc]",
+                "rate": "beta[loc] * I[age,loc]",
+            },
+            {"from": "I[age,loc]", "to": "R[age,loc]", "rate": "gamma"},
+        ],
+        "axes": [
+            {"name": "age", "type": "categorical", "coords": ["y", "o"]},
+            {"name": "loc", "type": "categorical", "coords": ["a", "b", "c"]},
+            {"name": "time", "type": "categorical", "coords": ["0", "1"]},
+        ],
+        "factorize_axes": ["loc"],
+    }
+    rhs = normalize_rhs(spec)
+    stripped = strip_block_axis(rhs, "loc")
+    tv = dict(stripped.time_varying_params)
+    # beta was time_varying with (time, loc) axes; after strip should be (time,)
+    if "beta" in tv:
+        assert "loc" not in tv["beta"]
+
+
+def test_strip_block_axis_raises_on_unknown_axis() -> None:
+    """strip_block_axis raises UnsupportedFeatureError for non-factorize axis."""
+    rhs = normalize_rhs(_sep_spec(factorize=["loc"]))
+    with pytest.raises(UnsupportedFeatureError, match=r"not in rhs\.meta"):
+        strip_block_axis(rhs, "age")
+
+
+def test_strip_block_axis_raises_when_axis_not_in_factorize() -> None:
+    """strip_block_axis raises when factorize_axes is absent."""
+    rhs = normalize_rhs(_sep_spec())  # no factorize_axes
+    with pytest.raises(UnsupportedFeatureError):
+        strip_block_axis(rhs, "loc")
+
+
+def test_strip_block_axis_meta_no_longer_contains_axis() -> None:
+    """Stripped meta no longer lists the block axis in axes or factorize_axes."""
+    rhs = normalize_rhs(_sep_spec(factorize=["loc"]))
+    stripped = strip_block_axis(rhs, "loc")
+    axes_names = [ax["name"] for ax in (stripped.meta.get("axes") or [])]
+    assert "loc" not in axes_names
+    assert "loc" not in (stripped.meta.get("factorize_axes") or [])
+
+
+# ---------------------------------------------------------------------------
+# compile_rhs: block_pytree_eval_fn integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_compile_rhs_emits_block_pytree_eval_fn_when_block_axes_nonempty() -> None:
+    """compile_rhs sets block_pytree_eval_fn when factorize_axes is declared."""
+    rhs = normalize_rhs(_sep_spec(factorize=["loc"]))
+    compiled = compile_rhs(rhs)
+    assert compiled.block_pytree_eval_fn is not None
+    assert compiled.block_template_shapes is not None
+
+
+def test_compile_rhs_no_factorize_axes_leaves_block_fields_none() -> None:
+    """compile_rhs sets block_pytree_eval_fn=None when no factorize_axes."""
+    rhs = normalize_rhs(_sep_spec())
+    compiled = compile_rhs(rhs)
+    assert compiled.block_pytree_eval_fn is None
+    assert compiled.block_template_shapes is None
+
+
+def test_block_template_shapes_have_no_block_axis() -> None:
+    """block_template_shapes reflect the per-block shape (loc axis removed)."""
+    rhs = normalize_rhs(_sep_spec(factorize=["loc"]))
+    compiled = compile_rhs(rhs)
+    assert compiled.block_template_shapes is not None
+    assert compiled.template_shapes is not None
+    # Each template in block_template_shapes should have one fewer axis
+    for base, shape in compiled.block_template_shapes.items():
+        full_shape = compiled.template_shapes[base]
+        assert len(shape) == len(full_shape) - 1
+
+
+def test_block_pytree_eval_fn_is_callable() -> None:
+    """block_pytree_eval_fn accepts a per-block state dict and returns derivatives."""
+    import numpy as np  # noqa: PLC0415
+
+    rhs = normalize_rhs(_sep_spec(factorize=["loc"]))
+    compiled = compile_rhs(rhs)
+    assert compiled.block_pytree_eval_fn is not None
+    assert compiled.block_template_shapes is not None
+    # Build a per-block state dict with age axis only
+    y_block = {
+        base: np.ones(shape, dtype=np.float64)
+        for base, shape in compiled.block_template_shapes.items()
+    }
+    result = compiled.block_pytree_eval_fn(0.0, y_block, beta=0.3, gamma=0.1)
+    assert set(result.keys()) == set(y_block.keys())
+    for base, arr in result.items():
+        assert arr.shape == y_block[base].shape
+
+
+def test_block_pytree_eval_fn_pickle_round_trip() -> None:
+    """CompiledRhs with block_pytree_eval_fn survives a pickle round-trip."""
+    import numpy as np  # noqa: PLC0415
+
+    rhs = normalize_rhs(_sep_spec(factorize=["loc"]))
+    compiled = compile_rhs(rhs)
+    restored = pickle.loads(pickle.dumps(compiled))  # noqa: S301
+    assert restored.block_pytree_eval_fn is not None
+    assert restored.block_template_shapes == compiled.block_template_shapes
+    # Functional check
+    assert compiled.block_template_shapes is not None
+    assert compiled.block_pytree_eval_fn is not None
+    y_block = {
+        base: np.ones(shape, dtype=np.float64)
+        for base, shape in compiled.block_template_shapes.items()
+    }
+    r1 = compiled.block_pytree_eval_fn(0.0, y_block, beta=0.3, gamma=0.1)
+    r2 = restored.block_pytree_eval_fn(0.0, y_block, beta=0.3, gamma=0.1)
+    for base in r1:
+        np.testing.assert_array_equal(r1[base], r2[base])


### PR DESCRIPTION
This pull request introduces support for block-axis stripping in the `op_system` codebase, enabling efficient per-block evaluation for models using `factorize_axes`. The changes are implemented in a staged manner, adding a new IR-level primitive to strip block axes, updating the compilation pipeline to produce block-stripped evaluation functions and shapes, and exposing these new capabilities through the `flepimop2-op_system` connector. This allows downstream engines (such as `diffrax_engine`) to vmap a specialized function over the block axis, improving correctness and performance for block-structured models.

Key changes include:

**Block-axis stripping infrastructure:**
- Added `src/op_system/_normalize_block.py` with the `strip_block_axis` function, which removes a specified block axis from a normalized RHS, updating all relevant templates, equations, aliases, shaped parameters, and metadata. This enables the creation of per-block evaluation functions by reducing rank rigidity and ensuring only the relevant slice of the model is compiled and evaluated. [[1]](diffhunk://#diff-7ce88d9ba9450697bd71aa156449f5fc8872c982e984a4226356cd342fc73a0eR1-R357) [[2]](diffhunk://#diff-fcb1381555e7ed7e2e1b34f79d3720ef4eb1be2de4a7ace427d1478608353acbR1-R144)

**Compilation pipeline enhancements:**
- Updated `src/op_system/compile.py` to add new fields to the `CompiledRhs` dataclass: `block_pytree_eval_fn` (the block-stripped evaluation function) and `block_template_shapes` (shapes with the block axis removed). These are populated during compilation if `factorize_axes` are present and a PyTree evaluation function is available. Serialization logic is updated accordingly. [[1]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R266-R280) [[2]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R344-R345)
- The compilation process now optionally produces both the standard and block-stripped evaluation functions and shape metadata, supporting engines that need to vmap over block axes.

**Connector and API exposure:**
- In `flepimop2-op_system/src/flepimop2/system/op_system/__init__.py`, surfaced the new `block_template_shapes` and `block_pytree_stepper_fn` fields in the connector's `options` dictionary. Added logic to expose a callable `block_pytree_stepper_fn` when the block-stripped evaluation function is available, allowing downstream consumers to use the new block-aware evaluation path. [[1]](diffhunk://#diff-88aacd0c414c630ca19a4a7c70d9b02f3196123051eb784dab60d0e4f5219bbcR132-R134) [[2]](diffhunk://#diff-88aacd0c414c630ca19a4a7c70d9b02f3196123051eb784dab60d0e4f5219bbcR176-R195) [[3]](diffhunk://#diff-fcb1381555e7ed7e2e1b34f79d3720ef4eb1be2de4a7ace427d1478608353acbR1-R144)

These changes lay the groundwork for improved block-wise computation in downstream engines, address rank-rigidity issues, and provide a clear, tested interface for future extensions.

Most important changes:

**Block-axis stripping and IR updates**
- Added `strip_block_axis` and supporting helpers in `src/op_system/_normalize_block.py` to remove a single block axis from a normalized RHS, updating all relevant IR and metadata for per-block compilation.

**Compilation and serialization**
- Extended `CompiledRhs` in `src/op_system/compile.py` with `block_pytree_eval_fn` and `block_template_shapes` fields, and updated serialization/deserialization to support these new fields. [[1]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R266-R280) [[2]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R344-R345)
- Enhanced the compilation pipeline to optionally produce and attach block-stripped evaluation functions and shapes when `factorize_axes` are present.

**Connector/adapter exposure**
- Updated the `flepimop2-op_system` connector to surface `block_template_shapes` and provide a `block_pytree_stepper_fn` callable in the options dictionary, making block-stripped evaluation available to downstream consumers. [[1]](diffhunk://#diff-88aacd0c414c630ca19a4a7c70d9b02f3196123051eb784dab60d0e4f5219bbcR132-R134) [[2]](diffhunk://#diff-88aacd0c414c630ca19a4a7c70d9b02f3196123051eb784dab60d0e4f5219bbcR176-R195)

closes #168