### PR TITLE
Feat/171 null from transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,19 @@ spec:
     - {from: I, to: R, rate: gamma}
 ```
 
+Source-only tracking transitions are also supported (``from: null`` or omitted):
+
+```yaml
+spec:
+  kind: transitions
+  state: [I, H_cum]
+  transitions:
+    - {to: H_cum, rate: k * I}  # equivalent to {from: null, ...}
+```
+
+This pattern is useful for cumulative trackers (e.g., weekly admissions via
+``diff(H_cum)``) without introducing a dummy donor compartment.
+
 ### Templated states with `apply_along`
 
 ```yaml

--- a/docs/development/issue-168-block-stripped-rhs-plan.md
+++ b/docs/development/issue-168-block-stripped-rhs-plan.md
@@ -77,19 +77,20 @@ logic lives in op_system, not the engine.
 
 ---
 
-### Slice 3 — `feat/168-engine-uses-block-fn`
+### Slice 3 — `feat/168-engine-uses-block-fn` ✅ DONE
 **Goal**: Switch `diffrax_engine` to use `block_pytree_eval_fn`; delete the engine-side stripping helper.
 
 This slice lands in **ACCIDDA/COVID19_USA**, not op_system.
 
+**What was done**:
 - `model_input/plugins/diffrax_engine.py`:
-  - In `_solve_one_block`: call `compiled.block_pytree_eval_fn` instead of `pytree_eval_fn`.
-  - In `_prepare_call`: when picking `block_axis`, also bind `block_template_shapes` for shape computations.
-  - Delete `_build_operator_terms_pytree_block` (its job is now done at compile time).
+  - Merged `_build_operator_terms_pytree_block` into `_build_operator_terms_pytree` (added `block_axis_name: str | None = None` parameter); deleted the separate 80-LOC block function.
+  - Block path now reads `stepper.option("block_template_shapes")` (from Slice 4 shim) instead of computing shapes inline.
+  - Replaced `else pytree_stepper_fn` fallback with a `RuntimeError` assertion — `block_pytree_stepper_fn` must be set when entering the block path.
+  - Acceptance gate (`SMH_R19_op_system_hierarchical.yml -t prior_predictive`) passes: EXIT=0.
 - `tests/test_diffrax_engine.py`:
-  - Update existing 4 tests to assert the block path uses `block_pytree_eval_fn` (mock or attribute check).
-  - Add `test_block_path_runs_for_alias_with_reduce_over_non_block_axis` — the original failing config-style alias (`N_total[loc]: sum over (age, vax)`).
-- Also: surface `block_template_shapes` on the flepimop2 connector if needed (read of `stepper.option("block_template_shapes")`).
+  - `_MockStepper` now exposes `block_pytree_stepper_fn` and `block_template_shapes` from `compiled.*`.
+  - All 4 existing tests pass with the real `block_pytree_eval_fn` path (no fallback).
 
 **Files**: COVID19_USA `model_input/plugins/diffrax_engine.py`, `tests/test_diffrax_engine.py`
 **Dependencies**: Slice 2 released (op_system version bump).

--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -74,6 +74,21 @@ def test_invalid_spec_raises() -> None:
         OpSystemSystem(spec=bad_spec)
 
 
+def test_source_only_transition_system_step() -> None:
+    """System adapter supports source-only transitions (from omitted/null)."""
+    spec: dict[str, object] = {
+        "kind": "transitions",
+        "state": ["I", "H_cum"],
+        "transitions": [
+            {"to": "H_cum", "rate": "k * I"},
+        ],
+    }
+    sys = OpSystemSystem(spec=spec)
+    y0 = np.array([3.0, 10.0], dtype=np.float64)
+    out = sys.step(np.float64(0.0), y0, k=2.0)
+    np.testing.assert_allclose(out, np.array([0.0, 6.0], dtype=np.float64))
+
+
 def test_option_mixing_kernels_bare_spec(sir_spec: dict[str, object]) -> None:
     """A spec without kernels exposes an empty mixing_kernels option."""
     sys = OpSystemSystem(spec=sir_spec)

