### PR TITLE
feat(#175): wire convolve_history → provider hook (Slices 1+2)

### DIFF
--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -132,6 +132,12 @@ class OpSystemSystem(SystemABC, module="flepimop2.system.op_system"):  # noqa: D
             "block_template_shapes": compiled.block_template_shapes,
             "pytree_stepper_fn": None,  # updated below if pytree path available
             "block_pytree_stepper_fn": None,  # updated below if block path available
+            # History-op surface (#175). ``history_requirements`` is always
+            # populated (empty tuple for specs without history operators);
+            # ``history_stepper_fn`` is set only when the compiled RHS
+            # produced a runnable ``history_eval_fn``.
+            "history_requirements": compiled.history_requirements,
+            "history_stepper_fn": None,  # updated below if history path available
         }
 
         def _stepper(
@@ -193,6 +199,36 @@ class OpSystemSystem(SystemABC, module="flepimop2.system.op_system"):  # noqa: D
         else:
             self._stepper_block_pytree = None
 
+        # Expose history stepper when history operators are present (#175).
+        # The returned callable accepts a ``history_provider`` keyword that
+        # the engine injects at solve time; the provider's ``.query`` method
+        # is wired to the lowered ``__hist_query(signal_id, body, **opts)``
+        # call sites. Engines should consult ``options['history_requirements']``
+        # to allocate per-signal history buffers ahead of time.
+        if compiled.history_eval_fn is not None:
+            history_eval_fn = compiled.history_eval_fn
+
+            def _stepper_history(
+                time: np.float64,
+                state_dict: dict[str, Any],
+                *,
+                history_provider: object,
+                **kwargs: Any,  # noqa: ANN401
+            ) -> dict[str, Any]:
+                params = dict(mixing_kernels)
+                params.update(kwargs)
+                return history_eval_fn(
+                    time,
+                    state_dict,
+                    history_provider=history_provider,
+                    **params,
+                )
+
+            self._stepper_history: Any = _stepper_history
+            self.options["history_stepper_fn"] = _stepper_history
+        else:
+            self._stepper_history = None
+
         self._compiled_rhs = compiled  # handy for debugging/adapters
 
     @override
@@ -214,6 +250,12 @@ class OpSystemSystem(SystemABC, module="flepimop2.system.op_system"):  # noqa: D
         if self._stepper_pytree is not None:
             bound.pytree_stepper = functools.partial(  # type: ignore[attr-defined]
                 self._stepper_pytree, **(params or {})
+            )
+        if self._stepper_history is not None:
+            # ``history_provider`` is per-call (not partialized) because the
+            # engine constructs and owns the history buffer registry.
+            bound.history_stepper = functools.partial(  # type: ignore[attr-defined]
+                self._stepper_history, **(params or {})
             )
         return cast("SystemProtocol", bound)
 

--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -90,55 +90,127 @@ class OpSystemSystem(SystemABC, module="flepimop2.system.op_system"):  # noqa: D
         """
         del context
 
-        spec_obj = self.spec
-        compiled = compile_spec(spec_obj)
-        n_state = len(compiled.state_names)
-
+        compiled = compile_spec(self.spec)
         axes_meta = self._extract_axes_meta(compiled)
         mixing_kernels = self._build_mixing_kernels(compiled, axes_meta.axis_coords)
         shape_dims, flatten_fn, unflatten_fn = self._make_shape_helpers(
-            n_state, axes_meta
+            len(compiled.state_names), axes_meta
         )
 
-        operators = self._extract_operators(compiled)
-        operator_axis = self._extract_operator_axis(compiled)
-        # Preserve the user-declared coordinate labels (typically strings
-        # like ``unvaccinated`` / ``age65to100``) alongside the numeric
-        # ``axis_coords`` arrays.  Engine plugins use this to translate
-        # shaped-IC coord assignments back to integer indices.
+        self.options = self._build_options(
+            compiled=compiled,
+            axes_meta=axes_meta,
+            shape_helpers=(shape_dims, flatten_fn, unflatten_fn),
+            mixing_kernels=mixing_kernels,
+        )
+
+        self._stepper = self._make_stepper(
+            compiled=compiled, mixing_kernels=mixing_kernels
+        )
+
+        self._stepper_pytree = self._maybe_make_pytree_stepper(
+            compiled=compiled,
+            mixing_kernels=mixing_kernels,
+        )
+        self.options["pytree_stepper_fn"] = self._stepper_pytree
+
+        self._stepper_block_pytree = self._maybe_make_block_pytree_stepper(
+            compiled=compiled,
+            mixing_kernels=mixing_kernels,
+        )
+        self.options["block_pytree_stepper_fn"] = self._stepper_block_pytree
+
+        self._stepper_history = self._maybe_make_history_stepper(
+            compiled=compiled,
+            mixing_kernels=mixing_kernels,
+        )
+        self.options["history_stepper_fn"] = self._stepper_history
+
+        self._compiled_rhs = compiled  # handy for debugging/adapters
+
+    @staticmethod
+    def _extract_axis_labels(compiled: CompiledRhs) -> dict[str, tuple[str, ...]]:
+        """Preserve declared axis coordinate labels for shaped-IC resolution.
+
+        Returns:
+            Mapping from axis name to declared coordinate labels.
+        """
         axis_labels: dict[str, tuple[str, ...]] = {}
         for ax in compiled.meta.get("axes", []) or []:
             name = ax.get("name")
             coords = ax.get("coords")
             if isinstance(name, str) and isinstance(coords, (list, tuple)):
                 axis_labels[name] = tuple(str(c) for c in coords)
-        self.options = {
+        return axis_labels
+
+    @staticmethod
+    def _merged_params(
+        mixing_kernels: Mapping[str, np.ndarray],
+        kwargs: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Merge static mixing-kernel params with call-time kwargs.
+
+        Returns:
+            Dict containing kernel defaults overridden by runtime kwargs.
+        """
+        merged = dict(mixing_kernels)
+        merged.update(kwargs)
+        return merged
+
+    def _build_options(
+        self,
+        *,
+        compiled: CompiledRhs,
+        axes_meta: _AxesMeta,
+        shape_helpers: tuple[
+            tuple[int, ...],
+            Callable[[np.ndarray], np.ndarray],
+            Callable[[np.ndarray], np.ndarray],
+        ],
+        mixing_kernels: Mapping[str, np.ndarray],
+    ) -> dict[str, object]:
+        """Build the public options map surfaced to engine plugins.
+
+        Returns:
+            Fully-populated options mapping for bound steppers/plugins.
+        """
+        shape_dims, flatten_fn, unflatten_fn = shape_helpers
+        return {
             **dict(self.options or {}),
             "axis_order": axes_meta.axis_order,
             "axis_sizes": axes_meta.axis_sizes,
             "axis_coords": axes_meta.axis_coords,
-            "axis_labels": axis_labels,
+            "axis_labels": self._extract_axis_labels(compiled),
             "state_names": compiled.state_names,
             "initial_state": compiled.meta.get("initial_state"),
             "state_shape": shape_dims,
             "flatten": flatten_fn,
             "unflatten": unflatten_fn,
-            "mixing_kernels": mixing_kernels,
-            "operators": operators,
-            "operator_axis": operator_axis,
+            "mixing_kernels": dict(mixing_kernels),
+            "operators": self._extract_operators(compiled),
+            "operator_axis": self._extract_operator_axis(compiled),
             "factorize_axes": compiled.factorize_axes,
             "block_axes": compiled.block_axes,
             "template_shapes": compiled.template_shapes,
             "block_template_shapes": compiled.block_template_shapes,
-            "pytree_stepper_fn": None,  # updated below if pytree path available
-            "block_pytree_stepper_fn": None,  # updated below if block path available
-            # History-op surface (#175). ``history_requirements`` is always
-            # populated (empty tuple for specs without history operators);
-            # ``history_stepper_fn`` is set only when the compiled RHS
-            # produced a runnable ``history_eval_fn``.
+            "pytree_stepper_fn": None,
+            "block_pytree_stepper_fn": None,
             "history_requirements": compiled.history_requirements,
-            "history_stepper_fn": None,  # updated below if history path available
+            "history_stepper_fn": None,
         }
+
+    @staticmethod
+    def _make_stepper(
+        *,
+        compiled: CompiledRhs,
+        mixing_kernels: Mapping[str, np.ndarray],
+    ) -> Callable[[np.float64, Float64NDArray], Float64NDArray]:
+        """Build scalar-vector stepper wrapper around compiled.eval_fn.
+
+        Returns:
+            Callable matching the flat state-vector stepper contract.
+        """
+        n_state = len(compiled.state_names)
 
         def _stepper(
             time: np.float64,
@@ -152,84 +224,92 @@ class OpSystemSystem(SystemABC, module="flepimop2.system.op_system"):  # noqa: D
                     f"expected ({n_state},), got {shape}."
                 )
                 raise ValueError(msg)
-            params = dict(mixing_kernels)
-            params.update(kwargs)
+            params = OpSystemSystem._merged_params(mixing_kernels, kwargs)
             return compiled.eval_fn(time, state, **params)
 
-        self._stepper = _stepper
+        return _stepper
 
-        # Expose PyTree stepper when the vectorized compile path succeeded.
-        # Accepts and returns a ``StateDict`` (base → shaped array) rather
-        # than a flat ``(n_state,)`` vector, enabling engines to skip the
-        # flatten/unflatten step and exploit block-diagonal structure.
-        if compiled.pytree_eval_fn is not None:
-            pytree_eval_fn = compiled.pytree_eval_fn
+    @staticmethod
+    def _maybe_make_pytree_stepper(
+        *,
+        compiled: CompiledRhs,
+        mixing_kernels: Mapping[str, np.ndarray],
+    ) -> Callable[[np.float64, dict[str, Any]], dict[str, Any]] | None:
+        """Build optional PyTree stepper wrapper when vectorized path exists.
 
-            def _stepper_pytree(
-                time: np.float64,
-                state_dict: dict[str, Any],
-                **kwargs: Any,  # noqa: ANN401
-            ) -> dict[str, Any]:
-                params = dict(mixing_kernels)
-                params.update(kwargs)
-                return pytree_eval_fn(time, state_dict, **params)
+        Returns:
+            PyTree stepper callable when available, otherwise ``None``.
+        """
+        pytree_eval_fn = compiled.pytree_eval_fn
+        if pytree_eval_fn is None:
+            return None
 
-            self._stepper_pytree: Any = _stepper_pytree
-            self.options["pytree_stepper_fn"] = _stepper_pytree
-        else:
-            self._stepper_pytree = None
+        def _stepper_pytree(
+            time: np.float64,
+            state_dict: dict[str, Any],
+            **kwargs: Any,  # noqa: ANN401
+        ) -> dict[str, Any]:
+            params = OpSystemSystem._merged_params(mixing_kernels, kwargs)
+            return pytree_eval_fn(time, state_dict, **params)
 
-        # Expose block PyTree stepper when block_pytree_eval_fn is available.
-        # The engine calls this function with a per-block-coord state dict
-        # (block axis removed) and vmaps it over the block axis.
-        if compiled.block_pytree_eval_fn is not None:
-            block_pytree_eval_fn = compiled.block_pytree_eval_fn
+        return _stepper_pytree
 
-            def _stepper_block_pytree(
-                time: np.float64,
-                state_dict: dict[str, Any],
-                **kwargs: Any,  # noqa: ANN401
-            ) -> dict[str, Any]:
-                params = dict(mixing_kernels)
-                params.update(kwargs)
-                return block_pytree_eval_fn(time, state_dict, **params)
+    @staticmethod
+    def _maybe_make_block_pytree_stepper(
+        *,
+        compiled: CompiledRhs,
+        mixing_kernels: Mapping[str, np.ndarray],
+    ) -> Callable[[np.float64, dict[str, Any]], dict[str, Any]] | None:
+        """Build optional block-pytree stepper wrapper.
 
-            self._stepper_block_pytree: Any = _stepper_block_pytree
-            self.options["block_pytree_stepper_fn"] = _stepper_block_pytree
-        else:
-            self._stepper_block_pytree = None
+        Returns:
+            Block-pytree stepper callable when available, otherwise ``None``.
+        """
+        block_pytree_eval_fn = compiled.block_pytree_eval_fn
+        if block_pytree_eval_fn is None:
+            return None
 
-        # Expose history stepper when history operators are present (#175).
-        # The returned callable accepts a ``history_provider`` keyword that
-        # the engine injects at solve time; the provider's ``.query`` method
-        # is wired to the lowered ``__hist_query(signal_id, body, **opts)``
-        # call sites. Engines should consult ``options['history_requirements']``
-        # to allocate per-signal history buffers ahead of time.
-        if compiled.history_eval_fn is not None:
-            history_eval_fn = compiled.history_eval_fn
+        def _stepper_block_pytree(
+            time: np.float64,
+            state_dict: dict[str, Any],
+            **kwargs: Any,  # noqa: ANN401
+        ) -> dict[str, Any]:
+            params = OpSystemSystem._merged_params(mixing_kernels, kwargs)
+            return block_pytree_eval_fn(time, state_dict, **params)
 
-            def _stepper_history(
-                time: np.float64,
-                state_dict: dict[str, Any],
-                *,
-                history_provider: object,
-                **kwargs: Any,  # noqa: ANN401
-            ) -> dict[str, Any]:
-                params = dict(mixing_kernels)
-                params.update(kwargs)
-                return history_eval_fn(
-                    time,
-                    state_dict,
-                    history_provider=history_provider,
-                    **params,
-                )
+        return _stepper_block_pytree
 
-            self._stepper_history: Any = _stepper_history
-            self.options["history_stepper_fn"] = _stepper_history
-        else:
-            self._stepper_history = None
+    @staticmethod
+    def _maybe_make_history_stepper(
+        *,
+        compiled: CompiledRhs,
+        mixing_kernels: Mapping[str, np.ndarray],
+    ) -> Callable[..., dict[str, Any]] | None:
+        """Build optional history-provider-aware stepper wrapper.
 
-        self._compiled_rhs = compiled  # handy for debugging/adapters
+        Returns:
+            History-aware stepper callable when available, otherwise ``None``.
+        """
+        history_eval_fn = compiled.history_eval_fn
+        if history_eval_fn is None:
+            return None
+
+        def _stepper_history(
+            time: np.float64,
+            state_dict: dict[str, Any],
+            *,
+            history_provider: object,
+            **kwargs: Any,  # noqa: ANN401
+        ) -> dict[str, Any]:
+            params = OpSystemSystem._merged_params(mixing_kernels, kwargs)
+            return history_eval_fn(
+                time,
+                state_dict,
+                history_provider=history_provider,
+                **params,
+            )
+
+        return _stepper_history
 
     @override
     def _bind_impl(

--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -773,3 +773,77 @@ def test_option_block_axes_from_spec() -> None:
     assert info.size == 2
     assert "S" in info.state_axis_pos
     assert info.state_axis_pos["S"] == 1  # loc is the second axis in S[age, loc]
+
+
+# ---------------------------------------------------------------------------
+# history operators surface (#175)
+# ---------------------------------------------------------------------------
+
+
+def test_history_requirements_default_empty(sir_spec: dict[str, object]) -> None:
+    """history_requirements is an empty tuple for specs without history ops."""
+    sys = OpSystemSystem(spec=sir_spec)
+    assert sys.option("history_requirements", None) == ()
+    assert sys.option("history_stepper_fn", "MISSING") is None
+
+
+def test_history_requirements_exposed_for_convolve_history_spec() -> None:
+    """Specs containing ``convolve_history`` expose requirements + stepper."""
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": ["a", "b"]}],
+        "state": ["x[loc]"],
+        "equations": {
+            "x[loc]": "convolve_history(x[loc], kernel=gamma, window=14)"
+        },
+    }
+    sys = OpSystemSystem(spec=spec)
+
+    reqs = sys.option("history_requirements", ())
+    assert isinstance(reqs, tuple)
+    assert len(reqs) >= 1
+    assert any(req["kind"] == "convolve_history" for req in reqs)
+    assert any(req["signal_id"] == 0 for req in reqs)
+
+    stepper_fn = sys.option("history_stepper_fn", None)
+    assert callable(stepper_fn)
+
+
+def test_bind_exposes_history_stepper_and_invokes_provider() -> None:
+    """bind() attaches history_stepper; the stepper routes through the provider."""
+    spec: dict[str, object] = {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": ["a", "b"]}],
+        "state": ["x[loc]"],
+        "equations": {
+            "x[loc]": "convolve_history(x[loc], kernel=gamma, window=14)"
+        },
+    }
+    sys = OpSystemSystem(spec=spec)
+    bound = sys.bind()
+    assert hasattr(bound, "history_stepper")
+
+    calls: list[tuple[int, object, dict[str, object]]] = []
+
+    class MockProvider:
+        def query(
+            self, signal_id: int, body: object, **options: object
+        ) -> object:
+            calls.append((signal_id, body, options))
+            return np.zeros_like(body)
+
+    shapes = sys.option("template_shapes", None)
+    assert shapes is not None
+    y_dict = {b: np.ones(s, dtype=np.float64) for b, s in shapes.items()}
+
+    result = bound.history_stepper(  # type: ignore[attr-defined]
+        time=np.float64(0.0),
+        state_dict=y_dict,
+        history_provider=MockProvider(),
+    )
+    assert "x" in result
+    assert len(calls) >= 1
+    signal_id, _body, options = calls[0]
+    assert signal_id == 0
+    assert options["kernel"] == "gamma"
+    assert options["window"] == 14

--- a/flepimop2-op_system/tests/test_system.py
+++ b/flepimop2-op_system/tests/test_system.py
@@ -793,9 +793,7 @@ def test_history_requirements_exposed_for_convolve_history_spec() -> None:
         "kind": "expr",
         "axes": [{"name": "loc", "coords": ["a", "b"]}],
         "state": ["x[loc]"],
-        "equations": {
-            "x[loc]": "convolve_history(x[loc], kernel=gamma, window=14)"
-        },
+        "equations": {"x[loc]": "convolve_history(x[loc], kernel=gamma, window=14)"},
     }
     sys = OpSystemSystem(spec=spec)
 
