### PR TITLE
feat(#175): add convolve_history docs and Erlang parity test

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,13 +245,53 @@ Expressions are parsed with `ast` and restricted to:
 - Helpers: `sum_state()`, `sum_prefix(prefix)`, `apply_along(...)`,
   `sum_over(...)`.
 
-Planned history helpers (`history(...)`, `delay(...)`, `convolve_history(...)`)
-are reserved for issue #173 and currently raise a targeted "not yet
-implemented" unsupported-feature error at compile time, including a
-`history_requirements=...` payload that specifies the required engine-side
-history buffer contract. Each requirement record currently includes:
-`scope`, `kind`, `signal_expr`, `options`, `required_options`,
-`missing_required_options`, and `unknown_options`.
+`convolve_history(...)` is available via the history-provider runtime hook
+(`CompiledRhs.history_eval_fn` and `OpSystemSystem`'s
+`options["history_stepper_fn"]`). `history(...)` and `delay(...)` remain
+reserved for issue #173 and still raise a targeted unsupported-feature error
+with `history_requirements=...` payloads.
+
+Each history requirement record currently includes: `scope`, `kind`,
+`signal_expr`, `options`, `required_options`, `missing_required_options`, and
+`unknown_options`.
+
+## Runnable convolve_history example
+
+```python
+import numpy as np
+
+from op_system import compile_spec
+
+spec = {
+  "kind": "expr",
+  "axes": [{"name": "loc", "coords": ["a", "b"]}],
+  "state": ["x[loc]"],
+  "equations": {
+    "x[loc]": "convolve_history(inflow[loc], kernel=gamma, window=14)"
+  },
+}
+compiled = compile_spec(spec)
+
+# history_eval_fn is available for axis-indexed convolve_history specs.
+assert compiled.history_eval_fn is not None
+print(compiled.history_requirements)
+
+
+class ZeroHistoryProvider:
+  def query(self, signal_id: int, body: object, **options: object) -> object:
+    # Runtime contract from lowering: __hist_query(signal_id, body, **options)
+    return np.zeros_like(body)
+
+
+state = {"x": np.array([1.0, 2.0], dtype=np.float64)}
+out = compiled.history_eval_fn(
+  0.0,
+  state,
+  history_provider=ZeroHistoryProvider(),
+  inflow=np.array([0.2, 0.4], dtype=np.float64),
+)
+print(out["x"])  # [0. 0.]
+```
 
 Anything else — non-`np` attribute access, imports, lambdas, comprehensions,
 other AST nodes — raises `ValueError` / `TypeError` /

--- a/tests/op_system/test_op_system_compile.py
+++ b/tests/op_system/test_op_system_compile.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import pickle  # noqa: S403
 import re
 from dataclasses import replace
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -33,6 +34,9 @@ from op_system._operators import OperatorDescriptor
 from op_system._vectorize import _bail
 from op_system.compile import CompiledRhs, _collect_eq_code, compile_rhs
 from op_system.specs import NormalizedRhs, normalize_rhs
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 @pytest.fixture
@@ -263,6 +267,107 @@ def test_history_eval_fn_is_none_when_no_history_ops() -> None:
     rhs = normalize_rhs(spec)
     compiled = compile_rhs(rhs, xp=np)
     assert compiled.history_eval_fn is None
+
+
+class _Erlang3HistoryProvider:
+    def __init__(self, *, dt: np.float64, rate: np.float64) -> None:
+        self._dt = dt
+        self._rate = rate
+        self._s1 = np.zeros(1, dtype=np.float64)
+        self._s2 = np.zeros(1, dtype=np.float64)
+        self._s3 = np.zeros(1, dtype=np.float64)
+
+    def query(self, signal_id: int, body: object, **options: object) -> object:
+        del signal_id, options
+        inflow = np.asarray(body, dtype=np.float64)
+        out = self._rate * self._s3
+        ds1 = inflow - self._rate * self._s1
+        ds2 = self._rate * self._s1 - self._rate * self._s2
+        ds3 = self._rate * self._s2 - self._rate * self._s3
+        self._s1 += self._dt * ds1
+        self._s2 += self._dt * ds2
+        self._s3 += self._dt * ds3
+        return out
+
+
+def _run_erlang3_parity_sim(
+    *,
+    chain_fn: Callable[..., dict[str, np.ndarray]],
+    hist_fn: Callable[..., dict[str, np.ndarray]],
+    dt: np.float64,
+    rate: np.float64,
+    inflow_trace: np.ndarray,
+) -> tuple[list[float], list[float]]:
+    provider = _Erlang3HistoryProvider(dt=dt, rate=rate)
+    state_chain = {
+        "x1": np.zeros(1, dtype=np.float64),
+        "x2": np.zeros(1, dtype=np.float64),
+        "x3": np.zeros(1, dtype=np.float64),
+    }
+    state_hist = {"h": np.zeros(1, dtype=np.float64)}
+    chain_out: list[float] = []
+    hist_out: list[float] = []
+
+    for step, t in enumerate(np.arange(len(inflow_trace), dtype=np.float64) * dt):
+        inflow = np.array([inflow_trace[step]], dtype=np.float64)
+        chain_out.append(float(rate * state_chain["x3"][0]))
+
+        chain_deriv = chain_fn(t, state_chain, inflow=inflow, rate=rate)
+        state_chain = {
+            name: value + dt * chain_deriv[name] for name, value in state_chain.items()
+        }
+
+        hist_deriv = hist_fn(
+            t,
+            state_hist,
+            history_provider=provider,
+            inflow=inflow,
+        )
+        hist_out.append(float(np.asarray(hist_deriv["h"])[0]))
+
+    return chain_out, hist_out
+
+
+def test_convolve_history_erlang3_matches_linear_chain_baseline() -> None:
+    """#175 acceptance: Erlang(3) history provider matches 3-stage chain baseline."""
+    chain_spec = {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": ["a"]}],
+        "state": ["x1[loc]", "x2[loc]", "x3[loc]"],
+        "equations": {
+            "x1[loc]": "inflow[loc] - rate * x1[loc]",
+            "x2[loc]": "rate * x1[loc] - rate * x2[loc]",
+            "x3[loc]": "rate * x2[loc] - rate * x3[loc]",
+        },
+    }
+    hist_spec = {
+        "kind": "expr",
+        "axes": [{"name": "loc", "coords": ["a"]}],
+        "state": ["h[loc]"],
+        "equations": {
+            "h[loc]": "convolve_history(inflow[loc], kernel=gamma, window=128)"
+        },
+    }
+
+    chain = compile_rhs(normalize_rhs(chain_spec))
+    hist = compile_rhs(normalize_rhs(hist_spec))
+    assert chain.pytree_eval_fn is not None
+    assert hist.history_eval_fn is not None
+
+    dt = np.float64(0.2)
+    rate = np.float64(1.3)
+    times = np.arange(120, dtype=np.float64) * dt
+    inflow_trace = np.exp(-times / np.float64(6.0)) + np.float64(0.2) * np.sin(times)
+
+    chain_out, hist_out = _run_erlang3_parity_sim(
+        chain_fn=chain.pytree_eval_fn,
+        hist_fn=hist.history_eval_fn,
+        dt=dt,
+        rate=rate,
+        inflow_trace=inflow_trace,
+    )
+
+    assert np.allclose(hist_out, chain_out, rtol=1e-12, atol=1e-12)
 
 
 def test_compile_rejects_disallowed_attribute_access() -> None:


### PR DESCRIPTION
This pull request improves support for the `convolve_history` operation, both in documentation and in testing. It updates the README to clarify the current status of history helpers and provides a runnable example for `convolve_history`. Additionally, it introduces a new test that verifies the correctness of `convolve_history` by comparing it to a 3-stage linear chain baseline (Erlang(3) system), ensuring mathematical parity.

Documentation updates:
* Expanded the `README.md` to clarify the availability of `convolve_history`, explain the runtime hook mechanism, and provide a runnable example demonstrating how to use `convolve_history` with a custom history provider.

Testing enhancements for `convolve_history`:
* Added a new test, `test_convolve_history_erlang3_matches_linear_chain_baseline`, which validates that the `convolve_history` implementation matches the output of a 3-stage linear chain (Erlang(3)) system, using a custom history provider and simulated input.
* Introduced supporting classes and functions in the test suite, including `_Erlang3HistoryProvider` and `_run_erlang3_parity_sim`, to facilitate the new test and simulate the required system dynamics.
* Added `TYPE_CHECKING` imports for improved type hinting in test files. [[1]](diffhunk://#diff-2fa3a022376673b04af8548e35d18cc87f0eac0a1985cffed7de0b40cf955447R25) [[2]](diffhunk://#diff-2fa3a022376673b04af8548e35d18cc87f0eac0a1985cffed7de0b40cf955447R38-R40)

closes #175