--- a/src/op_system/_normalize.py
+++ b/src/op_system/_normalize.py
@@ -854,17 +854,25 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
 
     old_limit = sys.getrecursionlimit()
     needed = max(old_limit, 10_000)
-    with _raise_recursion_limit(needed, old_limit):
+    with _raise_recursion_limit(needed, old_limit):  # noqa: PLR1702
         for tr_idx, tr_map in enumerate(transitions_raw):
             tr_valid = _validate_transition_mapping(dict(tr_map), idx=tr_idx)
-            frm_s = _get_required_str(tr_valid, idx=tr_idx, key="from")
             to_s = _get_required_str(tr_valid, idx=tr_idx, key="to")
             rate_s = _get_required_str(tr_valid, idx=tr_idx, key="rate")
             name_s = (
                 tr_valid.get("name") if isinstance(tr_valid.get("name"), str) else None
             )
 
-            frm_base, frm_tokens = parse_selector(frm_s)
+            # ``from: null`` (or omitted ``from``) is treated as a source-only
+            # transition: add ``+rate`` to ``to`` with no donor depletion.
+            frm_raw = tr_valid.get("from")
+            source_only = frm_raw is None
+            if source_only:
+                frm_base = ""
+                frm_tokens: list[Any] = []
+            else:
+                frm_s = _get_required_str(tr_valid, idx=tr_idx, key="from")
+                frm_base, frm_tokens = parse_selector(frm_s)
             to_base, to_tokens = parse_selector(to_s)
 
             # Collect wildcard axes
@@ -1081,7 +1089,7 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                 # Build per-axis-subset keys directly from the combo
                 # tuple without materializing an ``assignment`` dict.
                 from_key = tuple(combo[i] for i in from_key_idx)
-                from_name = from_name_memo.get(from_key)
+                from_name = None if source_only else from_name_memo.get(from_key)
                 to_key = tuple(combo[i] for i in to_key_idx)
                 to_name = to_name_memo.get(to_key)
                 # ``assignment`` is only required on memo misses or for
@@ -1089,7 +1097,7 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                 assignment: dict[str, str] | None = (
                     dict(zip(wildcard_axes, combo, strict=True)) if name_s else None
                 )
-                if from_name is None:
+                if not source_only and from_name is None:
                     assignment = assignment or dict(
                         zip(wildcard_axes, combo, strict=True)
                     )
@@ -1105,7 +1113,7 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                         to_base, to_tokens, assignment, axis_lookup=None
                     )
                     to_name_memo[to_key] = to_name
-                if from_name not in state_set:
+                if not source_only and from_name not in state_set:
                     raise InvalidRhsSpecError(
                         detail=f"transitions[{tr_idx}].from={from_name!r} not in state"
                     )
@@ -1144,17 +1152,34 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                 # from-template's wildcard axes, and the resulting
                 # ``flow_full`` / ``flow_reduce`` / negated forms are the
                 # SAME IR object for every combo of this transition.
+                flow_full: Expr
+                flow_reduce: Expr
+                neg_flow_full: Expr | None
+                neg_flow_reduce: Expr | None
                 if tpl_uniform:
-                    flow_full: Expr = tpl_flow_full  # type: ignore[assignment]
-                    flow_reduce: Expr = tpl_flow_reduce  # type: ignore[assignment]
-                    neg_flow_full: Expr = tpl_neg_flow_full  # type: ignore[assignment]
-                    neg_flow_reduce: Expr = tpl_neg_flow_reduce  # type: ignore[assignment]
+                    flow_full = tpl_flow_full  # type: ignore[assignment]
+                    flow_reduce = tpl_flow_reduce  # type: ignore[assignment]
+                    neg_flow_full = tpl_neg_flow_full
+                    neg_flow_reduce = tpl_neg_flow_reduce
                 else:
