### PR TITLE
Add block-history eval wiring

### DIFF
--- a/docs/development/issue-168-block-stripped-rhs-plan.md
+++ b/docs/development/issue-168-block-stripped-rhs-plan.md
@@ -1,4 +1,4 @@
-# Issue #168 — Block-stripped `pytree_eval_fn` for `factorize_axes` vmap
+*issu# Issue #168 — Block-stripped `pytree_eval_fn` for `factorize_axes` vmap
 
 **Repo**: ACCIDDA/op_system
 **Branch convention**: `feat/168-<slug>`

--- a/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
+++ b/flepimop2-op_system/src/flepimop2/system/op_system/__init__.py
@@ -133,6 +133,17 @@ class OpSystemSystem(SystemABC, module="flepimop2.system.op_system"):  # noqa: D
         self.options["body_eval_fn"] = self._stepper_body_eval
 
         self._compiled_rhs = compiled  # handy for debugging/adapters
+        self._stepper_block_history = self._maybe_make_block_history_stepper(
+            compiled=compiled,
+            mixing_kernels=mixing_kernels,
+        )
+        self.options["block_history_stepper_fn"] = self._stepper_block_history
+
+        self._stepper_block_body_eval = self._maybe_make_block_body_eval(
+            compiled=compiled,
+            mixing_kernels=mixing_kernels,
+        )
+        self.options["block_body_eval_fn"] = self._stepper_block_body_eval
 
     @staticmethod
     def _extract_axis_labels(compiled: CompiledRhs) -> dict[str, tuple[str, ...]]:
@@ -204,6 +215,8 @@ class OpSystemSystem(SystemABC, module="flepimop2.system.op_system"):  # noqa: D
             "history_requirements": compiled.history_requirements,
             "history_stepper_fn": None,
             "body_eval_fn": None,
+            "block_history_stepper_fn": None,
+            "block_body_eval_fn": None,
         }
 
     @staticmethod
@@ -342,6 +355,63 @@ class OpSystemSystem(SystemABC, module="flepimop2.system.op_system"):  # noqa: D
             return body_eval_fn(time, state_dict, **params)
 
         return _stepper_body_eval
