### PR TITLE
Feat/173 delay history operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,9 @@ Expressions are parsed with `ast` and restricted to:
 
 Planned history helpers (`history(...)`, `delay(...)`, `convolve_history(...)`)
 are reserved for issue #173 and currently raise a targeted "not yet
-implemented" validation error.
+implemented" unsupported-feature error at compile time, including a
+`history_requirements=...` payload that specifies the required engine-side
+history buffer contract.
 
 Anything else — non-`np` attribute access, imports, lambdas, comprehensions,
 other AST nodes — raises `ValueError` / `TypeError` /

--- a/README.md
+++ b/README.md
@@ -245,6 +245,10 @@ Expressions are parsed with `ast` and restricted to:
 - Helpers: `sum_state()`, `sum_prefix(prefix)`, `apply_along(...)`,
   `sum_over(...)`.
 
+Planned history helpers (`history(...)`, `delay(...)`, `convolve_history(...)`)
+are reserved for issue #173 and currently raise a targeted "not yet
+implemented" validation error.
+
 Anything else — non-`np` attribute access, imports, lambdas, comprehensions,
 other AST nodes — raises `ValueError` / `TypeError` /
 `UnsupportedFeatureError` at normalize time.

--- a/README.md
+++ b/README.md
@@ -249,7 +249,9 @@ Planned history helpers (`history(...)`, `delay(...)`, `convolve_history(...)`)
 are reserved for issue #173 and currently raise a targeted "not yet
 implemented" unsupported-feature error at compile time, including a
 `history_requirements=...` payload that specifies the required engine-side
-history buffer contract.
+history buffer contract. Each requirement record currently includes:
+`scope`, `kind`, `signal_expr`, `options`, `required_options`,
+`missing_required_options`, and `unknown_options`.
 
 Anything else — non-`np` attribute access, imports, lambdas, comprehensions,
 other AST nodes — raises `ValueError` / `TypeError` /

--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -94,12 +94,32 @@ class Reduce:
     kernel: str | None = None
 
 
-Expr = Literal | Sym | Subscript | Apply | Reduce
+@dataclass(frozen=True, slots=True)
+class HistoryOp:
+    """History-aware helper placeholder (issue #173 scaffolding).
+
+    ``kind`` is one of ``history`` / ``delay`` / ``convolve_history``.
+    ``body`` holds the signal expression to query over history and
+    ``options`` stores helper keyword arguments as ``(name, Expr)`` pairs.
+    """
+
+    kind: str
+    body: Expr
+    options: tuple[tuple[str, Expr], ...] = ()
+
+
+Expr = Literal | Sym | Subscript | Apply | Reduce | HistoryOp
 
 _HELPER_REDUCE_OPS: frozenset[str] = frozenset({
     "apply_along",
     "sum_over",
     "integrate_over",
+})
+
+_HELPER_HISTORY_OPS: frozenset[str] = frozenset({
+    "history",
+    "delay",
+    "convolve_history",
 })
 
 
@@ -190,7 +210,7 @@ def _extract_filter_from_value(value: Expr) -> tuple[str, tuple[str, ...]] | Non
 
 
 def _lower_single_helper(node: Apply) -> Expr:  # noqa: C901, PLR0912
-    if node.op not in _HELPER_REDUCE_OPS:
+    if node.op not in _HELPER_REDUCE_OPS | _HELPER_HISTORY_OPS:
         return node
 
     kw_nodes: list[Apply] = []
@@ -203,6 +223,15 @@ def _lower_single_helper(node: Apply) -> Expr:  # noqa: C901, PLR0912
 
     if len(positional) != 1:
         _invalid(detail=f"{node.op} requires exactly one inner expression")
+
+    if node.op in _HELPER_HISTORY_OPS:
+        options: list[tuple[str, Expr]] = []
+        for kw_node in kw_nodes:
+            if len(kw_node.args) != 2:
+                _invalid(detail="kwarg marker must contain (key, value)")
+            key = _kwarg_name(kw_node.args[0])
+            options.append((key, kw_node.args[1]))
+        return HistoryOp(kind=node.op, body=positional[0], options=tuple(options))
 
     bindings: list[tuple[str, str]] = []
     filters: list[tuple[str, tuple[str, ...]]] = []
@@ -277,6 +306,13 @@ def lower_helper_calls(expr: Expr) -> Expr:
             body=lower_helper_calls(expr.body),
             filters=expr.filters,
             kernel=expr.kernel,
+        )
+
+    if isinstance(expr, HistoryOp):
+        return HistoryOp(
+            kind=expr.kind,
+            body=lower_helper_calls(expr.body),
+            options=tuple((k, lower_helper_calls(v)) for k, v in expr.options),
         )
 
     return expr