-                    from_sym = Sym(name=from_name)
-                    flow_full = Apply(op="*", args=(ir_rate_full, from_sym))
-                    flow_reduce = Apply(op="*", args=(ir_rate_reduce, from_sym))
-                    neg_flow_full = Apply(op="neg", args=(flow_full,))
-                    neg_flow_reduce = Apply(op="neg", args=(flow_reduce,))
+                    neg_flow_full = None
+                    neg_flow_reduce = None
+                    if source_only:
+                        flow_full = ir_rate_full
+                        flow_reduce = ir_rate_reduce
+                    else:
+                        if from_name is None:
+                            raise InvalidRhsSpecError(
+                                detail=(
+                                    "transition source is required when "
+                                    "building non-source-only flow"
+                                )
+                            )
+                        from_sym = Sym(name=from_name)
+                        flow_full = Apply(op="*", args=(ir_rate_full, from_sym))
+                        flow_reduce = Apply(op="*", args=(ir_rate_reduce, from_sym))
+                        neg_flow_full = Apply(op="neg", args=(flow_full,))
+                        neg_flow_reduce = Apply(op="neg", args=(flow_reduce,))
 
                 # Accumulate: from_state gets -flow, to_state gets +flow.
                 # When synthesizing template-uniform IR for this transition
@@ -1174,9 +1199,21 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                     # whose mask-multiplied contribution is 0.
                     pass
                 else:
-                    d_ir_full[from_name].append(neg_flow_full)
+                    if not source_only:
+                        if (
+                            from_name is None
+                            or neg_flow_full is None
+                            or neg_flow_reduce is None
+                        ):
+                            raise InvalidRhsSpecError(
+                                detail=(
+                                    "transition bookkeeping error while "
+                                    "building signed flow contributions"
+                                )
+                            )
+                        d_ir_full[from_name].append(neg_flow_full)
+                        d_ir_reduce[from_name].append(neg_flow_reduce)
                     d_ir_full[to_name].append(flow_full)
-                    d_ir_reduce[from_name].append(neg_flow_reduce)
                     d_ir_reduce[to_name].append(flow_reduce)
 
                 # Collect rate symbols (alias Syms kept unresolved). Skip
@@ -1202,7 +1239,7 @@ def _build_transition_equations_ir(  # noqa: C901, PLR0912, PLR0913, PLR0914, PL
                         rate_key, rate_str_memo, ir_rate_full
                     )
                 tr_out: dict[str, Any] = dict(tr_valid)
-                tr_out["from"] = from_name
+                tr_out["from"] = None if source_only else from_name
                 tr_out["to"] = to_name
                 tr_out["rate"] = rate_string
                 if name_s:

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -376,6 +376,42 @@ def test_transitions_rhs_compiles_and_evaluates() -> None:
     assert np.allclose(out, expected)
 
 
+def test_transitions_source_only_compiles_and_evaluates() -> None:
+    """Source-only transitions add to ``to`` without draining any donor."""
+    spec = {
+        "kind": "transitions",
+        "state": ["I", "H_cum"],
+        "transitions": [
+            {"from": None, "to": "H_cum", "rate": "k * I"},
+        ],
+    }
+    rhs = normalize_rhs(spec)
+    compiled = compile_rhs(rhs, xp=np)
+
+    y = np.array([4.0, 10.0], dtype=np.float64)
+    out = compiled.eval_fn(np.float64(0.0), y, k=2.5)
+    np.testing.assert_allclose(out, np.array([0.0, 10.0], dtype=np.float64))
+
+
+def test_transitions_source_only_templated_vectorized() -> None:
+    """Templated source-only transitions work in the vectorized compile path."""
+    spec = {
+        "kind": "transitions",
+        "axes": [{"name": "age", "coords": ["y", "o"]}],
+        "state": ["I[age]", "H_cum[age]"],
+        "transitions": [
+            {"to": "H_cum[age]", "rate": "k[age] * I[age]"},
+        ],
+    }
+    rhs = normalize_rhs(spec)
+    compiled = compile_rhs(rhs, xp=np)
+
+    y = np.array([2.0, 3.0, 100.0, 200.0], dtype=np.float64)
+    out = compiled.eval_fn(np.float64(0.0), y, k=np.array([1.0, 0.5]))
+    # dI/dt = 0; dH_cum/dt = k[age] * I[age]
+    np.testing.assert_allclose(out, np.array([0.0, 0.0, 2.0, 1.5], dtype=np.float64))
+
+
 # ---------------------------------------------------------------------------
 # Meta threading (#11)
 # ---------------------------------------------------------------------------