+
+    @staticmethod
+    def _maybe_make_block_history_stepper(
+        *,
+        compiled: CompiledRhs,
+        mixing_kernels: Mapping[str, np.ndarray],
+    ) -> Callable[..., dict[str, Any]] | None:
+        """Build optional per-block history-provider-aware stepper wrapper.
+
+        Returns:
+            Block-history stepper callable when available, otherwise ``None``.
+        """
+        block_history_eval_fn = compiled.block_history_eval_fn
+        if block_history_eval_fn is None:
+            return None
+
+        def _stepper_block_history(
+            time: np.float64,
+            state_dict: dict[str, Any],
+            *,
+            history_provider: object,
+            **kwargs: Any,  # noqa: ANN401
+        ) -> dict[str, Any]:
+            params = OpSystemSystem._merged_params(mixing_kernels, kwargs)
+            return block_history_eval_fn(
+                time,
+                state_dict,
+                history_provider=history_provider,
+                **params,
+            )
+
+        return _stepper_block_history
+
+    @staticmethod
+    def _maybe_make_block_body_eval(
+        *,
+        compiled: CompiledRhs,
+        mixing_kernels: Mapping[str, np.ndarray],
+    ) -> Callable[..., dict[int, object]] | None:
+        """Build optional per-block body-eval wrapper for history engines.
+
+        Returns:
+            Block-body-eval callable when available, otherwise ``None``.
+        """
+        block_body_eval_fn = compiled.block_body_eval_fn
+        if block_body_eval_fn is None:
+            return None
+
+        def _stepper_block_body_eval(
+            time: np.float64,
+            state_dict: dict[str, Any],
+            **kwargs: Any,  # noqa: ANN401
+        ) -> dict[int, object]:
+            params = OpSystemSystem._merged_params(mixing_kernels, kwargs)
+            return block_body_eval_fn(time, state_dict, **params)
+
+        return _stepper_block_body_eval
 
     @override
     def _bind_impl(

--- a/src/op_system/_ir_lower.py
+++ b/src/op_system/_ir_lower.py
@@ -1325,6 +1325,71 @@ def _lower_apply(  # noqa: PLR0913
 # ---------------------------------------------------------------------------
 
 
+def _validate_lift_cell_conflicts(
+    *,
+    expr: Expr,
+    cell_to_template: Mapping[str, tuple[str, tuple[str, ...]]],
+) -> set[str]:
+    """Collect referenced cells and reject incompatible same-base combinations.
+
+    Returns:
+        Set of expanded cell names referenced by ``expr`` that are present in
+        ``cell_to_template``.
+
+    Raises:
+        UnsupportedIRLoweringError: If two distinct per-cell symbols sharing the
+            same template base co-occur in ``expr``.
+    """
+    seen_bases: dict[str, str] = {}
+    referenced_cells: set[str] = set()
+    for node in walk(expr):
+        if not isinstance(node, Sym):
+            continue
+        entry = cell_to_template.get(node.name)
+        if entry is None:
+            continue
+        referenced_cells.add(node.name)
+        base, axes = entry
+        if not axes:
+            continue
+        prior = seen_bases.get(base)
+        if prior is None:
+            seen_bases[base] = node.name
+            continue
+        if prior != node.name:
+            msg = (
+                f"cannot lift per-cell IR for buffer {base!r}: multiple "
+                f"distinct cells co-occur ({prior!r} and {node.name!r}); "
+                "this signals a string-expanded axis reduction"
+            )
+            raise UnsupportedIRLoweringError(msg)
+    return referenced_cells
+
+
+def _build_lift_cell_mapping(
+    *,
+    referenced_cells: set[str],
+    cell_to_template: Mapping[str, tuple[str, tuple[str, ...]]],
+) -> dict[str, Expr]:
+    """Build ``substitute`` mapping for per-cell symbol to template-form IR node.
+
+    Returns:
+        Mapping from expanded per-cell symbol names to rewritten template-form
+        IR nodes used by :func:`substitute`.
+    """
+    mapping: dict[str, Expr] = {}
+    for cell_name in referenced_cells:
+        base, axes = cell_to_template[cell_name]
+        if not axes:
+            mapping[cell_name] = Sym(name=f"{base}_buf")
+            continue
+        mapping[cell_name] = Subscript(
+            name=base,
+            indices=tuple(AxisIndex(axis=ax, kind=AxisKind.FREE) for ax in axes),
+        )
+    return mapping
+
+
 def lift_cell_ir_to_template(
     expr: Expr,
     *,
@@ -1341,8 +1406,8 @@ def lift_cell_ir_to_template(
     :class:`Subscript` against the buffer's base name, suitable as input to
     :func:`lower_to_vector_ast`.
 
-    Symbols not in ``cell_to_template`` — scalar parameters or unbound
-    names — are left unchanged. Mappings whose template has ``axes == ()``
+    Symbols not in ``cell_to_template`` - scalar parameters or unbound
+    names - are left unchanged. Mappings whose template has ``axes == ()``
     (e.g. scalar aliases) rewrite the symbol to a bare ``Sym(f"{base}_buf")``
     leaf so the result evaluates against the runtime's ``<base>_buf``
     binding.
@@ -1359,49 +1424,31 @@ def lift_cell_ir_to_template(
 
     Returns:
         A new IR expression equivalent to ``expr`` but with all matched
-        cell-name :class:`Sym` leaves replaced — by FREE-index
+        cell-name :class:`Sym` leaves replaced - by FREE-index
         :class:`Subscript` nodes (templated buffers) or scalar-buffer
         :class:`Sym` leaves (scalar aliases).
-
-    Raises:
-        UnsupportedIRLoweringError: If two distinct per-cell symbols
-            sharing the same templated ``base`` co-occur in ``expr``
-            (signals a string-expanded axis reduction that cannot be
-            represented as a single FREE-axis subscript).
     """
-    mapping: dict[str, Expr] = {}
-    for cell_name, (base, axes) in cell_to_template.items():
-        if not axes:
-            mapping[cell_name] = Sym(name=f"{base}_buf")
-            continue
-        mapping[cell_name] = Subscript(
-            name=base,
-            indices=tuple(AxisIndex(axis=ax, kind=AxisKind.FREE) for ax in axes),
-        )
-    if not mapping:
+    if not cell_to_template:
         return expr
-    # Refuse the lift when multiple distinct per-cell symbols of the same
-    # templated buffer co-occur in ``expr``: that signals an axis reduction
-    # (e.g. ``apply_along`` or ``sum_over``) that the normalizer expanded
-    # to a per-cell sum at the string level. Collapsing those cells back to
-    # a single FREE-axis subscript would silently broadcast instead of
-    # reduce, producing wrong results.
-    seen_bases: dict[str, str] = {}
-    for node in walk(expr):
-        if not isinstance(node, Sym):
-            continue
-        entry = cell_to_template.get(node.name)
-        if entry is None or not entry[1]:
-            continue
-        base = entry[0]
-        prior = seen_bases.get(base)
-        if prior is None:
-            seen_bases[base] = node.name
-        elif prior != node.name:
-            msg = (
-                f"cannot lift per-cell IR for buffer {base!r}: multiple "
-                f"distinct cells co-occur ({prior!r} and {node.name!r}); "
-                "this signals a string-expanded axis reduction"
-            )
-            raise UnsupportedIRLoweringError(msg)
+
+    # Build the substitution mapping lazily: walk ``expr`` once collecting
+    # the set of Sym names present, then only construct replacement nodes
+    # for the cell-names that actually appear. The previous implementation
+    # eagerly materialized one Subscript+AxisIndex tuple per entry in
+    # ``cell_to_template`` on every call, which is O(N_cells) per history
+    # node and becomes the dominant compile-time cost on large models
+    # (e.g. 6k+ history-node visits x 24k-entry cell_to_template => ~150M
+    # allocations). In practice each per-cell IR body references only a
+    # handful of distinct Sym names, so the lazy form is bounded by body
+    # size rather than total cell count.
+    referenced_cells = _validate_lift_cell_conflicts(
+        expr=expr,
+        cell_to_template=cell_to_template,
+    )
+    if not referenced_cells:
+        return expr
+    mapping = _build_lift_cell_mapping(
+        referenced_cells=referenced_cells,
+        cell_to_template=cell_to_template,
+    )
     return substitute(expr, mapping)

--- a/src/op_system/compile.py
+++ b/src/op_system/compile.py
@@ -337,6 +337,18 @@ class CompiledRhs:
     body_eval_fn: BodyEvalFn | None = field(
         default=None, repr=False, compare=False, hash=False
     )
+    # ``block_history_eval_fn`` mirrors ``history_eval_fn`` but wraps
+    # ``block_pytree_eval_fn`` (the per-block-coord RHS).  Engines can
+    # jax.vmap this over the block axis for history solves.
+    # ``None`` when ``block_pytree_eval_fn`` or ``history_eval_fn`` is None.
+    block_history_eval_fn: HistoryEvalFn | None = field(
+        default=None, repr=False, compare=False, hash=False
+    )
+    # ``block_body_eval_fn`` mirrors ``body_eval_fn`` but for the per-block
+    # compile.  Set iff ``block_history_eval_fn`` is set.
+    block_body_eval_fn: BodyEvalFn | None = field(
+        default=None, repr=False, compare=False, hash=False
+    )
     # Private: source spec retained for pickling. ``compile_rhs`` populates
     # this; direct constructions without ``_rhs`` are not picklable (the
     # ``eval_fn`` closure cannot be serialized) and will raise from
@@ -405,6 +417,8 @@ class CompiledRhs:
         object.__setattr__(self, "history_requirements", rebuilt.history_requirements)
         object.__setattr__(self, "history_eval_fn", rebuilt.history_eval_fn)
         object.__setattr__(self, "body_eval_fn", rebuilt.body_eval_fn)
+        object.__setattr__(self, "block_history_eval_fn", rebuilt.block_history_eval_fn)
+        object.__setattr__(self, "block_body_eval_fn", rebuilt.block_body_eval_fn)
         object.__setattr__(self, "_rhs", rhs)
 
 
@@ -1448,6 +1462,22 @@ def _build_history_artifacts(
     return history_requirements, history_eval_fn, _make_body_eval_fn(history_eval_fn)
 
 
+def _build_block_history_artifacts(
+    *,
+    block_pytree_eval_fn: PytreeEvalFn | None,
+    history_requirements: tuple[dict[str, object], ...],
+) -> tuple[HistoryEvalFn | None, BodyEvalFn | None]:
+    """Build per-block history/body evaluators when available.
+
+    Returns:
+        Tuple of ``(block_history_eval_fn, block_body_eval_fn)``.
+    """
+    if block_pytree_eval_fn is None or not history_requirements:
+        return None, None
+    blk_hist_fn = _make_history_eval_fn(block_pytree_eval_fn)
+    return blk_hist_fn, _make_body_eval_fn(blk_hist_fn)
+
+
 def _wrap_time_varying_artifacts(
     *,
     rhs: NormalizedRhs,
@@ -1636,6 +1666,26 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
         rhs
     )
 
+    # Apply both time-varying and synth-const wrappers to ``pytree_eval_fn``
+    # BEFORE ``_build_history_artifacts`` consumes it.  history_eval_fn /
+    # body_eval_fn capture the pytree_eval_fn reference at construction
+    # time, so any later re-wrapping would not propagate into them; that
+    # would leave runtime history-body calls missing time-varying param
+    # slicing and synthesized constants (e.g. __op_system_mask__* one-hot
+    # arrays for pinned transition selectors).
+    synth_consts: Mapping[str, object] | None = None
+    if eval_fn is not None:
+        eval_fn, pytree_eval_fn = _wrap_time_varying_artifacts(
+            rhs=rhs,
+            eval_fn=eval_fn,
+            pytree_eval_fn=pytree_eval_fn,
+        )
+        eval_fn, pytree_eval_fn, synth_consts = _apply_synth_const_wrappers(
+            rhs=rhs,
+            eval_fn=eval_fn,
+            pytree_eval_fn=pytree_eval_fn,
+        )
+
     history_requirements, history_eval_fn, body_eval_fn = _build_history_artifacts(
         rhs=rhs,
         plan=plan,
@@ -1646,17 +1696,6 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
         rhs=rhs,
         eval_fn=eval_fn,
         history_requirements=history_requirements,
-    )
-
-    eval_fn, pytree_eval_fn = _wrap_time_varying_artifacts(
-        rhs=rhs,
-        eval_fn=eval_fn,
-        pytree_eval_fn=pytree_eval_fn,
-    )
-    eval_fn, pytree_eval_fn, synth_consts = _apply_synth_const_wrappers(
-        rhs=rhs,
-        eval_fn=eval_fn,
-        pytree_eval_fn=pytree_eval_fn,
     )
 
     block_axes = analyze_block_axes(rhs)
@@ -1675,6 +1714,14 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
         synth_consts=synth_consts,
     )
 
+    # Build per-block history / body eval fns when both the block compile and
+    # history path succeeded.  These wrap ``block_pytree_eval_fn`` exactly as
+    # ``history_eval_fn`` / ``body_eval_fn`` wrap ``pytree_eval_fn``.
+    block_history_eval_fn, block_body_eval_fn = _build_block_history_artifacts(
+        block_pytree_eval_fn=block_pytree_eval_fn,
+        history_requirements=history_requirements,
+    )
+
     return CompiledRhs(
         state_names=rhs.state_names,
         param_names=tuple(rhs.param_names),
@@ -1690,5 +1737,7 @@ def compile_rhs(rhs: NormalizedRhs, *, xp: object | None = None) -> CompiledRhs:
         history_requirements=history_requirements,
         history_eval_fn=history_eval_fn,
         body_eval_fn=body_eval_fn,
+        block_history_eval_fn=block_history_eval_fn,
+        block_body_eval_fn=block_body_eval_fn,
         _rhs=rhs,
     )


### PR DESCRIPTION
This pull request adds support for per-block history and body evaluation in the operator system, improving both performance and flexibility for block-structured right-hand side (RHS) plans. The changes introduce new evaluation functions at both the compile and runtime layers, and optimize IR lowering for large models by switching to a lazy substitution strategy.

**Block-structured evaluation support:**

- Added new fields to `CompiledRhs` (`block_history_eval_fn` and `block_body_eval_fn`) to support per-block history and body evaluation, mirroring the existing per-system evaluation functions. These are constructed only when the block-structured RHS is available. [[1]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R340-R351) [[2]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R1465-R1480) [[3]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R1717-R1724) [[4]](diffhunk://#diff-8e2086917cc8429224fcf95a737477ae0c947e9862470fcb26c6de9045a0ae71R1740-R1741)
- Updated the pickling and unpickling logic for `CompiledRhs` to include the new per-block evaluation functions.
- In the system initialization (`OpSystemSystem.__init__`), added logic to build and store the per-block stepper and body evaluation functions, making them available in the options dictionary for downstream use. [[1]](diffhunk://#diff-88aacd0c414c630ca19a4a7c70d9b02f3196123051eb784dab60d0e4f5219bbcR136-R146) [[2]](diffhunk://#diff-88aacd0c414c630ca19a4a7c70d9b02f3196123051eb784dab60d0e4f5219bbcR218-R219) [[3]](diffhunk://#diff-88aacd0c414c630ca19a4a7c70d9b02f3196123051eb784dab60d0e4f5219bbcR359-R415)

**IR lowering and performance optimization:**

- Refactored `lift_cell_ir_to_template` to lazily construct the substitution mapping for per-cell symbols, reducing compile-time cost for large models. The new implementation only creates replacement nodes for symbols actually present in the IR body, instead of eagerly creating one for every cell. [[1]](diffhunk://#diff-972bd1d88a010cec7d13f086705a2dd6f19f85bcbd8ce19cda35f08eb771f9e3R1328-R1392) [[2]](diffhunk://#diff-972bd1d88a010cec7d13f086705a2dd6f19f85bcbd8ce19cda35f08eb771f9e3L1344-R1410) [[3]](diffhunk://#diff-972bd1d88a010cec7d13f086705a2dd6f19f85bcbd8ce19cda35f08eb771f9e3L1362-L1406)
- Extracted conflict detection and mapping logic into helper functions for clarity and maintainability. [[1]](diffhunk://#diff-972bd1d88a010cec7d13f086705a2dd6f19f85bcbd8ce19cda35f08eb771f9e3R1328-R1392) [[2]](diffhunk://#diff-972bd1d88a010cec7d13f086705a2dd6f19f85bcbd8ce19cda35f08eb771f9e3L1344-R1410)

**Documentation:**

- Minor update to the development issue documentation to clarify the scope of block-stripped `pytree_eval_fn` for `factorize_axes` vmap.

These changes collectively enable efficient and correct handling of block-structured plans, particularly for large-scale models with many history nodes and cell templates.