@@ -815,9 +813,7 @@ def test_bind_exposes_history_stepper_and_invokes_provider() -> None:
         "kind": "expr",
         "axes": [{"name": "loc", "coords": ["a", "b"]}],
         "state": ["x[loc]"],
-        "equations": {
-            "x[loc]": "convolve_history(x[loc], kernel=gamma, window=14)"
-        },
+        "equations": {"x[loc]": "convolve_history(x[loc], kernel=gamma, window=14)"},
     }
     sys = OpSystemSystem(spec=spec)
     bound = sys.bind()
@@ -826,9 +822,8 @@ def test_bind_exposes_history_stepper_and_invokes_provider() -> None:
     calls: list[tuple[int, object, dict[str, object]]] = []
 
     class MockProvider:
-        def query(
-            self, signal_id: int, body: object, **options: object
-        ) -> object:
+        @staticmethod
+        def query(signal_id: int, body: object, **options: object) -> object:
             calls.append((signal_id, body, options))
             return np.zeros_like(body)
 

--- a/src/op_system/_ir.py
+++ b/src/op_system/_ir.py
@@ -584,10 +584,17 @@ def ir_to_ast_expr(expr: Expr) -> ast.expr:  # noqa: C901, PLR0911, PLR0912
     if isinstance(expr, Reduce):
         _invalid(detail="structured Reduce nodes cannot be converted to Python AST yet")
     if isinstance(expr, HistoryOp):
+        if expr.kind in {"history", "delay"}:
+            _invalid(
+                detail=(
+                    "history/delay operators are recognized but not yet "
+                    f"implemented (helper={expr.kind!r}); see issue #173"
+                )
+            )
         _invalid(
             detail=(
-                "history/delay operators are recognized but not yet "
-                f"implemented (helper={expr.kind!r}); see issue #173"
+                f"{expr.kind} requires the vectorized lowering path "
+                "(this scalar-AST function is legacy and insufficient)"
             )
         )
     if isinstance(expr, Apply):

--- a/src/op_system/_ir_lower.py
+++ b/src/op_system/_ir_lower.py
@@ -44,6 +44,7 @@ from op_system._ir import (
     Sym,
     classify_axis_index,
     substitute,
+    unparse_ir,
     walk,
 )
 