--- a/tests/op_system/test_op_system_specs.py
+++ b/tests/op_system/test_op_system_specs.py
@@ -136,6 +136,52 @@ def test_transitions_accepts_optional_name_and_preserves_meta() -> None:
     assert "name" not in transitions_meta[1]
 
 
+def test_transitions_support_source_only_null_from() -> None:
+    """`from: null` should add inflow to ``to`` without donor depletion."""
+    spec = {
+        "kind": "transitions",
+        "state": ["I", "H_cum"],
+        "transitions": [
+            {"from": None, "to": "H_cum", "rate": "k * I"},
+        ],
+    }
+
+    rhs = normalize_transitions_rhs(spec)
+    assert rhs.state_names == ("I", "H_cum")
+    assert rhs.param_names == ("k",)
+    transitions_meta = rhs.meta.get("transitions")
+    assert isinstance(transitions_meta, list)
+    assert transitions_meta[0]["from"] is None
+    assert transitions_meta[0]["to"] == "H_cum"
+
+    compiled = compile_rhs(rhs)
+    y = np.array([2.0, 5.0], dtype=np.float64)
+    dydt = compiled.eval_fn(0.0, y, k=3.0)
+    np.testing.assert_allclose(dydt, np.array([0.0, 6.0]))
+
+
+def test_transitions_support_source_only_omitted_from() -> None:
+    """Missing ``from`` should behave the same as ``from: null``."""
+    spec = {
+        "kind": "transitions",
+        "state": ["I", "H_cum"],
+        "transitions": [
+            {"to": "H_cum", "rate": "I"},
+        ],
+    }
+
+    rhs = normalize_transitions_rhs(spec)
+    transitions_meta = rhs.meta.get("transitions")
+    assert isinstance(transitions_meta, list)
+    assert transitions_meta[0]["from"] is None
+    assert transitions_meta[0]["to"] == "H_cum"
+
+    compiled = compile_rhs(rhs)
+    y = np.array([4.0, 1.0], dtype=np.float64)
+    dydt = compiled.eval_fn(0.0, y)
+    np.testing.assert_allclose(dydt, np.array([0.0, 4.0]))
+
+
 def test_transitions_rejects_nonstring_name() -> None:
     """Transition names must be non-empty strings when provided."""
     spec = {


### PR DESCRIPTION
This pull request adds support for "source-only" transitions in the op_system modeling framework, allowing transitions that only add to a target compartment without removing from any donor (i.e., `from: null` or omitted). This feature is useful for cumulative trackers and simplifies model specs that previously required dummy donor compartments. The implementation includes parser/compiler changes, documentation updates, and comprehensive tests to ensure correct behavior.

**Source-only transition support:**

* Updated the transition normalization logic in `_build_transition_equations_ir` to treat transitions with `from: null` or omitted as source-only, adding inflow to the target compartment without donor depletion. This includes correct handling in both scalar and templated/vectorized cases. [[1]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L857-R874) [[2]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L1084-R1100) [[3]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L1108-R1116) [[4]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531R1155-R1177) [[5]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531R1202-R1216) [[6]](diffhunk://#diff-8c5a8769ff2bd0743a3522815b0eee3becae401b4e92fe91aa7757687dff2531L1205-R1242)
* Updated the documentation in `README.md` to describe and provide examples of source-only transitions, clarifying their use and equivalence between `from: null` and omitted `from`.

**Testing:**

* Added new tests in `test_op_system_specs.py` and `test_op_system_compile.py` to verify that source-only transitions (both with explicit `from: null` and omitted `from`) compile and evaluate correctly, including vectorized/templated cases. [[1]](diffhunk://#diff-36e364ac2850dcbaf98a9d8947baec052b6fc82135b5733a3a53e387c1803fe0R139-R184) [[2]](diffhunk://#diff-2fa3a022376673b04af8548e35d18cc87f0eac0a1985cffed7de0b40cf955447R379-R414)
* Added a test in `test_system.py` to confirm that the system adapter supports source-only transitions.

These changes make it easier and more robust to define cumulative or inflow-only states in compartmental models.

Closes #171