@@ -547,6 +583,13 @@ def ir_to_ast_expr(expr: Expr) -> ast.expr:  # noqa: C901, PLR0911, PLR0912
         )
     if isinstance(expr, Reduce):
         _invalid(detail="structured Reduce nodes cannot be converted to Python AST yet")
+    if isinstance(expr, HistoryOp):
+        _invalid(
+            detail=(
+                "history/delay operators are recognized but not yet "
+                f"implemented (helper={expr.kind!r}); see issue #173"
+            )
+        )
     if isinstance(expr, Apply):
         if expr.op == "neg" and len(expr.args) == 1:
             return ast.UnaryOp(op=ast.USub(), operand=ir_to_ast_expr(expr.args[0]))
@@ -844,6 +887,23 @@ def _unparse_ir(  # noqa: C901, PLR0912
             _memo[key] = result
         return result
 
+    if isinstance(expr, HistoryOp):
+        body_str = _unparse_ir(expr.body, parent_prec=0, is_right=False, _memo=_memo)
+        kw_parts = [
+            (
+                f"{k}="
+                f"{_unparse_ir(v, parent_prec=0, is_right=False, _memo=_memo)}"
+            )
+            for k, v in expr.options
+        ]
+        suffix = ""
+        if kw_parts:
+            suffix = ", " + ", ".join(kw_parts)
+        result = f"{expr.kind}({body_str}{suffix})"
+        if _memo is not None and key is not None:
+            _memo[key] = result
+        return result
+
     _invalid(detail=f"unsupported IR node in unparser: {type(expr).__name__}")
 
 
@@ -899,6 +959,11 @@ def iter_subscripts(expr: Expr) -> Iterator[Subscript]:
         return
     if isinstance(expr, Reduce):
         yield from iter_subscripts(expr.body)
+        return
+    if isinstance(expr, HistoryOp):
+        yield from iter_subscripts(expr.body)
+        for _, opt_expr in expr.options:
+            yield from iter_subscripts(opt_expr)
 
 
 def walk(expr: Expr) -> Iterator[Expr]:
@@ -919,6 +984,11 @@ def walk(expr: Expr) -> Iterator[Expr]:
         return
     if isinstance(expr, Reduce):
         yield from walk(expr.body)
+        return
+    if isinstance(expr, HistoryOp):
+        yield from walk(expr.body)
+        for _, opt_expr in expr.options:
+            yield from walk(opt_expr)
 
 
 def _free_symbols_push_children(
@@ -935,6 +1005,16 @@ def _free_symbols_push_children(
         stack.append((node, True))
         if id(node.body) not in memo:
             stack.append((node.body, False))
+        return
+    if isinstance(node, HistoryOp):
+        stack.append((node, True))
+        if id(node.body) not in memo:
+            stack.append((node.body, False))
+        stack.extend(
+            (opt_expr, False)
+            for _, opt_expr in reversed(node.options)
+            if id(opt_expr) not in memo
+        )
         return
     _invalid(detail=f"unsupported IR node in free_symbols: {type(node).__name__}")
 
@@ -956,6 +1036,11 @@ def _free_symbols_finalize(
     if isinstance(node, Reduce):
         bound = {bind for _, bind in node.bindings}
         return frozenset(memo[id(node.body)] - bound)
+    if isinstance(node, HistoryOp):
+        acc: set[str] = set(memo[id(node.body)])
+        for _, opt_expr in node.options:
+            acc.update(memo[id(opt_expr)])
+        return frozenset(acc)
     _invalid(detail=f"unsupported IR node in free_symbols: {type(node).__name__}")
 
 
@@ -1054,6 +1139,12 @@ def substitute(
             filters=expr.filters,
             kernel=expr.kernel,
         )
+    if isinstance(expr, HistoryOp):
+        return HistoryOp(
+            kind=expr.kind,
+            body=substitute(expr.body, mapping, memo),
+            options=tuple((k, substitute(v, mapping, memo)) for k, v in expr.options),
+        )
     _invalid(detail=f"unsupported IR node in substitute: {type(expr).__name__}")
 
 
@@ -1074,11 +1165,17 @@ def _map_children(expr: Expr, fn: Callable[[Expr], Expr]) -> Expr:
             filters=expr.filters,
             kernel=expr.kernel,
         )
+    if isinstance(expr, HistoryOp):
+        new_body = fn(expr.body)
+        new_options = tuple((k, fn(v)) for k, v in expr.options)
+        if new_body == expr.body and new_options == expr.options:
+            return expr
+        return HistoryOp(kind=expr.kind, body=new_body, options=new_options)
     return expr
 
 
 def _is_cse_candidate(expr: Expr) -> bool:
-    return isinstance(expr, (Apply, Reduce))
+    return isinstance(expr, (Apply, Reduce, HistoryOp))
 
 
 def _expr_cost(expr: Expr) -> int:
@@ -1086,6 +1183,8 @@ def _expr_cost(expr: Expr) -> int:
         return 1 + sum(_expr_cost(arg) for arg in expr.args)
     if isinstance(expr, Reduce):
         return 1 + _expr_cost(expr.body)
+    if isinstance(expr, HistoryOp):
+        return 1 + _expr_cost(expr.body) + sum(_expr_cost(v) for _, v in expr.options)
     return 1
 
 
@@ -1095,6 +1194,10 @@ def _postorder(expr: Expr, out: dict[Expr, int]) -> None:
             _postorder(arg, out)
     elif isinstance(expr, Reduce):
         _postorder(expr.body, out)
+    elif isinstance(expr, HistoryOp):
+        _postorder(expr.body, out)
+        for _, opt_expr in expr.options:
+            _postorder(opt_expr, out)
     out[expr] = out.get(expr, 0) + 1
 
 
@@ -1223,6 +1326,15 @@ def resolve_axis_kinds(expr: Expr, *, axis_names: frozenset[str]) -> Expr:  # no
             filters=expr.filters,
             kernel=expr.kernel,
         )
+    if isinstance(expr, HistoryOp):
+        new_body = resolve_axis_kinds(expr.body, axis_names=axis_names)
+        new_options = tuple(
+            (k, resolve_axis_kinds(v, axis_names=axis_names))
+            for k, v in expr.options
+        )
+        if new_body is expr.body and new_options == expr.options:
+            return expr
+        return HistoryOp(kind=expr.kind, body=new_body, options=new_options)
     _invalid(detail=f"unsupported IR node in resolve_axis_kinds: {type(expr).__name__}")
 
 
@@ -1231,6 +1343,7 @@ __all__ = [
     "AxisIndex",
     "AxisKind",
     "Expr",
+    "HistoryOp",
     "Literal",
     "Reduce",
     "Subscript",

--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -800,7 +800,7 @@ def _unparse_binary(
     return _wrap(rendered, need=need_parens)
 
 
-def _unparse_ir(  # noqa: C901, PLR0912
+def _unparse_ir(  # noqa: C901, PLR0911, PLR0912, PLR0914, PLR0915
     expr: Expr,
     *,
     parent_prec: int,
@@ -890,10 +890,7 @@ def _unparse_ir(  # noqa: C901, PLR0912
     if isinstance(expr, HistoryOp):
         body_str = _unparse_ir(expr.body, parent_prec=0, is_right=False, _memo=_memo)
         kw_parts = [
-            (
-                f"{k}="
-                f"{_unparse_ir(v, parent_prec=0, is_right=False, _memo=_memo)}"
-            )
+            (f"{k}={_unparse_ir(v, parent_prec=0, is_right=False, _memo=_memo)}")
             for k, v in expr.options
         ]
         suffix = ""
@@ -1037,10 +1034,10 @@ def _free_symbols_finalize(
         bound = {bind for _, bind in node.bindings}
         return frozenset(memo[id(node.body)] - bound)
     if isinstance(node, HistoryOp):
-        acc: set[str] = set(memo[id(node.body)])
+        hist_acc: set[str] = set(memo[id(node.body)])
         for _, opt_expr in node.options:
-            acc.update(memo[id(opt_expr)])
-        return frozenset(acc)
+            hist_acc.update(memo[id(opt_expr)])
+        return frozenset(hist_acc)
     _invalid(detail=f"unsupported IR node in free_symbols: {type(node).__name__}")
 
 
@@ -1148,7 +1145,7 @@ def substitute(
     _invalid(detail=f"unsupported IR node in substitute: {type(expr).__name__}")
 
 
-def _map_children(expr: Expr, fn: Callable[[Expr], Expr]) -> Expr:
+def _map_children(expr: Expr, fn: Callable[[Expr], Expr]) -> Expr:  # noqa: PLR0911
     if isinstance(expr, Apply):
         new_args = tuple(fn(arg) for arg in expr.args)
         if new_args == expr.args:
@@ -1329,8 +1326,7 @@ def resolve_axis_kinds(expr: Expr, *, axis_names: frozenset[str]) -> Expr:  # no
     if isinstance(expr, HistoryOp):
         new_body = resolve_axis_kinds(expr.body, axis_names=axis_names)
         new_options = tuple(
-            (k, resolve_axis_kinds(v, axis_names=axis_names))
-            for k, v in expr.options
+            (k, resolve_axis_kinds(v, axis_names=axis_names)) for k, v in expr.options
         )
         if new_body is expr.body and new_options == expr.options:
             return expr

--- a/src/op_system/_ir_lower.py
+++ b/src/op_system/_ir_lower.py
@@ -37,6 +37,7 @@ from op_system._ir import (
     AxisIndex,
     AxisKind,
     Expr,
+    HistoryOp,
     Literal,
     Reduce,
     Subscript,
@@ -519,6 +520,17 @@ def lower_to_vector_ast(  # noqa: PLR0913
             shaped_param_axes=shaped_param_axes,
             axis_alias=axis_alias,
         )
+
+    if isinstance(expr, HistoryOp):
+        msg = (
+            "history/delay operators require engine-managed history "
+            "buffers and cannot be lowered in v1 (issue #173)"
+        )
+        raise UnsupportedIRLoweringError(msg)
+
+    if not isinstance(expr, Reduce):
+        msg = f"unsupported IR node in lowering: {type(expr).__name__}"
+        raise UnsupportedIRLoweringError(msg)
 
     return _lower_reduce(
         expr,

--- a/src/op_system/_ir_templates.py
+++ b/src/op_system/_ir_templates.py
@@ -184,10 +184,10 @@ def _compute_free_axes(
             return body_axes
         return (body_axes - bound) or _EMPTY_AXES
     if isinstance(node, HistoryOp):
-        acc: set[str] = set(_free_axes_in(node.body, shaped=shaped, memo=memo))
+        hist_acc: set[str] = set(_free_axes_in(node.body, shaped=shaped, memo=memo))
         for _, opt_expr in node.options:
-            acc |= _free_axes_in(opt_expr, shaped=shaped, memo=memo)
-        return frozenset(acc) or _EMPTY_AXES
+            hist_acc |= _free_axes_in(opt_expr, shaped=shaped, memo=memo)
+        return frozenset(hist_acc) or _EMPTY_AXES
     # Literal, Sym, and any other leaf node carry no free axes.
     return _EMPTY_AXES
 

--- a/src/op_system/_ir_templates.py
+++ b/src/op_system/_ir_templates.py
@@ -28,6 +28,7 @@ from ._ir import (
     Apply,
     AxisIndex,
     Expr,
+    HistoryOp,
     Literal,
     Reduce,
     Subscript,
@@ -182,6 +183,11 @@ def _compute_free_axes(
         if not (bound and body_axes):
             return body_axes
         return (body_axes - bound) or _EMPTY_AXES
+    if isinstance(node, HistoryOp):
+        acc: set[str] = set(_free_axes_in(node.body, shaped=shaped, memo=memo))
+        for _, opt_expr in node.options:
+            acc |= _free_axes_in(opt_expr, shaped=shaped, memo=memo)
+        return frozenset(acc) or _EMPTY_AXES
     # Literal, Sym, and any other leaf node carry no free axes.
     return _EMPTY_AXES
 
@@ -245,7 +251,7 @@ def expand_inline_templates(
             shaped_params=shaped,
             axis_lookup=axis_lookup,
         )
-    # Compound nodes (Apply / Reduce): skip the recursion entirely when
+    # Compound nodes (Apply / Reduce / HistoryOp): skip the recursion entirely when
     # the cached free-axis set is disjoint from ``assignment``. This is
     # the dominant win for per-coord alias pinning where ``assignment``
     # is ``{<one-axis>: ...}`` but the body spans many axes (issue #145).
@@ -291,6 +297,15 @@ def expand_inline_templates(
         )
     elif isinstance(expr, Reduce):
         result = _expand_reduce(
+            expr,
+            assignment=assignment,
+            shaped_params=shaped,
+            axis_lookup=axis_lookup,
+            free_axes_memo=_free_axes_memo,
+            expand_result_memo=_expand_result_memo,
+        )
+    elif isinstance(expr, HistoryOp):
+        result = _expand_history_op(
             expr,
             assignment=assignment,
             shaped_params=shaped,
@@ -358,7 +373,49 @@ def _expand_reduce(  # noqa: PLR0913
     )
     if new_body is expr.body:
         return expr
-    return Reduce(kind=expr.kind, bindings=expr.bindings, body=new_body)
+    return Reduce(
+        kind=expr.kind,
+        bindings=expr.bindings,
+        body=new_body,
+        filters=expr.filters,
+        kernel=expr.kernel,
+    )
+
+
+def _expand_history_op(  # noqa: PLR0913
+    expr: HistoryOp,
+    *,
+    assignment: Mapping[str, str],
+    shaped_params: Mapping[str, tuple[str, ...]],
+    axis_lookup: Mapping[str, Sequence[str]] | None,
+    free_axes_memo: dict[int, frozenset[str]] | None,
+    expand_result_memo: dict[tuple[object, ...], Expr] | None = None,
+) -> Expr:
+    new_body = expand_inline_templates(
+        expr.body,
+        assignment=assignment,
+        shaped_params=shaped_params,
+        axis_lookup=axis_lookup,
+        _free_axes_memo=free_axes_memo,
+        _expand_result_memo=expand_result_memo,
+    )
+    new_options = tuple(
+        (
+            k,
+            expand_inline_templates(
+                opt_expr,
+                assignment=assignment,
+                shaped_params=shaped_params,
+                axis_lookup=axis_lookup,
+                _free_axes_memo=free_axes_memo,
+                _expand_result_memo=expand_result_memo,
+            ),
+        )
+        for k, opt_expr in expr.options
+    )
+    if new_body is expr.body and new_options == expr.options:
+        return expr
+    return HistoryOp(kind=expr.kind, body=new_body, options=new_options)
 
 
 __all__ = [
@@ -407,6 +464,11 @@ def _walk_for_axes(
         _walk_for_axes(node.body, shaped=shaped, seen=seen)
         for _, bind in node.bindings:
             seen.pop(bind, None)
+        return
+    if isinstance(node, HistoryOp):
+        _walk_for_axes(node.body, shaped=shaped, seen=seen)
+        for _, opt_expr in node.options:
+            _walk_for_axes(opt_expr, shaped=shaped, seen=seen)
 
 
 def free_axes(

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -40,7 +40,14 @@ from numpy.typing import NDArray
 
 from op_system._block_axes import BlockAxisInfo, analyze_block_axes
 from op_system._errors import InvalidExpressionError, UnsupportedFeatureError
-from op_system._ir import Expr, extract_common_subexpressions, ir_to_ast_expr
+from op_system._ir import (
+    Expr,
+    HistoryOp,
+    extract_common_subexpressions,
+    ir_to_ast_expr,
+    unparse_ir,
+    walk,
+)
 from op_system._normalize import ExprRhs, TransitionsRhs
 from op_system._operators import OperatorDescriptor
 from op_system._symbols import parse_expression_string
@@ -750,6 +757,43 @@ def _make_eval_fn(
     return eval_fn
 
 
+def _history_requirements_from_ir(
+    *,
+    aliases_ir: Mapping[str, Expr] | None,
+    equations_ir: tuple[Expr | None, ...] | None,
+) -> tuple[dict[str, object], ...]:
+    """Collect structured history-operator requirements from typed IR.
+
+    Returns:
+        Tuple of requirement records, each containing helper kind, body,
+        and normalized option expressions.
+    """
+    reqs: list[dict[str, object]] = []
+    if aliases_ir:
+        for alias_name, alias_expr in aliases_ir.items():
+            for node in walk(alias_expr):
+                if isinstance(node, HistoryOp):
+                    reqs.append({
+                        "scope": f"alias:{alias_name}",
+                        "kind": node.kind,
+                        "body": unparse_ir(node.body),
+                        "options": {k: unparse_ir(v) for k, v in node.options},
+                    })
+    if equations_ir:
+        for eq_idx, eq_expr in enumerate(equations_ir):
+            if eq_expr is None:
+                continue
+            for node in walk(eq_expr):
+                if isinstance(node, HistoryOp):
+                    reqs.append({
+                        "scope": f"equation:{eq_idx}",
+                        "kind": node.kind,
+                        "body": unparse_ir(node.body),
+                        "options": {k: unparse_ir(v) for k, v in node.options},
+                    })
+    return tuple(reqs)
+
+
 # -----------------------------------------------------------------------------
 # Public compile API
 # -----------------------------------------------------------------------------
@@ -1094,6 +1138,20 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
         _raise_unsupported_feature(
             feature=f"rhs type={type(rhs).__name__}",
             detail="Only ExprRhs and TransitionsRhs are supported in v1.",
+        )
+
+    history_requirements = _history_requirements_from_ir(
+        aliases_ir=rhs.aliases_ir,
+        equations_ir=rhs.equations_ir,
+    )
+    if history_requirements:
+        _raise_unsupported_feature(
+            feature="history operators",
+            detail=(
+                "History/delay operators require engine-managed state history "
+                "buffers and are not implemented yet (issue #173). "
+                f"history_requirements={history_requirements!r}"
+            ),
         )
 
     # Lazy load via importlib to avoid a static circular import

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -415,6 +415,12 @@ _ALLOWED_CALL_FUNCS: frozenset[str] = frozenset({
 
 _ALLOWED_HELPER_FUNCS: frozenset[str] = frozenset({"sum_state", "sum_prefix"})
 
+_PLANNED_HISTORY_HELPERS: frozenset[str] = frozenset({
+    "history",
+    "delay",
+    "convolve_history",
+})
+
 
 def _parse_expr(expr: str) -> ast.Expression:
     """Parse a Python expression and return the AST.
@@ -446,6 +452,13 @@ def _validate_call(func: ast.AST, *, expr: str) -> None:
 
     if isinstance(func, ast.Name):
         helper_name = str(func.id)
+        if helper_name in _PLANNED_HISTORY_HELPERS:
+            _raise_invalid_expression(
+                detail=(
+                    "history/delay operators are recognized but not yet "
+                    f"implemented (helper={helper_name!r}); see issue #173"
+                )
+            )
         if helper_name not in _ALLOWED_HELPER_FUNCS:
             _raise_invalid_expression(
                 detail=f"{DISALLOWED_FUNCTION_CALL}: {helper_name}"

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -768,29 +768,56 @@ def _history_requirements_from_ir(
         Tuple of requirement records, each containing helper kind, body,
         and normalized option expressions.
     """
+    required_by_kind: dict[str, tuple[str, ...]] = {
+        "history": ("lag",),
+        "delay": ("tau",),
+        "convolve_history": ("kernel", "window"),
+    }
+    allowed_by_kind: dict[str, tuple[str, ...]] = {
+        "history": ("lag", "interpolation", "history_axis"),
+        "delay": ("tau", "interpolation", "history_axis"),
+        "convolve_history": (
+            "kernel",
+            "window",
+            "kernel_params",
+            "interpolation",
+            "history_axis",
+        ),
+    }
+
+    def _make_req(scope: str, node: HistoryOp) -> dict[str, object]:
+        options = {k: unparse_ir(v) for k, v in node.options}
+        required = required_by_kind.get(node.kind, ())
+        allowed = allowed_by_kind.get(node.kind, ())
+        missing = tuple(k for k in required if k not in options)
+        unknown = tuple(sorted(k for k in options if k not in allowed))
+        return {
+            "scope": scope,
+            "kind": node.kind,
+            "signal_expr": unparse_ir(node.body),
+            "options": options,
+            "required_options": required,
+            "missing_required_options": missing,
+            "unknown_options": unknown,
+        }
+
     reqs: list[dict[str, object]] = []
     if aliases_ir:
         for alias_name, alias_expr in aliases_ir.items():
-            for node in walk(alias_expr):
-                if isinstance(node, HistoryOp):
-                    reqs.append({
-                        "scope": f"alias:{alias_name}",
-                        "kind": node.kind,
-                        "body": unparse_ir(node.body),
-                        "options": {k: unparse_ir(v) for k, v in node.options},
-                    })
+            reqs.extend(
+                _make_req(f"alias:{alias_name}", node)
+                for node in walk(alias_expr)
+                if isinstance(node, HistoryOp)
+            )
     if equations_ir:
         for eq_idx, eq_expr in enumerate(equations_ir):
             if eq_expr is None:
                 continue
-            for node in walk(eq_expr):
-                if isinstance(node, HistoryOp):
-                    reqs.append({
-                        "scope": f"equation:{eq_idx}",
-                        "kind": node.kind,
-                        "body": unparse_ir(node.body),
-                        "options": {k: unparse_ir(v) for k, v in node.options},
-                    })
+            reqs.extend(
+                _make_req(f"equation:{eq_idx}", node)
+                for node in walk(eq_expr)
+                if isinstance(node, HistoryOp)
+            )
     return tuple(reqs)
 
 

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -185,6 +185,44 @@ def test_compile_rejects_planned_history_helpers_with_targeted_message(
         compile_rhs(rhs, xp=np)
 
 
+def test_history_requirements_payload_includes_missing_required_options() -> None:
+    """history_requirements payload reports missing mandatory helper kwargs."""
+    spec = {"kind": "expr", "state": ["x"], "equations": {"x": "delay(x)"}}
+    rhs = normalize_rhs(spec)
+
+    with pytest.raises(UnsupportedFeatureError) as exc_info:
+        compile_rhs(rhs, xp=np)
+
+    msg = str(exc_info.value)
+    assert "'kind': 'delay'" in msg
+    assert "'required_options': ('tau',)" in msg
+    assert "'missing_required_options': ('tau',)" in msg
+
+
+def test_history_requirements_payload_captures_provided_options() -> None:
+    """history_requirements payload preserves normalized option expressions."""
+    spec = {
+        "kind": "expr",
+        "state": ["x"],
+        "equations": {
+            "x": "convolve_history(x, kernel=gamma, window=14, interpolation=linear)"
+        },
+    }
+    rhs = normalize_rhs(spec)
+
+    with pytest.raises(UnsupportedFeatureError) as exc_info:
+        compile_rhs(rhs, xp=np)
+
+    msg = str(exc_info.value)
+    assert "'kind': 'convolve_history'" in msg
+    assert (
+        "'options': {'kernel': 'gamma', 'window': '14', 'interpolation': 'linear'}"
+        in msg
+    )
+    assert "'missing_required_options': ()" in msg
+    assert "'unknown_options': ()" in msg
+
+
 def test_compile_rejects_disallowed_attribute_access() -> None:
     """Disallowed attribute access should be rejected before evaluation."""
     spec = {"kind": "expr", "state": ["x"], "equations": {"x": "x.real"}}

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -171,6 +171,20 @@ def test_compile_rejects_nonwhitelisted_helper() -> None:
         compile_rhs(rhs, xp=np)
 
 
+@pytest.mark.parametrize("helper", ["history", "delay", "convolve_history"])
+def test_compile_rejects_planned_history_helpers_with_targeted_message(
+    helper: str,
+) -> None:
+    """#173 scaffold: planned history helpers have explicit unsupported diagnostics."""
+    spec = {"kind": "expr", "state": ["x"], "equations": {"x": f"{helper}(x)"}}
+    rhs = normalize_rhs(spec)
+    with pytest.raises(
+        ValueError,
+        match=r"history/delay operators are recognized but not yet implemented",
+    ):
+        compile_rhs(rhs, xp=np)
+
+
 def test_compile_rejects_disallowed_attribute_access() -> None:
     """Disallowed attribute access should be rejected before evaluation."""
     spec = {"kind": "expr", "state": ["x"], "equations": {"x": "x.real"}}

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -179,8 +179,8 @@ def test_compile_rejects_planned_history_helpers_with_targeted_message(
     spec = {"kind": "expr", "state": ["x"], "equations": {"x": f"{helper}(x)"}}
     rhs = normalize_rhs(spec)
     with pytest.raises(
-        ValueError,
-        match=r"history/delay operators are recognized but not yet implemented",
+        UnsupportedFeatureError,
+        match=r"issue #173.*history_requirements=",
     ):
         compile_rhs(rhs, xp=np)
 

--- a/tests/op_system/test_op_system_ir.py
+++ b/tests/op_system/test_op_system_ir.py
@@ -10,6 +10,7 @@ from op_system._errors import InvalidExpressionError
 from op_system._ir import (
     Apply,
     AxisIndex,
+    HistoryOp,
     Literal,
     Reduce,
     Subscript,
@@ -236,3 +237,28 @@ def test_lower_helper_combines_binding_and_filter_across_axes() -> None:
     assert isinstance(ir, Reduce)
     assert ir.bindings == (("age", "a"), ("vax", "b"))
     assert ir.filters == (("vax", ("v", "w")),)
+
+
+@pytest.mark.parametrize("helper,arg_name", [("history", "lag"), ("delay", "tau")])
+def test_lower_helper_rewrites_history_family_calls(
+    helper: str,
+    arg_name: str,
+) -> None:
+    """History-family helpers lower to structured HistoryOp nodes."""
+    ir = parse_expr_to_ir(f"{helper}(I, {arg_name}=7)", lower_helpers=True)
+
+    assert isinstance(ir, HistoryOp)
+    assert ir.kind == helper
+    assert ir.body == Sym(name="I")
+    assert ir.options == ((arg_name, Literal(value=7)),)
+
+
+def test_ir_to_ast_rejects_structured_history_nodes_for_now() -> None:
+    """#173 scaffold: HistoryOp exists in IR but has no runtime lowering yet."""
+    ir = parse_expr_to_ir("delay(I, tau=7)", lower_helpers=True)
+
+    with pytest.raises(
+        InvalidExpressionError,
+        match=r"history/delay operators are recognized but not yet implemented",
+    ):
+        ir_to_ast_expr(ir)

--- a/tests/op_system/test_op_system_ir.py
+++ b/tests/op_system/test_op_system_ir.py
@@ -239,7 +239,7 @@ def test_lower_helper_combines_binding_and_filter_across_axes() -> None:
     assert ir.filters == (("vax", ("v", "w")),)
 
 
-@pytest.mark.parametrize("helper,arg_name", [("history", "lag"), ("delay", "tau")])
+@pytest.mark.parametrize(("helper", "arg_name"), [("history", "lag"), ("delay", "tau")])
 def test_lower_helper_rewrites_history_family_calls(
     helper: str,
     arg_name: str,

--- a/tests/op_system/test_op_system_ir_substitute.py
+++ b/tests/op_system/test_op_system_ir_substitute.py
@@ -6,6 +6,7 @@ from op_system._ir import (
     Apply,
     AxisIndex,
     Expr,
+    HistoryOp,
     Literal,
     Reduce,
     Subscript,
@@ -105,3 +106,20 @@ def test_substitute_is_identity_when_no_match() -> None:
     """Substituting an empty mapping yields a structurally equal tree."""
     expr = parse_expr_to_ir("a + b * c")
     assert substitute(expr, {}) == expr
+
+
+def test_historyop_free_symbols_and_substitute() -> None:
+    """HistoryOp participates in free-symbol analysis and substitution."""
+    expr = HistoryOp(
+        kind="delay",
+        body=Sym(name="I"),
+        options=(("tau", Sym(name="tau_param")),),
+    )
+
+    assert free_symbols(expr) == frozenset({"I", "tau_param"})
+    out = substitute(expr, {"I": Sym(name="incidence")})
+    assert out == HistoryOp(
+        kind="delay",
+        body=Sym(name="incidence"),
+        options=(("tau", Sym(name="tau_param")),),
+    )

--- a/tests/op_system/test_op_system_ir_unparse.py
+++ b/tests/op_system/test_op_system_ir_unparse.py
@@ -34,3 +34,13 @@ def test_unparse_ir_renders_helper_reduce_node() -> None:
     rendered = unparse_ir(ir)
     assert rendered.startswith("apply_along(")
     assert "age=ap" in rendered
+
+
+def test_unparse_ir_renders_history_helper_node() -> None:
+    """Lowered history/delay helper nodes unparse back to helper-call syntax."""
+    ir1 = parse_expr_to_ir("delay(I, tau=7)", lower_helpers=True)
+
+    rendered = unparse_ir(ir1)
+    assert rendered == "delay(I, tau=7)"
+    ir2 = parse_expr_to_ir(rendered, lower_helpers=True)
+    assert ir1 == ir2


### PR DESCRIPTION
This pull request introduces internal scaffolding for planned "history" helper operators (`history`, `delay`, `convolve_history`) in the IR, preparing for future implementation (see issue #173). These helpers are now recognized during parsing, normalized into a new `HistoryOp` IR node, and handled throughout the IR transformation pipeline. However, they are not yet implemented: any attempt to lower or execute them results in a targeted error with detailed requirements for engine-side support. The changes also ensure that all relevant IR utilities (e.g., symbol/axis analysis, substitution, unparsing) are compatible with the new node.

Key changes:

**History Helper Scaffolding and IR Support**
- Introduced the `HistoryOp` IR node to represent history-aware helper calls, including support for options and signal expressions. All IR utilities (`walk`, `substitute`, `free_symbols`, axis analysis, CSE, etc.) are updated to handle `HistoryOp` nodes. [[1]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6L97-R124) [[2]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R959-R963) [[3]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R984-R988) [[4]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R1006-R1015) [[5]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R1036-R1040) [[6]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R1139-R1148) [[7]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R1165-R1184) [[8]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R1194-R1197) [[9]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R1326-R1333) [[10]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R1342) [[11]](diffhunk://#diff-972bd1d88a010cec7d13f086705a2dd6f19f85bcbd8ce19cda35f08eb771f9e3R40) [[12]](diffhunk://#diff-b41bfad43521ade515b277c6ef147f3d30c84f577a6602ef41f828c6e6b72017R31) [[13]](diffhunk://#diff-b41bfad43521ade515b277c6ef147f3d30c84f577a6602ef41f828c6e6b72017R186-R190) [[14]](diffhunk://#diff-b41bfad43521ade515b277c6ef147f3d30c84f577a6602ef41f828c6e6b72017L248-R254) [[15]](diffhunk://#diff-b41bfad43521ade515b277c6ef147f3d30c84f577a6602ef41f828c6e6b72017R307-R315) [[16]](diffhunk://#diff-b41bfad43521ade515b277c6ef147f3d30c84f577a6602ef41f828c6e6b72017L361-R418) [[17]](diffhunk://#diff-b41bfad43521ade515b277c6ef147f3d30c84f577a6602ef41f828c6e6b72017R467-R471)

**Parsing, Validation, and Error Handling**
- Updated parsing and validation logic to recognize planned history helpers, raising a targeted "not yet implemented" error with a detailed requirements payload at compile time if used in user code. [[1]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R425-R430) [[2]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R462-R468) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R248-R255)

**IR Lowering and Execution**
- Ensured that attempts to lower or execute `HistoryOp` nodes raise a clear error indicating that engine-side history buffer support is required and referencing the relevant issue. [[1]](diffhunk://#diff-972bd1d88a010cec7d13f086705a2dd6f19f85bcbd8ce19cda35f08eb771f9e3R524-R534) [[2]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R586-R592)

**Unparsing and Debugging**
- Added support for pretty-printing and unparsing `HistoryOp` nodes for debugging and round-tripping, including options and body expressions. [[1]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6L760-R803) [[2]](diffhunk://#diff-b2eaee02467354d161398b2e5193df26a0336fc9e471599a2005c0f8099991f6R890-R903)

These changes lay the groundwork for future implementation of history-aware helpers while ensuring that the IR and all related utilities remain robust and forward-compatible.

closes #173