@@ -402,6 +403,112 @@ def _lower_shaped_param_subscript(  # noqa: C901, PLR0911, PLR0912, PLR0915
 # ---------------------------------------------------------------------------
 
 
+def _lower_history_op(  # noqa: PLR0913
+    expr: HistoryOp,
+    *,
+    target_axes: tuple[str, ...],
+    buffer_axes: Mapping[str, tuple[str, ...]],
+    axis_names: frozenset[str],
+    reducible_axes: frozenset[str] = frozenset(),
+    axis_weights: Mapping[str, tuple[float, ...]] | None = None,
+    axis_coords: Mapping[str, tuple[str, ...]] | None = None,
+    axis_types: Mapping[str, str] | None = None,
+    shaped_param_axes: Mapping[str, tuple[str, ...]] | None = None,
+    axis_alias: Mapping[str, str] | None = None,
+    history_signal_id_map: Mapping[tuple[str, str, tuple[tuple[str, str], ...]], int] | None = None,
+) -> ast.expr:
+    """Lower a HistoryOp to a __hist_query call.
+
+    Args:
+        expr: The HistoryOp node.
+        history_signal_id_map: Maps (kind, body_repr, options_tuple) to signal_id.
+            Required for convolve_history; None triggers raise.
+        ... (other args match lower_to_vector_ast)
+
+    Returns:
+        ast.Call node calling __hist_query(signal_id, body, **options).
+
+    Raises:
+        UnsupportedIRLoweringError: If kind is not convolve_history or if
+            signal_id_map is missing.
+    """
+    if expr.kind in {"history", "delay"}:
+        msg = (
+            f"{expr.kind} operator requires engine-managed history buffers "
+            "and cannot be lowered in v1 (issue #173)"
+        )
+        raise UnsupportedIRLoweringError(msg)
+
+    if expr.kind != "convolve_history":
+        msg = f"unknown HistoryOp kind: {expr.kind!r}"
+        raise UnsupportedIRLoweringError(msg)
+
+    if history_signal_id_map is None:
+        msg = (
+            "convolve_history lowering requires a signal_id_map; "
+            "this is a caller error (vectorize path should provide it)"
+        )
+        raise UnsupportedIRLoweringError(msg)
+
+    # Build lookup key: (kind, body_repr, options_tuple).
+    body_repr = unparse_ir(expr.body)
+    options_tuple = tuple((k, unparse_ir(v)) for k, v in expr.options)
+    lookup_key = (expr.kind, body_repr, options_tuple)
+    signal_id = history_signal_id_map.get(lookup_key)
+    if signal_id is None:
+        msg = (
+            f"convolve_history node not found in signal_id_map: {lookup_key}; "
+            "this indicates a mismatch between compile.py and lowering traversal order"
+        )
+        raise UnsupportedIRLoweringError(msg)
+
+    # Lower body expression.
+    body_ast = lower_to_vector_ast(
+        expr.body,
+        target_axes=target_axes,
+        buffer_axes=buffer_axes,
+        axis_names=axis_names,
+        reducible_axes=reducible_axes,
+        axis_weights=axis_weights,
+        axis_coords=axis_coords,
+        axis_types=axis_types,
+        shaped_param_axes=shaped_param_axes,
+        axis_alias=axis_alias,
+        history_signal_id_map=history_signal_id_map,
+    )
+
+    # Lower options: Literal → Constant, Sym → Constant(name), else recurse.
+    keywords: list[ast.keyword] = []
+    for opt_name, opt_expr in expr.options:
+        if isinstance(opt_expr, Literal):
+            opt_ast = ast.Constant(value=opt_expr.value)
+        elif isinstance(opt_expr, Sym):
+            # Pass symbolic name as string for runtime dispatch.
+            opt_ast = ast.Constant(value=opt_expr.name)
+        else:
+            # Recursively lower complex option expressions.
+            opt_ast = lower_to_vector_ast(
+                opt_expr,
+                target_axes=target_axes,
+                buffer_axes=buffer_axes,
+                axis_names=axis_names,
+                reducible_axes=reducible_axes,
+                axis_weights=axis_weights,
+                axis_coords=axis_coords,
+                axis_types=axis_types,
+                shaped_param_axes=shaped_param_axes,
+                axis_alias=axis_alias,
+                history_signal_id_map=history_signal_id_map,
+            )
+        keywords.append(ast.keyword(arg=opt_name, value=opt_ast))
+
+    return ast.Call(
+        func=ast.Name(id="__hist_query", ctx=ast.Load()),
+        args=[ast.Constant(value=signal_id), body_ast],
+        keywords=keywords,
+    )
+
+
 def lower_to_vector_ast(  # noqa: PLR0913
     expr: Expr,
     *,
@@ -414,6 +521,7 @@ def lower_to_vector_ast(  # noqa: PLR0913
     axis_types: Mapping[str, str] | None = None,
     shaped_param_axes: Mapping[str, tuple[str, ...]] | None = None,
     axis_alias: Mapping[str, str] | None = None,
+    history_signal_id_map: Mapping[tuple[str, str, tuple[tuple[str, str], ...]], int] | None = None,
 ) -> ast.expr:
     """Lower an IR expression to a vector-shape AST.
 
@@ -519,14 +627,23 @@ def lower_to_vector_ast(  # noqa: PLR0913
             axis_types=axis_types,
             shaped_param_axes=shaped_param_axes,
             axis_alias=axis_alias,
+            history_signal_id_map=history_signal_id_map,
         )
 
     if isinstance(expr, HistoryOp):
-        msg = (
-            "history/delay operators require engine-managed history "
-            "buffers and cannot be lowered in v1 (issue #173)"
+        return _lower_history_op(
+            expr,
+            target_axes=target_axes,
+            buffer_axes=buffer_axes,
+            axis_names=axis_names,
+            reducible_axes=reducible_axes,
+            axis_weights=axis_weights,
+            axis_coords=axis_coords,
+            axis_types=axis_types,
+            shaped_param_axes=shaped_param_axes,
+            axis_alias=axis_alias,
+            history_signal_id_map=history_signal_id_map,
         )
-        raise UnsupportedIRLoweringError(msg)
 
     if not isinstance(expr, Reduce):
         msg = f"unsupported IR node in lowering: {type(expr).__name__}"
@@ -543,6 +660,7 @@ def lower_to_vector_ast(  # noqa: PLR0913
         axis_types=axis_types,
         shaped_param_axes=shaped_param_axes,
         axis_alias=axis_alias,
+        history_signal_id_map=history_signal_id_map,
     )
 
 
@@ -692,6 +810,7 @@ def _lower_reduce(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915
     axis_types: Mapping[str, str] | None = None,
     shaped_param_axes: Mapping[str, tuple[str, ...]] | None = None,
     axis_alias: Mapping[str, str] | None = None,
+    history_signal_id_map: Mapping[tuple[str, str, tuple[tuple[str, str], ...]], int] | None = None,
 ) -> ast.expr:
     """Lower a :class:`Reduce` node to ``np.sum(body, axis=...)``.
 
@@ -814,6 +933,7 @@ def _lower_reduce(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915
         axis_types=axis_types,
         shaped_param_axes=shaped_param_axes,
         axis_alias=child_axis_alias,
+        history_signal_id_map=history_signal_id_map,
     )
 
     # Resolve per-axis filter coord lists to integer indices. The
@@ -1131,6 +1251,7 @@ def _lower_apply(  # noqa: PLR0913
     axis_types: Mapping[str, str] | None = None,
     shaped_param_axes: Mapping[str, tuple[str, ...]] | None = None,
     axis_alias: Mapping[str, str] | None = None,
+    history_signal_id_map: Mapping[tuple[str, str, tuple[tuple[str, str], ...]], int] | None = None,
 ) -> ast.expr:
     def lower(child: Expr) -> ast.expr:
         return lower_to_vector_ast(
@@ -1144,6 +1265,7 @@ def _lower_apply(  # noqa: PLR0913
             axis_types=axis_types,
             shaped_param_axes=shaped_param_axes,
             axis_alias=axis_alias,
+            history_signal_id_map=history_signal_id_map,
         )
 
     if expr.op == "neg" and len(expr.args) == 1:

--- a/src/op_system/_ir_lower.py
+++ b/src/op_system/_ir_lower.py
@@ -415,15 +415,23 @@ def _lower_history_op(  # noqa: PLR0913
     axis_types: Mapping[str, str] | None = None,
     shaped_param_axes: Mapping[str, tuple[str, ...]] | None = None,
     axis_alias: Mapping[str, str] | None = None,
-    history_signal_id_map: Mapping[tuple[str, str, tuple[tuple[str, str], ...]], int] | None = None,
+    history_signal_id_map: Mapping[tuple[str, str, tuple[tuple[str, str], ...]], int]
+    | None = None,
 ) -> ast.expr:
     """Lower a HistoryOp to a __hist_query call.
 
     Args:
         expr: The HistoryOp node.
-        history_signal_id_map: Maps (kind, body_repr, options_tuple) to signal_id.
-            Required for convolve_history; None triggers raise.
-        ... (other args match lower_to_vector_ast)
+        target_axes: Target broadcast axis order for the lowered body.
+        buffer_axes: Mapping of buffer name to declared axis order.
+        axis_names: Registered axis labels.
+        reducible_axes: Axis labels allowed for reduction.
+        axis_weights: Optional per-axis integration weights.
+        axis_coords: Optional per-axis coordinate labels.
+        axis_types: Optional per-axis type declarations.
+        shaped_param_axes: Optional mapping for shaped-parameter axes.
+        axis_alias: Optional synthetic-axis to real-axis mapping.
+        history_signal_id_map: Mapping from history-op lookup key to signal id.
 
     Returns:
         ast.Call node calling __hist_query(signal_id, body, **options).
@@ -480,6 +488,7 @@ def _lower_history_op(  # noqa: PLR0913
     # Lower options: Literal → Constant, Sym → Constant(name), else recurse.
     keywords: list[ast.keyword] = []
     for opt_name, opt_expr in expr.options:
+        opt_ast: ast.expr
         if isinstance(opt_expr, Literal):
             opt_ast = ast.Constant(value=opt_expr.value)
         elif isinstance(opt_expr, Sym):
@@ -521,7 +530,8 @@ def lower_to_vector_ast(  # noqa: PLR0913
     axis_types: Mapping[str, str] | None = None,
     shaped_param_axes: Mapping[str, tuple[str, ...]] | None = None,
     axis_alias: Mapping[str, str] | None = None,
-    history_signal_id_map: Mapping[tuple[str, str, tuple[tuple[str, str], ...]], int] | None = None,
+    history_signal_id_map: Mapping[tuple[str, str, tuple[tuple[str, str], ...]], int]
+    | None = None,
 ) -> ast.expr:
     """Lower an IR expression to a vector-shape AST.
 
@@ -575,6 +585,9 @@ def lower_to_vector_ast(  # noqa: PLR0913
             and :func:`_lower_shaped_param_subscript` so labeled
             indices still match the real buffer axes while preserving
             the synthetic label for ``target_axes`` broadcast alignment.
+        history_signal_id_map: Optional mapping from
+            ``(kind, body_repr, options_tuple)`` to signal id for lowering
+            :class:`HistoryOp` nodes.
 
     Returns:
         An ``ast.expr`` suitable for ``compile(ast.Expression(body=...))``
@@ -584,39 +597,39 @@ def lower_to_vector_ast(  # noqa: PLR0913
         UnsupportedIRLoweringError: If ``expr`` (or any subexpression)
             contains a node outside the v1 subset.
     """
+    lowered: ast.expr
     if isinstance(expr, Literal):
-        return ast.Constant(value=expr.value)
-
-    if isinstance(expr, Sym):
-        return _name(expr.name)
-
-    if isinstance(expr, Subscript):
+        lowered = ast.Constant(value=expr.value)
+    elif isinstance(expr, Sym):
+        lowered = _name(expr.name)
+    elif isinstance(expr, Subscript):
         src_axes = buffer_axes.get(expr.name)
         if src_axes is not None:
-            return lower_subscript_to_buffer(
+            lowered = lower_subscript_to_buffer(
                 expr,
                 src_axes=src_axes,
                 target_axes=target_axes,
                 axis_names=axis_names,
                 axis_alias=axis_alias,
             )
-        shaped_axes = (shaped_param_axes or {}).get(expr.name)
-        if shaped_axes is not None:
-            return _lower_shaped_param_subscript(
-                expr,
-                src_axes=shaped_axes,
-                target_axes=target_axes,
-                axis_names=axis_names,
-                axis_alias=axis_alias,
-            )
-        msg = (
-            f"subscript {expr.name!r} is not a registered templated "
-            "buffer or shaped parameter — v1 lowering cannot resolve it"
-        )
-        raise UnsupportedIRLoweringError(msg)
-
-    if isinstance(expr, Apply):
-        return _lower_apply(
+        else:
+            shaped_axes = (shaped_param_axes or {}).get(expr.name)
+            if shaped_axes is not None:
+                lowered = _lower_shaped_param_subscript(
+                    expr,
+                    src_axes=shaped_axes,
+                    target_axes=target_axes,
+                    axis_names=axis_names,
+                    axis_alias=axis_alias,
+                )
+            else:
+                msg = (
+                    f"subscript {expr.name!r} is not a registered templated "
+                    "buffer or shaped parameter — v1 lowering cannot resolve it"
+                )
+                raise UnsupportedIRLoweringError(msg)
+    elif isinstance(expr, Apply):
+        lowered = _lower_apply(
             expr,
             target_axes=target_axes,
             buffer_axes=buffer_axes,
@@ -629,9 +642,8 @@ def lower_to_vector_ast(  # noqa: PLR0913
             axis_alias=axis_alias,
             history_signal_id_map=history_signal_id_map,
         )
-
-    if isinstance(expr, HistoryOp):
-        return _lower_history_op(
+    elif isinstance(expr, HistoryOp):
+        lowered = _lower_history_op(
             expr,
             target_axes=target_axes,
             buffer_axes=buffer_axes,
@@ -644,24 +656,25 @@ def lower_to_vector_ast(  # noqa: PLR0913
             axis_alias=axis_alias,
             history_signal_id_map=history_signal_id_map,
         )
-
-    if not isinstance(expr, Reduce):
+    elif isinstance(expr, Reduce):
+        lowered = _lower_reduce(
+            expr,
+            target_axes=target_axes,
+            buffer_axes=buffer_axes,
+            axis_names=axis_names,
+            reducible_axes=reducible_axes,
+            axis_weights=axis_weights,
+            axis_coords=axis_coords,
+            axis_types=axis_types,
+            shaped_param_axes=shaped_param_axes,
+            axis_alias=axis_alias,
+            history_signal_id_map=history_signal_id_map,
+        )
+    else:
         msg = f"unsupported IR node in lowering: {type(expr).__name__}"
         raise UnsupportedIRLoweringError(msg)
 
-    return _lower_reduce(
-        expr,
-        target_axes=target_axes,
-        buffer_axes=buffer_axes,
-        axis_names=axis_names,
-        reducible_axes=reducible_axes,
-        axis_weights=axis_weights,
-        axis_coords=axis_coords,
-        axis_types=axis_types,
-        shaped_param_axes=shaped_param_axes,
-        axis_alias=axis_alias,
-        history_signal_id_map=history_signal_id_map,
-    )
+    return lowered
 
 
 _REDUCE_SUM_KINDS: frozenset[str] = frozenset({
@@ -810,7 +823,8 @@ def _lower_reduce(  # noqa: C901, PLR0912, PLR0913, PLR0914, PLR0915
     axis_types: Mapping[str, str] | None = None,
     shaped_param_axes: Mapping[str, tuple[str, ...]] | None = None,
     axis_alias: Mapping[str, str] | None = None,
-    history_signal_id_map: Mapping[tuple[str, str, tuple[tuple[str, str], ...]], int] | None = None,
+    history_signal_id_map: Mapping[tuple[str, str, tuple[tuple[str, str], ...]], int]
+    | None = None,
 ) -> ast.expr:
     """Lower a :class:`Reduce` node to ``np.sum(body, axis=...)``.
 
@@ -1251,7 +1265,8 @@ def _lower_apply(  # noqa: PLR0913
     axis_types: Mapping[str, str] | None = None,
     shaped_param_axes: Mapping[str, tuple[str, ...]] | None = None,
     axis_alias: Mapping[str, str] | None = None,
-    history_signal_id_map: Mapping[tuple[str, str, tuple[tuple[str, str], ...]], int] | None = None,
+    history_signal_id_map: Mapping[tuple[str, str, tuple[tuple[str, str], ...]], int]
+    | None = None,
 ) -> ast.expr:
     def lower(child: Expr) -> ast.expr:
         return lower_to_vector_ast(

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -37,6 +37,7 @@ from op_system._ir_lower import (
     lift_cell_ir_to_template,
     lower_to_vector_ast,
 )
+from op_system._ir import HistoryOp, unparse_ir, walk
 from op_system.compile import (
     _SAFE_BUILTINS,
     _check_numeric_dtype,
@@ -213,6 +214,17 @@ def _try_ir_fast_path(  # noqa: PLR0913
         return None
     try:
         lifted = lift_cell_ir_to_template(expr_ir, cell_to_template=cell_to_template)
+        # Build signal_id_map by walking lifted IR in pre-order (matches compile.py).
+        history_signal_id_map: dict[tuple[str, str, tuple[tuple[str, str], ...]], int] = {}
+        signal_id = 0
+        for node in walk(lifted):
+            if isinstance(node, HistoryOp):
+                body_repr = unparse_ir(node.body)
+                options_tuple = tuple((k, unparse_ir(v)) for k, v in node.options)
+                key = (node.kind, body_repr, options_tuple)
+                if key not in history_signal_id_map:
+                    history_signal_id_map[key] = signal_id
+                    signal_id += 1
         body = lower_to_vector_ast(
             lifted,
             target_axes=target_axes,
@@ -223,6 +235,7 @@ def _try_ir_fast_path(  # noqa: PLR0913
             axis_coords=axis_coords,
             axis_types=axis_types,
             shaped_param_axes=shaped_param_axes,
+            history_signal_id_map=history_signal_id_map,
         )
     except UnsupportedIRLoweringError:
         return None
@@ -533,6 +546,17 @@ def _try_cse_eq_plan(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0914
     # assigned name so rewritten equation codes can reference it by Sym.
     cse_codes_list: list[tuple[str, CodeType]] = []
     for name, binding_ir in bindings:
+        # Build signal_id_map by walking binding_ir in pre-order (matches compile.py).
+        history_signal_id_map: dict[tuple[str, str, tuple[tuple[str, str], ...]], int] = {}
+        signal_id = 0
+        for node in walk(binding_ir):
+            if isinstance(node, HistoryOp):
+                body_repr = unparse_ir(node.body)
+                options_tuple = tuple((k, unparse_ir(v)) for k, v in node.options)
+                key = (node.kind, body_repr, options_tuple)
+                if key not in history_signal_id_map:
+                    history_signal_id_map[key] = signal_id
+                    signal_id += 1
         try:
             body = lower_to_vector_ast(
                 binding_ir,
@@ -544,6 +568,7 @@ def _try_cse_eq_plan(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0914
                 axis_coords=axis_coords,
                 axis_types=axis_types,
                 shaped_param_axes=shaped_param_axes,
+                history_signal_id_map=history_signal_id_map,
             )
         except UnsupportedIRLoweringError:
             return None
@@ -558,6 +583,17 @@ def _try_cse_eq_plan(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0914
     # Compile one rewritten equation code per state template.
     eq_groups: list[_EqGroup] = []
     for buf, rewritten_ir in zip(state_buffers, rewritten_irs, strict=True):
+        # Build signal_id_map by walking rewritten_ir in pre-order (matches compile.py).
+        history_signal_id_map = {}
+        signal_id = 0
+        for node in walk(rewritten_ir):
+            if isinstance(node, HistoryOp):
+                body_repr = unparse_ir(node.body)
+                options_tuple = tuple((k, unparse_ir(v)) for k, v in node.options)
+                key = (node.kind, body_repr, options_tuple)
+                if key not in history_signal_id_map:
+                    history_signal_id_map[key] = signal_id
+                    signal_id += 1
         try:
             body = lower_to_vector_ast(
                 rewritten_ir,
@@ -569,6 +605,7 @@ def _try_cse_eq_plan(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0914
                 axis_coords=axis_coords,
                 axis_types=axis_types,
                 shaped_param_axes=shaped_param_axes,
+                history_signal_id_map=history_signal_id_map,
             )
         except UnsupportedIRLoweringError:
             return None

--- a/src/op_system/_vectorize.py
+++ b/src/op_system/_vectorize.py
@@ -31,13 +31,20 @@ from dataclasses import dataclass
 from itertools import combinations as _comb
 from typing import TYPE_CHECKING, Any, cast
 
-from op_system._ir import Apply, Literal, Sym, extract_common_subexpressions
+from op_system._ir import (
+    Apply,
+    HistoryOp,
+    Literal,
+    Sym,
+    extract_common_subexpressions,
+    unparse_ir,
+    walk,
+)
 from op_system._ir_lower import (
     UnsupportedIRLoweringError,
     lift_cell_ir_to_template,
     lower_to_vector_ast,
 )
-from op_system._ir import HistoryOp, unparse_ir, walk
 from op_system.compile import (
     _SAFE_BUILTINS,
     _check_numeric_dtype,
@@ -173,6 +180,140 @@ class _VectorPlan:
     cse_codes: tuple[tuple[str, CodeType], ...] = ()
 
 
+@dataclass(frozen=True, slots=True)
+class _LoweringContext:
+    """Shared lowering configuration for IR-to-AST code generation."""
+
+    buffer_axes: Mapping[str, tuple[str, ...]]
+    axis_names: frozenset[str]
+    reducible_axes: frozenset[str]
+    axis_weights: Mapping[str, tuple[float, ...]] | None
+    axis_coords: Mapping[str, tuple[str, ...]] | None
+    axis_types: Mapping[str, str] | None
+    shaped_param_axes: Mapping[str, tuple[str, ...]] | None
+
+
+def _build_history_signal_id_map(
+    expr: Expr,
+) -> dict[tuple[str, str, tuple[tuple[str, str], ...]], int]:
+    """Build stable history signal ids from IR pre-order traversal.
+
+    Returns:
+        Mapping from ``(kind, body_repr, options_tuple)`` to dense integer
+        signal ids in first-seen pre-order.
+    """
+    history_signal_id_map: dict[tuple[str, str, tuple[tuple[str, str], ...]], int] = {}
+    signal_id = 0
+    for node in walk(expr):
+        if not isinstance(node, HistoryOp):
+            continue
+        body_repr = unparse_ir(node.body)
+        options_tuple = tuple((k, unparse_ir(v)) for k, v in node.options)
+        key = (node.kind, body_repr, options_tuple)
+        if key in history_signal_id_map:
+            continue
+        history_signal_id_map[key] = signal_id
+        signal_id += 1
+    return history_signal_id_map
+
+
+def _compile_ir_expr(
+    expr: Expr,
+    *,
+    target_axes: tuple[str, ...],
+    context: _LoweringContext,
+    filename: str,
+) -> CodeType | None:
+    """Lower IR to AST and compile it into an eval-ready code object.
+
+    Returns:
+        Code object on success, otherwise ``None`` when lowering/compile fails.
+    """
+    try:
+        body = lower_to_vector_ast(
+            expr,
+            target_axes=target_axes,
+            buffer_axes=context.buffer_axes,
+            axis_names=context.axis_names,
+            reducible_axes=context.reducible_axes,
+            axis_weights=context.axis_weights,
+            axis_coords=context.axis_coords,
+            axis_types=context.axis_types,
+            shaped_param_axes=context.shaped_param_axes,
+            history_signal_id_map=_build_history_signal_id_map(expr),
+        )
+    except UnsupportedIRLoweringError:
+        return None
+    tree = ast.Expression(body=body)
+    ast.fix_missing_locations(tree)
+    try:
+        return compile(tree, filename=filename, mode="eval")
+    except (ValueError, TypeError, SyntaxError):
+        return None
+
+
+def _compile_cse_bindings(
+    *,
+    bindings: tuple[tuple[str, Expr], ...],
+    common_axes: tuple[str, ...],
+    context: _LoweringContext,
+) -> list[tuple[str, CodeType]] | None:
+    """Compile template-level CSE bindings.
+
+    Returns:
+        List of ``(name, code)`` CSE bindings, or ``None`` on failure.
+    """
+    cse_codes_list: list[tuple[str, CodeType]] = []
+    for name, binding_ir in bindings:
+        code = _compile_ir_expr(
+            binding_ir,
+            target_axes=common_axes,
+            context=context,
+            filename="<op_system_cse>",
+        )
+        if code is None:
+            return None
+        cse_codes_list.append((name, code))
+    return cse_codes_list
+
+
+def _compile_cse_eq_groups(
+    *,
+    state_buffers: list[_BufferTemplate],
+    rewritten_irs: tuple[Expr, ...],
+    context: _LoweringContext,
+) -> list[_EqGroup] | None:
+    """Compile rewritten CSE equations into vectorized equation groups.
+
+    Returns:
+        List of vectorized equation groups, or ``None`` on failure.
+    """
+    eq_groups: list[_EqGroup] = []
+    for buf, rewritten_ir in zip(state_buffers, rewritten_irs, strict=True):
+        code = _compile_ir_expr(
+            rewritten_ir,
+            target_axes=buf.axes,
+            context=context,
+            filename="<op_system_vec>",
+        )
+        if code is None:
+            return None
+        assembly_perm = tuple(range(len(buf.axes)))
+        eq_groups.append(
+            _EqGroup(
+                base=buf.base,
+                codes=(code,),
+                vec_axes=buf.axes,
+                vec_shape=buf.shape,
+                unroll_axes=(),
+                unroll_shape=(),
+                assembly_perm=assembly_perm,
+                full_shape=buf.shape,
+            )
+        )
+    return eq_groups
+
+
 def _try_ir_fast_path(  # noqa: PLR0913
     expr_ir: Expr,
     *,
@@ -214,17 +355,11 @@ def _try_ir_fast_path(  # noqa: PLR0913
         return None
     try:
         lifted = lift_cell_ir_to_template(expr_ir, cell_to_template=cell_to_template)
-        # Build signal_id_map by walking lifted IR in pre-order (matches compile.py).
-        history_signal_id_map: dict[tuple[str, str, tuple[tuple[str, str], ...]], int] = {}
-        signal_id = 0
-        for node in walk(lifted):
-            if isinstance(node, HistoryOp):
-                body_repr = unparse_ir(node.body)
-                options_tuple = tuple((k, unparse_ir(v)) for k, v in node.options)
-                key = (node.kind, body_repr, options_tuple)
-                if key not in history_signal_id_map:
-                    history_signal_id_map[key] = signal_id
-                    signal_id += 1
+    except UnsupportedIRLoweringError:
+        return None
+
+    history_signal_id_map = _build_history_signal_id_map(lifted)
+    try:
         body = lower_to_vector_ast(
             lifted,
             target_axes=target_axes,
@@ -453,7 +588,7 @@ def _rewrite_cell_to_vector(  # noqa: PLR0913
 # ---------------------------------------------------------------------------
 
 
-def _try_cse_eq_plan(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0914
+def _try_cse_eq_plan(  # noqa: C901, PLR0911, PLR0912, PLR0913
     *,
     state_buffers: list[_BufferTemplate],
     rhs: NormalizedRhs,
@@ -506,7 +641,15 @@ def _try_cse_eq_plan(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0914
         if tpl.axes:
             buffer_axes[tpl.base] = tpl.axes
 
-    axis_names = frozenset(axis_index.keys())
+    lowering_context = _LoweringContext(
+        buffer_axes=buffer_axes,
+        axis_names=frozenset(axis_index.keys()),
+        reducible_axes=reducible_axes,
+        axis_weights=axis_weights,
+        axis_coords=axis_coords,
+        axis_types=axis_types,
+        shaped_param_axes=shaped_param_axes,
+    )
 
     # Lift the first-cell IR for each template to template form.
     # Prefer equations_ir_reduce (preserves Reduce helper structure) so that
@@ -544,91 +687,21 @@ def _try_cse_eq_plan(  # noqa: C901, PLR0911, PLR0912, PLR0913, PLR0914
     # Compile CSE binding codes.  Each binding is computed once after alias
     # buffers are assembled; its result is added to the eval env under the
     # assigned name so rewritten equation codes can reference it by Sym.
-    cse_codes_list: list[tuple[str, CodeType]] = []
-    for name, binding_ir in bindings:
-        # Build signal_id_map by walking binding_ir in pre-order (matches compile.py).
-        history_signal_id_map: dict[tuple[str, str, tuple[tuple[str, str], ...]], int] = {}
-        signal_id = 0
-        for node in walk(binding_ir):
-            if isinstance(node, HistoryOp):
-                body_repr = unparse_ir(node.body)
-                options_tuple = tuple((k, unparse_ir(v)) for k, v in node.options)
-                key = (node.kind, body_repr, options_tuple)
-                if key not in history_signal_id_map:
-                    history_signal_id_map[key] = signal_id
-                    signal_id += 1
-        try:
-            body = lower_to_vector_ast(
-                binding_ir,
-                target_axes=common_axes,
-                buffer_axes=buffer_axes,
-                axis_names=axis_names,
-                reducible_axes=reducible_axes,
-                axis_weights=axis_weights,
-                axis_coords=axis_coords,
-                axis_types=axis_types,
-                shaped_param_axes=shaped_param_axes,
-                history_signal_id_map=history_signal_id_map,
-            )
-        except UnsupportedIRLoweringError:
-            return None
-        tree = ast.Expression(body=body)
-        ast.fix_missing_locations(tree)
-        try:
-            code = compile(tree, filename="<op_system_cse>", mode="eval")
-        except (ValueError, TypeError, SyntaxError):
-            return None
-        cse_codes_list.append((name, code))
+    cse_codes_list = _compile_cse_bindings(
+        bindings=bindings,
+        common_axes=common_axes,
+        context=lowering_context,
+    )
+    if cse_codes_list is None:
+        return None
 
-    # Compile one rewritten equation code per state template.
-    eq_groups: list[_EqGroup] = []
-    for buf, rewritten_ir in zip(state_buffers, rewritten_irs, strict=True):
-        # Build signal_id_map by walking rewritten_ir in pre-order (matches compile.py).
-        history_signal_id_map = {}
-        signal_id = 0
-        for node in walk(rewritten_ir):
-            if isinstance(node, HistoryOp):
-                body_repr = unparse_ir(node.body)
-                options_tuple = tuple((k, unparse_ir(v)) for k, v in node.options)
-                key = (node.kind, body_repr, options_tuple)
-                if key not in history_signal_id_map:
-                    history_signal_id_map[key] = signal_id
-                    signal_id += 1
-        try:
-            body = lower_to_vector_ast(
-                rewritten_ir,
-                target_axes=buf.axes,
-                buffer_axes=buffer_axes,
-                axis_names=axis_names,
-                reducible_axes=reducible_axes,
-                axis_weights=axis_weights,
-                axis_coords=axis_coords,
-                axis_types=axis_types,
-                shaped_param_axes=shaped_param_axes,
-                history_signal_id_map=history_signal_id_map,
-            )
-        except UnsupportedIRLoweringError:
-            return None
-        tree = ast.Expression(body=body)
-        ast.fix_missing_locations(tree)
-        try:
-            code = compile(tree, filename="<op_system_vec>", mode="eval")
-        except (ValueError, TypeError, SyntaxError):
-            return None
-        # CSE path always produces a fully-vectorized code (no unrolled axes).
-        assembly_perm = tuple(range(len(buf.axes)))
-        eq_groups.append(
-            _EqGroup(
-                base=buf.base,
-                codes=(code,),
-                vec_axes=buf.axes,
-                vec_shape=buf.shape,
-                unroll_axes=(),
-                unroll_shape=(),
-                assembly_perm=assembly_perm,
-                full_shape=buf.shape,
-            )
-        )
+    eq_groups = _compile_cse_eq_groups(
+        state_buffers=state_buffers,
+        rewritten_irs=rewritten_irs,
+        context=lowering_context,
+    )
+    if eq_groups is None:
+        return None
 
     return tuple(cse_codes_list), eq_groups
 

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -225,6 +225,19 @@ class PytreeEvalFn(Protocol):
     ) -> StateDict: ...
 
 
+class HistoryEvalFn(Protocol):
+    """Callable RHS evaluator with history provider support.
+
+    Accepts ``y`` as a ``StateDict`` and a ``history_provider`` object
+    implementing a ``query(signal_id, body, **options)`` method.
+    Returns a ``StateDict`` of derivatives.
+    """
+
+    def __call__(  # noqa: D102
+        self, t: object, y: StateDict, *, history_provider: object, **params: object
+    ) -> StateDict: ...
+
+
 @dataclass(frozen=True, slots=True)
 class CompiledRhs:
     """Container for a compiled RHS evaluation function.
@@ -283,6 +296,19 @@ class CompiledRhs:
     # for the stripped compile.  ``None`` when ``block_pytree_eval_fn`` is
     # ``None``.
     block_template_shapes: dict[str, tuple[int, ...]] | None = field(
+        default=None, repr=False, compare=False, hash=False
+    )
+    # ``history_requirements`` captures structured history-operator metadata
+    # from the IR, including signal_id assignment. Empty tuple when no history
+    # operators are present. Excluded from equality and hash (derived from
+    # ``_rhs``).
+    history_requirements: tuple[Mapping[str, object], ...] = field(
+        default_factory=tuple, repr=False, compare=False, hash=False
+    )
+    # ``history_eval_fn`` is set when history_requirements is non-empty AND
+    # the vectorized path succeeds. It wraps ``pytree_eval_fn`` to inject the
+    # ``history_provider`` kwarg. Excluded from equality, repr, hash.
+    history_eval_fn: HistoryEvalFn | None = field(
         default=None, repr=False, compare=False, hash=False
     )
     # Private: source spec retained for pickling. ``compile_rhs`` populates
@@ -350,6 +376,8 @@ class CompiledRhs:
         object.__setattr__(self, "template_shapes", rebuilt.template_shapes)
         object.__setattr__(self, "block_pytree_eval_fn", rebuilt.block_pytree_eval_fn)
         object.__setattr__(self, "block_template_shapes", rebuilt.block_template_shapes)
+        object.__setattr__(self, "history_requirements", rebuilt.history_requirements)
+        object.__setattr__(self, "history_eval_fn", rebuilt.history_eval_fn)
         object.__setattr__(self, "_rhs", rhs)
 
 
@@ -766,7 +794,7 @@ def _history_requirements_from_ir(
 
     Returns:
         Tuple of requirement records, each containing helper kind, body,
-        and normalized option expressions.
+        signal_id, and normalized option expressions.
     """
     required_by_kind: dict[str, tuple[str, ...]] = {
         "history": ("lag",),
@@ -785,13 +813,14 @@ def _history_requirements_from_ir(
         ),
     }
 
-    def _make_req(scope: str, node: HistoryOp) -> dict[str, object]:
+    def _make_req(signal_id: int, scope: str, node: HistoryOp) -> dict[str, object]:
         options = {k: unparse_ir(v) for k, v in node.options}
         required = required_by_kind.get(node.kind, ())
         allowed = allowed_by_kind.get(node.kind, ())
         missing = tuple(k for k in required if k not in options)
         unknown = tuple(sorted(k for k in options if k not in allowed))
         return {
+            "signal_id": signal_id,
             "scope": scope,
             "kind": node.kind,
             "signal_expr": unparse_ir(node.body),
@@ -802,22 +831,21 @@ def _history_requirements_from_ir(
         }
 
     reqs: list[dict[str, object]] = []
+    signal_id = 0
     if aliases_ir:
         for alias_name, alias_expr in aliases_ir.items():
-            reqs.extend(
-                _make_req(f"alias:{alias_name}", node)
-                for node in walk(alias_expr)
-                if isinstance(node, HistoryOp)
-            )
+            for node in walk(alias_expr):
+                if isinstance(node, HistoryOp):
+                    reqs.append(_make_req(signal_id, f"alias:{alias_name}", node))
+                    signal_id += 1
     if equations_ir:
         for eq_idx, eq_expr in enumerate(equations_ir):
             if eq_expr is None:
                 continue
-            reqs.extend(
-                _make_req(f"equation:{eq_idx}", node)
-                for node in walk(eq_expr)
-                if isinstance(node, HistoryOp)
-            )
+            for node in walk(eq_expr):
+                if isinstance(node, HistoryOp):
+                    reqs.append(_make_req(signal_id, f"equation:{eq_idx}", node))
+                    signal_id += 1
     return tuple(reqs)
 
 
@@ -1120,6 +1148,15 @@ def _wrap_pytree_eval_fn_for_synth_consts(
     return wrapped
 
 
+def _make_history_eval_fn(pytree_eval_fn: PytreeEvalFn) -> HistoryEvalFn:
+    """Wrap pytree_eval_fn to inject history_provider.query as __hist_query."""
+    def history_eval_fn(
+        t: object, y: StateDict, *, history_provider: object, **params: object
+    ) -> StateDict:
+        return pytree_eval_fn(t, y, __hist_query=history_provider.query, **params)
+    return history_eval_fn
+
+
 def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:  # noqa: C901, PLR0914
     """Compile a normalized RHS into a runnable evaluation function.
 
@@ -1171,7 +1208,7 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
         aliases_ir=rhs.aliases_ir,
         equations_ir=rhs.equations_ir,
     )
-    if history_requirements:
+    if any(req["kind"] in {"history", "delay"} for req in history_requirements):
         _raise_unsupported_feature(
             feature="history operators",
             detail=(
@@ -1234,14 +1271,32 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
         else None
     )
 
+    # Construct history_eval_fn when history operators are present and
+    # the vectorized path succeeded.
+    history_eval_fn: HistoryEvalFn | None = None
+    if history_requirements and pytree_eval_fn is not None:
+        history_eval_fn = _make_history_eval_fn(pytree_eval_fn)
+
     if eval_fn is None:
-        eval_fn = _make_eval_fn(
-            state_names=rhs.state_names,
-            aliases=rhs.aliases,
-            equations=rhs.equations,
-            aliases_ir=rhs.aliases_ir,
-            equations_ir=rhs.equations_ir,
-        )
+        if history_requirements:
+            # The scalar eval_fn path cannot route a history_provider; emit a
+            # sentinel that raises clearly if called. Consumers of specs with
+            # history operators must use pytree_eval_fn + history_eval_fn.
+            def eval_fn(*_args: object, **_kwargs: object) -> NoReturn:  # noqa: D401,E501
+                raise NotImplementedError(
+                    "scalar eval_fn is not available for specs containing "
+                    "history operators (e.g. convolve_history); use "
+                    "history_eval_fn(t, y, history_provider=..., **params) "
+                    "instead."
+                )
+        else:
+            eval_fn = _make_eval_fn(
+                state_names=rhs.state_names,
+                aliases=rhs.aliases,
+                equations=rhs.equations,
+                aliases_ir=rhs.aliases_ir,
+                equations_ir=rhs.equations_ir,
+            )
 
     time_axis_name = str(rhs.meta.get("time_axis", "time"))
     axes_meta = tuple(rhs.meta.get("axes") or ())
@@ -1317,5 +1372,7 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
         template_shapes=template_shapes,
         block_pytree_eval_fn=block_pytree_eval_fn,
         block_template_shapes=block_template_shapes,
+        history_requirements=history_requirements,
+        history_eval_fn=history_eval_fn,
         _rhs=rhs,
     )

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -830,22 +830,40 @@ def _history_requirements_from_ir(
             "unknown_options": unknown,
         }
 
+    def _append_history_nodes(
+        signal_id: int,
+        *,
+        scope: str,
+        expr: Expr,
+        sink: list[dict[str, object]],
+    ) -> int:
+        for node in walk(expr):
+            if not isinstance(node, HistoryOp):
+                continue
+            sink.append(_make_req(signal_id, scope, node))
+            signal_id += 1
+        return signal_id
+
     reqs: list[dict[str, object]] = []
     signal_id = 0
     if aliases_ir:
         for alias_name, alias_expr in aliases_ir.items():
-            for node in walk(alias_expr):
-                if isinstance(node, HistoryOp):
-                    reqs.append(_make_req(signal_id, f"alias:{alias_name}", node))
-                    signal_id += 1
+            signal_id = _append_history_nodes(
+                signal_id,
+                scope=f"alias:{alias_name}",
+                expr=alias_expr,
+                sink=reqs,
+            )
     if equations_ir:
         for eq_idx, eq_expr in enumerate(equations_ir):
             if eq_expr is None:
                 continue
-            for node in walk(eq_expr):
-                if isinstance(node, HistoryOp):
-                    reqs.append(_make_req(signal_id, f"equation:{eq_idx}", node))
-                    signal_id += 1
+            signal_id = _append_history_nodes(
+                signal_id,
+                scope=f"equation:{eq_idx}",
+                expr=eq_expr,
+                sink=reqs,
+            )
     return tuple(reqs)
 
 
@@ -1149,15 +1167,202 @@ def _wrap_pytree_eval_fn_for_synth_consts(
 
 
 def _make_history_eval_fn(pytree_eval_fn: PytreeEvalFn) -> HistoryEvalFn:
-    """Wrap pytree_eval_fn to inject history_provider.query as __hist_query."""
+    """Wrap pytree_eval_fn to inject history_provider.query as __hist_query.
+
+    Returns:
+        History-aware wrapper that forwards ``history_provider.query`` as
+        ``__hist_query``.
+    """
+
     def history_eval_fn(
         t: object, y: StateDict, *, history_provider: object, **params: object
     ) -> StateDict:
-        return pytree_eval_fn(t, y, __hist_query=history_provider.query, **params)
+        query_fn = cast("Any", history_provider).query
+        return pytree_eval_fn(t, y, __hist_query=query_fn, **params)
+
     return history_eval_fn
 
 
-def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:  # noqa: C901, PLR0914
+def _warn_on_deprecated_xp(xp: object | None) -> None:
+    """Emit the compile_rhs deprecation warning for compile-time xp."""
+    if xp is None:
+        return
+    warnings.warn(
+        "compile_rhs(xp=...) is deprecated and ignored. The compiled "
+        "eval_fn now infers its array namespace from the input `y` at "
+        "call time via __array_namespace__(); pass JAX arrays for a "
+        "JAX-native call, NumPy arrays for a NumPy call. The `xp` "
+        "kwarg will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+
+def _validate_rhs_type(rhs: NormalizedRhs) -> None:
+    """Ensure compile_rhs received a supported normalized RHS variant."""
+    if isinstance(rhs, (ExprRhs, TransitionsRhs)):
+        return
+    _raise_unsupported_feature(
+        feature=f"rhs type={type(rhs).__name__}",
+        detail="Only ExprRhs and TransitionsRhs are supported in v1.",
+    )
+
+
+def _validate_history_kinds(
+    history_requirements: tuple[dict[str, object], ...],
+) -> None:
+    """Reject history kinds that still require engine-managed buffers."""
+    if not any(req["kind"] in {"history", "delay"} for req in history_requirements):
+        return
+    _raise_unsupported_feature(
+        feature="history operators",
+        detail=(
+            "History/delay operators require engine-managed state history "
+            "buffers and are not implemented yet (issue #173). "
+            f"history_requirements={history_requirements!r}"
+        ),
+    )
+
+
+def _enforce_vector_plan_for_axes(
+    *,
+    rhs: NormalizedRhs,
+    vec: Any,  # noqa: ANN401
+    plan: object,
+) -> None:
+    """Raise when an axis-indexed spec fails vector-plan construction."""
+    if plan is not None:
+        return
+    axes_meta_check = (
+        rhs.meta.get("axes") if isinstance(rhs.meta, _MappingABC) else None
+    )
+    bail_reason = vec.last_vector_plan_bail_reason() or ""
+    if (
+        axes_meta_check
+        and bail_reason != "scalar (non-wildcard) state template present"
+    ):
+        _raise_unsupported_feature(
+            feature="vectorized eval path",
+            detail=(
+                f"Spec declares axes but the vectorizer could not build a "
+                f"plan: {bail_reason}. All axis-indexed specs must use the "
+                f"vectorized path. If this expression pattern should be "
+                f"supported, please file an issue referencing issue #160."
+            ),
+        )
+
+
+def _build_primary_eval_artifacts(
+    rhs: NormalizedRhs,
+) -> tuple[Any, EvalFn | None, PytreeEvalFn | None, dict[str, tuple[int, ...]] | None]:
+    """Build vector plan and derive primary eval callables.
+
+    Returns:
+        Tuple of ``(vec_module, eval_fn, pytree_eval_fn, template_shapes)``.
+    """
+    vec = importlib.import_module("op_system._vectorize")
+    plan = vec.build_vector_plan(rhs)
+    _enforce_vector_plan_for_axes(rhs=rhs, vec=vec, plan=plan)
+
+    eval_fn: EvalFn | None = (
+        vec.make_vectorized_eval_fn(plan) if plan is not None else None
+    )
+    pytree_eval_fn: PytreeEvalFn | None = (
+        vec.make_pytree_eval_fn(plan) if plan is not None else None
+    )
+    template_shapes: dict[str, tuple[int, ...]] | None = (
+        {tpl.base: tpl.shape for tpl in plan.state_templates}
+        if plan is not None
+        else None
+    )
+    return vec, eval_fn, pytree_eval_fn, template_shapes
+
+
+def _scalar_history_eval_unavailable() -> EvalFn:
+    """Return a sentinel eval_fn for history specs without scalar support."""
+
+    def eval_fn(*_args: object, **_kwargs: object) -> NoReturn:
+        message = (
+            "scalar eval_fn is not available for specs containing "
+            "history operators (e.g. convolve_history); use "
+            "history_eval_fn(t, y, history_provider=..., **params) "
+            "instead."
+        )
+        raise NotImplementedError(message)
+
+    return eval_fn
+
+
+def _resolve_eval_fn(
+    *,
+    rhs: NormalizedRhs,
+    eval_fn: EvalFn | None,
+    history_requirements: tuple[dict[str, object], ...],
+) -> EvalFn:
+    """Select vectorized, scalar, or history-sentinel eval_fn.
+
+    Returns:
+        Concrete evaluator callable to expose in :class:`CompiledRhs`.
+    """
+    if eval_fn is not None:
+        return eval_fn
+    if history_requirements:
+        return _scalar_history_eval_unavailable()
+    return _make_eval_fn(
+        state_names=rhs.state_names,
+        aliases=rhs.aliases,
+        equations=rhs.equations,
+        aliases_ir=rhs.aliases_ir,
+        equations_ir=rhs.equations_ir,
+    )
+
+
+def _build_block_pytree_artifacts(
+    *,
+    rhs: NormalizedRhs,
+    vec: Any,  # noqa: ANN401
+    pytree_eval_fn: PytreeEvalFn | None,
+    block_axes: tuple[BlockAxisInfo, ...],
+    synth_consts: Mapping[str, object] | None,
+) -> tuple[PytreeEvalFn | None, dict[str, tuple[int, ...]] | None]:
+    """Build block-stripped pytree eval function and shapes when available.
+
+    Returns:
+        Tuple of ``(block_pytree_eval_fn, block_template_shapes)``.
+    """
+    block_pytree_eval_fn: PytreeEvalFn | None = None
+    block_template_shapes: dict[str, tuple[int, ...]] | None = None
+    if pytree_eval_fn is None or not block_axes:
+        return block_pytree_eval_fn, block_template_shapes
+
+    from op_system._normalize_block import strip_block_axis  # noqa: PLC0415
+
+    stripped = strip_block_axis(rhs, block_axes[0].name)
+    stripped_plan = vec.build_vector_plan(stripped)
+    if stripped_plan is None:
+        return block_pytree_eval_fn, block_template_shapes
+
+    raw_block_fn: PytreeEvalFn = vec.make_pytree_eval_fn(stripped_plan)
+    block_template_shapes = {
+        tpl.base: tpl.shape for tpl in stripped_plan.state_templates
+    }
+    stripped_time_axis = str(stripped.meta.get("time_axis", "time"))
+    stripped_axes_meta = tuple(stripped.meta.get("axes") or ())
+    raw_block_fn = _wrap_pytree_eval_fn_for_time_varying(
+        raw_block_fn,
+        time_varying_params=stripped.time_varying_params,
+        time_axis_name=stripped_time_axis,
+        axes_meta=stripped_axes_meta,
+    )
+    if isinstance(synth_consts, _MappingABC) and synth_consts:
+        raw_block_fn = _wrap_pytree_eval_fn_for_synth_consts(
+            raw_block_fn, dict(synth_consts)
+        )
+    block_pytree_eval_fn = raw_block_fn
+    return block_pytree_eval_fn, block_template_shapes
+
+
+def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
     """Compile a normalized RHS into a runnable evaluation function.
 
     Always uses the vectorized eval path that operates on shaped buffers
@@ -1188,88 +1393,16 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
         ``UnsupportedFeatureError`` is raised (see bail reason in the detail
         message) rather than silently degrading to the scalar path.
     """
-    if xp is not None:
-        warnings.warn(
-            "compile_rhs(xp=...) is deprecated and ignored. The compiled "
-            "eval_fn now infers its array namespace from the input `y` at "
-            "call time via __array_namespace__(); pass JAX arrays for a "
-            "JAX-native call, NumPy arrays for a NumPy call. The `xp` "
-            "kwarg will be removed in a future release.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-    if not isinstance(rhs, (ExprRhs, TransitionsRhs)):
-        _raise_unsupported_feature(
-            feature=f"rhs type={type(rhs).__name__}",
-            detail="Only ExprRhs and TransitionsRhs are supported in v1.",
-        )
+    _warn_on_deprecated_xp(xp)
+    _validate_rhs_type(rhs)
 
     history_requirements = _history_requirements_from_ir(
         aliases_ir=rhs.aliases_ir,
         equations_ir=rhs.equations_ir,
     )
-    if any(req["kind"] in {"history", "delay"} for req in history_requirements):
-        _raise_unsupported_feature(
-            feature="history operators",
-            detail=(
-                "History/delay operators require engine-managed state history "
-                "buffers and are not implemented yet (issue #173). "
-                f"history_requirements={history_requirements!r}"
-            ),
-        )
+    _validate_history_kinds(history_requirements)
 
-    # Lazy load via importlib to avoid a static circular import
-    # (op_system._vectorize imports helpers from this module).
-    vec = importlib.import_module("op_system._vectorize")
-    plan = vec.build_vector_plan(rhs)
-
-    if plan is None:
-        # Specs that declare axes MUST vectorize.  Falling back to the scalar
-        # path for an axis-indexed spec is catastrophically slow (O(N*M*...)
-        # Python loop per eval call), breaks the PyTree interface
-        # (pytree_eval_fn / template_shapes are absent), and silently hides
-        # vectorizer regressions.  Raise loudly so the gap gets fixed.
-        #
-        # Exceptions:
-        # - Genuinely scalar specs (no axes declared) have no tensor structure
-        #   to exploit and the scalar path is correct for them.
-        # - Specs that declare only a continuous time axis (for time-varying
-        #   parameters) but have scalar state templates are functionally scalar.
-        # - Mixed specs where some states lack axis wildcards (e.g. a scalar
-        #   background compartment alongside axis-indexed states) bail with
-        #   "scalar (non-wildcard) state template present"; this is a known
-        #   limitation and the scalar path is the correct fallback.
-        # Only fire the error for bail reasons that indicate an *unexpected*
-        # vectorization failure (e.g. unsupported expression patterns).
-        axes_meta_check = (
-            rhs.meta.get("axes") if isinstance(rhs.meta, _MappingABC) else None
-        )
-        bail_reason = vec.last_vector_plan_bail_reason() or ""
-        if (
-            axes_meta_check
-            and bail_reason != "scalar (non-wildcard) state template present"
-        ):
-            _raise_unsupported_feature(
-                feature="vectorized eval path",
-                detail=(
-                    f"Spec declares axes but the vectorizer could not build a "
-                    f"plan: {bail_reason}. All axis-indexed specs must use the "
-                    f"vectorized path. If this expression pattern should be "
-                    f"supported, please file an issue referencing issue #160."
-                ),
-            )
-
-    eval_fn: EvalFn | None = (
-        vec.make_vectorized_eval_fn(plan) if plan is not None else None
-    )
-    pytree_eval_fn: PytreeEvalFn | None = (
-        vec.make_pytree_eval_fn(plan) if plan is not None else None
-    )
-    template_shapes: dict[str, tuple[int, ...]] | None = (
-        {tpl.base: tpl.shape for tpl in plan.state_templates}
-        if plan is not None
-        else None
-    )
+    vec, eval_fn, pytree_eval_fn, template_shapes = _build_primary_eval_artifacts(rhs)
 
     # Construct history_eval_fn when history operators are present and
     # the vectorized path succeeded.
@@ -1277,26 +1410,11 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
     if history_requirements and pytree_eval_fn is not None:
         history_eval_fn = _make_history_eval_fn(pytree_eval_fn)
 
-    if eval_fn is None:
-        if history_requirements:
-            # The scalar eval_fn path cannot route a history_provider; emit a
-            # sentinel that raises clearly if called. Consumers of specs with
-            # history operators must use pytree_eval_fn + history_eval_fn.
-            def eval_fn(*_args: object, **_kwargs: object) -> NoReturn:  # noqa: D401,E501
-                raise NotImplementedError(
-                    "scalar eval_fn is not available for specs containing "
-                    "history operators (e.g. convolve_history); use "
-                    "history_eval_fn(t, y, history_provider=..., **params) "
-                    "instead."
-                )
-        else:
-            eval_fn = _make_eval_fn(
-                state_names=rhs.state_names,
-                aliases=rhs.aliases,
-                equations=rhs.equations,
-                aliases_ir=rhs.aliases_ir,
-                equations_ir=rhs.equations_ir,
-            )
+    eval_fn = _resolve_eval_fn(
+        rhs=rhs,
+        eval_fn=eval_fn,
+        history_requirements=history_requirements,
+    )
 
     time_axis_name = str(rhs.meta.get("time_axis", "time"))
     axes_meta = tuple(rhs.meta.get("axes") or ())
@@ -1334,31 +1452,17 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
     # vectorizer.  Engines can jax.vmap this over the block axis instead
     # of baking literal axis indices that break under vmap.
     # ------------------------------------------------------------------
-    block_pytree_eval_fn: PytreeEvalFn | None = None
-    block_template_shapes: dict[str, tuple[int, ...]] | None = None
-    if pytree_eval_fn is not None and block_axes:
-        from op_system._normalize_block import strip_block_axis  # noqa: PLC0415
-
-        stripped = strip_block_axis(rhs, block_axes[0].name)
-        stripped_plan = vec.build_vector_plan(stripped)
-        if stripped_plan is not None:
-            raw_block_fn: PytreeEvalFn = vec.make_pytree_eval_fn(stripped_plan)
-            block_template_shapes = {
-                tpl.base: tpl.shape for tpl in stripped_plan.state_templates
-            }
-            stripped_time_axis = str(stripped.meta.get("time_axis", "time"))
-            stripped_axes_meta = tuple(stripped.meta.get("axes") or ())
-            raw_block_fn = _wrap_pytree_eval_fn_for_time_varying(
-                raw_block_fn,
-                time_varying_params=stripped.time_varying_params,
-                time_axis_name=stripped_time_axis,
-                axes_meta=stripped_axes_meta,
-            )
-            if isinstance(synth_consts, _MappingABC) and synth_consts:
-                raw_block_fn = _wrap_pytree_eval_fn_for_synth_consts(
-                    raw_block_fn, dict(synth_consts)
-                )
-            block_pytree_eval_fn = raw_block_fn
+    block_pytree_eval_fn, block_template_shapes = _build_block_pytree_artifacts(
+        rhs=rhs,
+        vec=vec,
+        pytree_eval_fn=pytree_eval_fn,
+        block_axes=block_axes,
+        synth_consts=(
+            cast("Mapping[str, object]", synth_consts)
+            if isinstance(synth_consts, _MappingABC)
+            else None
+        ),
+    )
 
     return CompiledRhs(
         state_names=rhs.state_names,

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -171,7 +171,7 @@ def test_compile_rejects_nonwhitelisted_helper() -> None:
         compile_rhs(rhs, xp=np)
 
 
-@pytest.mark.parametrize("helper", ["history", "delay", "convolve_history"])
+@pytest.mark.parametrize("helper", ["history", "delay"])
 def test_compile_rejects_planned_history_helpers_with_targeted_message(
     helper: str,
 ) -> None:
@@ -200,7 +200,7 @@ def test_history_requirements_payload_includes_missing_required_options() -> Non
 
 
 def test_history_requirements_payload_captures_provided_options() -> None:
-    """history_requirements payload preserves normalized option expressions."""
+    """#174 integration: signal_id and provided options exposed in requirements map."""
     spec = {
         "kind": "expr",
         "state": ["x"],
@@ -209,18 +209,63 @@ def test_history_requirements_payload_captures_provided_options() -> None:
         },
     }
     rhs = normalize_rhs(spec)
+    compiled = compile_rhs(rhs, xp=np)
+    assert compiled.history_requirements
+    first_req = compiled.history_requirements[0]
+    assert first_req["signal_id"] == 0
+    assert first_req["options"]["kernel"] == "gamma"
+    assert first_req["options"]["window"] == "14"
+    assert first_req["options"]["interpolation"] == "linear"
 
-    with pytest.raises(UnsupportedFeatureError) as exc_info:
-        compile_rhs(rhs, xp=np)
 
-    msg = str(exc_info.value)
-    assert "'kind': 'convolve_history'" in msg
-    assert (
-        "'options': {'kernel': 'gamma', 'window': '14', 'interpolation': 'linear'}"
-        in msg
+def test_convolve_history_compiles_and_calls_provider() -> None:
+    """#175 integration: convolve_history lowers to provider hook invocation."""
+    spec = {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": ["a", "b"]}],
+        "state": ["x[loc]"],
+        "equations": {
+            "x[loc]": "convolve_history(x[loc], kernel=gamma, window=14)"
+        },
+    }
+    rhs = normalize_rhs(spec)
+    compiled = compile_rhs(rhs)
+    assert compiled.pytree_eval_fn is not None
+    assert compiled.history_eval_fn is not None
+    # Per-cell scopes report one requirement per axis coord; the vectorized
+    # lowering collapses to a single ``__hist_query`` call (signal_id == 0).
+    assert len(compiled.history_requirements) >= 1
+    assert any(req["signal_id"] == 0 for req in compiled.history_requirements)
+
+    # Mock provider exposes a ``.query`` method matching the lowered call:
+    # ``__hist_query(signal_id, body, **options)``.
+    mock_queries: list[tuple[int, object, dict[str, object]]] = []
+
+    class MockProvider:
+        def query(
+            self, signal_id: int, body: object, **options: object
+        ) -> object:
+            mock_queries.append((signal_id, body, options))
+            return np.zeros_like(body)
+
+    state = {"x": np.array([1.5, 2.5])}
+    result = compiled.history_eval_fn(
+        0.0, state, history_provider=MockProvider()
     )
-    assert "'missing_required_options': ()" in msg
-    assert "'unknown_options': ()" in msg
+    assert len(mock_queries) >= 1
+    signal_id, body, opts = mock_queries[0]
+    assert signal_id == 0
+    assert opts["kernel"] == "gamma"
+    assert opts["window"] == 14
+    assert "x" in result
+
+
+def test_history_eval_fn_is_none_when_no_history_ops() -> None:
+    """#175 integration: history_eval_fn is None when no history ops present."""
+    spec = {"kind": "expr", "state": ["x"], "equations": {"x": "x + 1"}}
+    rhs = normalize_rhs(spec)
+    compiled = compile_rhs(rhs, xp=np)
+    assert compiled.history_eval_fn is None
 
 
 def test_compile_rejects_disallowed_attribute_access() -> None:

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -212,10 +212,12 @@ def test_history_requirements_payload_captures_provided_options() -> None:
     compiled = compile_rhs(rhs, xp=np)
     assert compiled.history_requirements
     first_req = compiled.history_requirements[0]
+    options = first_req["options"]
+    assert isinstance(options, dict)
     assert first_req["signal_id"] == 0
-    assert first_req["options"]["kernel"] == "gamma"
-    assert first_req["options"]["window"] == "14"
-    assert first_req["options"]["interpolation"] == "linear"
+    assert options["kernel"] == "gamma"
+    assert options["window"] == "14"
+    assert options["interpolation"] == "linear"
 
 
 def test_convolve_history_compiles_and_calls_provider() -> None:
@@ -224,9 +226,7 @@ def test_convolve_history_compiles_and_calls_provider() -> None:
         "kind": "expr",
         "axes": [{"name": "loc", "coords": ["a", "b"]}],
         "state": ["x[loc]"],
-        "equations": {
-            "x[loc]": "convolve_history(x[loc], kernel=gamma, window=14)"
-        },
+        "equations": {"x[loc]": "convolve_history(x[loc], kernel=gamma, window=14)"},
     }
     rhs = normalize_rhs(spec)
     compiled = compile_rhs(rhs)
@@ -242,18 +242,15 @@ def test_convolve_history_compiles_and_calls_provider() -> None:
     mock_queries: list[tuple[int, object, dict[str, object]]] = []
 
     class MockProvider:
-        def query(
-            self, signal_id: int, body: object, **options: object
-        ) -> object:
+        @staticmethod
+        def query(signal_id: int, body: object, **options: object) -> object:
             mock_queries.append((signal_id, body, options))
             return np.zeros_like(body)
 
     state = {"x": np.array([1.5, 2.5])}
-    result = compiled.history_eval_fn(
-        0.0, state, history_provider=MockProvider()
-    )
+    result = compiled.history_eval_fn(0.0, state, history_provider=MockProvider())
     assert len(mock_queries) >= 1
-    signal_id, body, opts = mock_queries[0]
+    signal_id, _body, opts = mock_queries[0]
     assert signal_id == 0
     assert opts["kernel"] == "gamma"
     assert opts["window"] == 14


### PR DESCRIPTION
Implements Layers 1 and 2 of #175 (#173 / #174 follow-up). Layer 3 (flepimop2 diffrax engine) is in a separate repo and tracked there.

## Slice 1 — op_system core lowering
- ``HistoryOp(convolve_history)`` lowers to ``__hist_query(signal_id, body, **opts)`` Call in the vectorized AST path (\`_ir_lower.py\`).
- \`CompiledRhs\` gains two fields (repr=False, compare=False, hash=False):
  - \`history_requirements: tuple[Mapping[str, object], ...]\` — informational payload with \`signal_id\`, \`scope\`, \`kind\`, \`signal_expr\`, \`options\`, \`required_options\`, \`missing_required_options\`, \`unknown_options\`.
  - \`history_eval_fn: HistoryEvalFn | None\` — \`(t, y, *, history_provider, **params) -> StateDict\` that injects \`history_provider.query\` as \`__hist_query\` into \`pytree_eval_fn\`.
- \`signal_id\` is deterministic via a per-call-site \`walk()\` over the IR being lowered, mirroring \`_history_requirements_from_ir\`'s pre-order. Each call site in \`_vectorize.py\` builds its own map locally — no cross-cutting plumbing.
- Scalar \`eval_fn\` is replaced by a sentinel that raises a clear \`NotImplementedError\` when \`history_requirements\` is non-empty (the scalar path cannot accept a \`history_provider\`).
- \`history\` and \`delay\` kinds still raise \`UnsupportedFeatureError\` — out of scope for this PR.

## Slice 2 — provider surface
- \`OpSystemSystem\` (\`flepimop2-op_system\`) exposes:
  - \`options[\"history_requirements\"]\` (always populated; \`()\` when no history ops).
  - \`options[\"history_stepper_fn\"]\` (set only when \`compiled.history_eval_fn\` is available).
- \`bind()\` attaches \`bound.history_stepper\`; \`history_provider\` is **per-call** (not partialized) so engines can swap registries between solves.

## Tests
- op_system: 430 passed, 10 skipped. New: \`test_convolve_history_compiles_and_calls_provider\`, \`test_history_eval_fn_is_none_when_no_history_ops\`; converted \`test_history_requirements_payload_captures_provided_options\` from raises→success.
- provider: 51 passed, 1 skipped. New: empty-default, populated-requirements, end-to-end bind+MockProvider invocation.

## Known follow-ups
1. **Requirements scope cardinality.** Per-cell scopes report N requirements (one per axis coord), but the vectorized lowering collapses to a single \`__hist_query\` call. Provider only sees lifted signal_ids. Tests are intentionally lax (\`>= 1\`).
2. **Options stringification.** \`requirements[*][\"options\"]\` holds raw IR-text (\`\"14\"\`, \`\"gamma\"\`); runtime lowering passes Python values (int \`14\`).
3. **Scalar-state history specs.** Specs without axes don't enter vectorize so \`history_eval_fn\` is \`None\`. Acceptable for compartmental models.

Refs: #173, #174.